### PR TITLE
Add soundfile support for SFZ sampler

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Simple demos for algorithmic music pattern generation.
 
+## Dependencies
+
+This project uses the [soundfile](https://pysoundfile.readthedocs.io/) library to load
+WAV and FLAC samples for the SFZ sampler.
+
 ## Generate N minutes of music
 
 1. Create a song specification JSON (see `core/song_spec.py` for fields).

--- a/core/sfz_sampler.py
+++ b/core/sfz_sampler.py
@@ -5,9 +5,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List
 import math
-import wave
-import struct
 import numpy as np
+import soundfile as sf
 
 from .stems import Stem
 
@@ -24,13 +23,13 @@ class SFZRegion:
     def load(self) -> None:
         if self.samples is not None:
             return
-        with wave.open(str(self.sample_path), "rb") as wf:
-            self.sample_rate = wf.getframerate()
-            frames = wf.getnframes()
-            raw = wf.readframes(frames)
-            fmt = "<" + "h" * frames
-            data = struct.unpack(fmt, raw)
-            self.samples = [s / 32768.0 for s in data]
+        data, sr = sf.read(str(self.sample_path), always_2d=True, dtype="float32")
+        self.sample_rate = sr
+        if data.shape[1] > 1:
+            data = np.mean(data, axis=1)
+        else:
+            data = data[:, 0]
+        self.samples = data.tolist()
 
 
 class SFZSampler:


### PR DESCRIPTION
## Summary
- use `soundfile` to load audio so SFZ regions handle WAV and FLAC
- downmix multi-channel audio to mono before sampling
- document the new `soundfile` dependency

## Testing
- `pip install soundfile` *(fails: Could not find a version that satisfies the requirement soundfile)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'soundfile')*


------
https://chatgpt.com/codex/tasks/task_e_68bf5c8b85c0832597842011bcd4b1cd