### PR TITLE
docs: document external piano samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,13 @@ python -m core.main_synth --spec path/to/spec.json --minutes 3 --seed 42 --print
 ```
 
 `main_synth.py` will extend the section list to meet the requested duration and print a JSON plan of events for each instrument.  The example above generates at least three minutes of material and writes it to `plan.json` while printing instrument event counts to the console.
+
+## Using External Piano Samples
+
+To render the piano part with external SFZ samples, pass the path using the `--piano-sfz` flag. The default configuration points to `assets/sfz/piano.sfz` in `render_config.json`.
+
+```bash
+python main_render.py --spec path/to/spec.json --piano-sfz /path/to/custom/piano.sfz --mix out/piano.wav
+```
+
+This command renders the keys using the specified SFZ instrument and writes the mix to `out/piano.wav`.


### PR DESCRIPTION
## Summary
- explain how to use the `--piano-sfz` flag to render with external piano samples
- show custom SFZ path example

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf3d58a15c83259e6986e5a21fc003