### PR TITLE
Add stem building orchestration

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -10,12 +10,13 @@ from .stems import (
     beats_to_secs,
     enforce_register,
     dedupe_collisions,
+    build_stems_for_song,
 )
 
 __all__ = [
     "SongSpec", "Section",
     "generate_satb", "parse_chord_symbol",
-    "build_patterns_for_song",
+    "build_patterns_for_song", "build_stems_for_song",
     "Note", "Stem", "Stems",
     "bars_to_beats", "beats_to_secs",
     "enforce_register", "dedupe_collisions",


### PR DESCRIPTION
## Summary
- implement `build_stems_for_song` to render drum, bass, key and pad stems across song sections
- expose stem builder in package exports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf226492d48325b7704f46cf482acb