### PR TITLE
Implement key rendering with guide tones and arpeggios

### DIFF
--- a/tests/test_render_keys.py
+++ b/tests/test_render_keys.py
@@ -1,0 +1,25 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.stems import render_keys
+
+
+def test_chord_stabs_with_tensions_and_no_leading_tone_duplication():
+    pattern = {
+        "stabs": [1] + [0]*15,
+        "tension_policy": {0: [11, 14]},
+    }
+    voiced = [[60, 64, 67, 71]]  # Cmaj7
+    register = {"keys": [60, 84]}
+    notes = render_keys(pattern, voiced, register, "4/4", 120, seed=1)
+    pitches = sorted(n.pitch for n in notes)
+    assert pitches == [64, 71, 74]
+
+
+def test_arpeggio_iterates_satb_order():
+    pattern = {"arp": [1, 0, 1, 0, 1, 0, 1, 0]}
+    voiced = [[60, 64, 67, 71]]  # ascending bass->soprano
+    register = {"keys": [60, 84]}
+    notes = render_keys(pattern, voiced, register, "4/4", 120, seed=2)
+    pitches = [n.pitch for n in notes]
+    assert pitches == [71, 67, 64, 60]


### PR DESCRIPTION
## Summary
- add `render_keys` to convert key patterns into note stems
- support chord stabs with guide tones, tensions, and leading tone safeguards
- handle SATB arpeggio sequencing
- add unit tests for key rendering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf1edc3d908325995a2135501314d1