### PR TITLE
Implement MIDI export and inline sample verification

### DIFF
--- a/tests/test_export_midi.py
+++ b/tests/test_export_midi.py
@@ -1,0 +1,14 @@
+from core.stems import Stem, export_midi
+
+
+def _mini_stems():
+    return {"test": [Stem(start=0.0, dur=0.5, pitch=60, vel=100, chan=0)]}
+
+
+def test_export_midi(tmp_path):
+    out_file = tmp_path / "mini.mid"
+    export_midi(_mini_stems(), out_file)
+    expected = bytes.fromhex(
+        "4d546864000000060001000101e04d54726b0000000d00903c648360803c0000ff2f00"
+    )
+    assert out_file.read_bytes() == expected


### PR DESCRIPTION
## Summary
- add `export_midi` helper to write stems as MIDI, falling back to built-in writer if `mido` is missing
- drop binary example and verify MIDI output via inline hex bytes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf240808d48325903b0eb47aa09787