### PR TITLE
Map density to hit probability and note rate

### DIFF
--- a/tests/test_density_params.py
+++ b/tests/test_density_params.py
@@ -1,0 +1,17 @@
+import os, sys, pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.pattern_synth import density_to_hit_prob, density_to_note_rate
+
+
+def test_density_to_hit_prob_boundaries():
+    assert density_to_hit_prob(0) == 0
+    assert density_to_hit_prob(0.5) == 0.5
+    assert density_to_hit_prob(1) == 1
+
+
+def test_density_to_note_rate_boundaries():
+    assert density_to_note_rate(0) == 1
+    assert density_to_note_rate(0.5) == 3
+    assert density_to_note_rate(1) == 4


### PR DESCRIPTION
## Summary
- convert density to hit probability and note rate via helper functions
- apply mapping across drum, bass, key and pad generators
- add boundary tests for density parameter mappings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf109476cc83258f1f584b930351f2