### PR TITLE
Add note/tempo stem helpers

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -2,9 +2,12 @@
 from .song_spec import SongSpec, Section
 from .theory import generate_satb, parse_chord_symbol  # if you want to expose it
 from .pattern_synth import build_patterns_for_song
+from .stems import Note, Stem, Stems, bars_to_beats, beats_to_secs
 
 __all__ = [
     "SongSpec", "Section",
     "generate_satb", "parse_chord_symbol",
     "build_patterns_for_song",
+    "Note", "Stem", "Stems",
+    "bars_to_beats", "beats_to_secs",
 ]

--- a/core/stems.py
+++ b/core/stems.py
@@ -1,0 +1,61 @@
+"""Basic musical stem structures and conversion helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Note:
+    """Single note event."""
+
+    start: float
+    dur: float
+    pitch: int
+    vel: int
+    chan: int
+
+
+@dataclass
+class Stem:
+    """A note container; currently identical to :class:`Note`."""
+
+    start: float
+    dur: float
+    pitch: int
+    vel: int
+    chan: int
+
+
+@dataclass
+class Stems:
+    """Placeholder for collections of notes; same fields as :class:`Note`."""
+
+    start: float
+    dur: float
+    pitch: int
+    vel: int
+    chan: int
+
+
+def bars_to_beats(meter: str) -> int:
+    """Return the number of beats contained in one bar of ``meter``.
+
+    ``meter`` should be a string of the form ``"N/D"`` such as ``"4/4"`` or
+    ``"6/8"``. Only the numerator (``N``) is needed to compute beats per bar.
+    """
+
+    try:
+        num_str, _ = meter.split("/", 1)
+        return int(num_str)
+    except Exception as e:  # pragma: no cover - defensive
+        raise ValueError(f"Invalid meter string: {meter!r}") from e
+
+
+def beats_to_secs(tempo: float) -> float:
+    """Return seconds per beat for a given ``tempo`` in BPM."""
+
+    if tempo <= 0:
+        raise ValueError("tempo must be positive")
+    return 60.0 / tempo
+


### PR DESCRIPTION
## Summary
- define dataclasses for Note, Stem, and Stems
- add bars_to_beats and beats_to_secs helpers
- expose new types and helpers from core package

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf1b68bbdc8325b0f29cd13a32a4b4