### PR TITLE
Replace wave with soundfile and add FLAC render test

### DIFF
--- a/tests/test_flac_reference.py
+++ b/tests/test_flac_reference.py
@@ -1,0 +1,25 @@
+import math
+from pathlib import Path
+
+import pytest
+
+sf = pytest.importorskip("soundfile")
+
+from core.stems import Stem
+from core.render import render_keys
+
+
+def test_flac_reference_renders(tmp_path):
+    sample_path = tmp_path / "tone.flac"
+    sr = 22050
+    freq = 440.0
+    frames = sr // 10
+    samples = [math.sin(2 * math.pi * freq * i / sr) for i in range(frames)]
+    sf.write(sample_path, samples, sr)
+
+    sfz = tmp_path / "inst.sfz"
+    sfz.write_text("<region> sample=tone.flac lokey=0 hikey=127 pitch_keycenter=60")
+
+    notes = [Stem(start=0.0, dur=0.1, pitch=60, vel=100, chan=0)]
+    audio = render_keys(notes, sfz, sr)
+    assert any(abs(x) > 0 for x in audio)

--- a/tests/test_render_piano.py
+++ b/tests/test_render_piano.py
@@ -2,11 +2,11 @@ import os
 import sys
 import json
 import math
-import struct
-import wave
 from pathlib import Path
 
 import pytest
+
+sf = pytest.importorskip("soundfile")
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -41,20 +41,16 @@ def test_render_piano(tmp_path):
     # Prepare SFZ and matching sample in the temporary directory
     sfz_src = Path("assets/sfz/piano.sfz")
     sfz_path = tmp_path / "piano.sfz"
-    sfz_path.write_text(sfz_src.read_text())
+    sfz_text = sfz_src.read_text().replace(".wav", ".flac")
+    sfz_path.write_text(sfz_text)
 
-    sample_path = tmp_path / "piano_C4.wav"
+    sample_path = tmp_path / "piano_C4.flac"
     sr = 44100
     freq = 440.0
     dur = 0.5
     frames = int(sr * dur)
     samples = [math.sin(2 * math.pi * freq * i / sr) for i in range(frames)]
-    pcm = [int(s * 32767) for s in samples]
-    with wave.open(str(sample_path), "w") as wf:
-        wf.setnchannels(1)
-        wf.setsampwidth(2)
-        wf.setframerate(sr)
-        wf.writeframes(struct.pack("<" + "h" * len(pcm), *pcm))
+    sf.write(sample_path, samples, sr)
 
     # Build stems and render using the piano SFZ
     stems = build_stems_for_song(spec, spec.seed)

--- a/tests/test_sfz_sampler.py
+++ b/tests/test_sfz_sampler.py
@@ -1,7 +1,9 @@
 import math
-import struct
-import wave
 from pathlib import Path
+
+import pytest
+
+sf = pytest.importorskip("soundfile")
 
 from core.stems import Stem
 from core.render import render_keys
@@ -10,23 +12,18 @@ from core.sfz_sampler import SFZSampler
 
 def test_basic_sfz_render(tmp_path):
     """Ensure sampler renders velocity-scaled notes without clipping."""
-    # create a temporary WAV sample (simple sine wave)
-    sample_path = tmp_path / "sine.wav"
+    # create a temporary FLAC sample (simple sine wave)
+    sample_path = tmp_path / "sine.flac"
     sr = 22050
     freq = 440.0
     dur = 0.5
     frames = int(sr * dur)
     samples = [math.sin(2 * math.pi * freq * i / sr) for i in range(frames)]
-    pcm = [int(s * 32767) for s in samples]
-    with wave.open(str(sample_path), "w") as wf:
-        wf.setnchannels(1)
-        wf.setsampwidth(2)
-        wf.setframerate(sr)
-        wf.writeframes(struct.pack("<" + "h" * len(pcm), *pcm))
+    sf.write(sample_path, samples, sr)
 
     # create matching SFZ referencing the generated sample
     sfz = tmp_path / "inst.sfz"
-    sfz.write_text("<region> sample=sine.wav lokey=0 hikey=127 pitch_keycenter=60")
+    sfz.write_text("<region> sample=sine.flac lokey=0 hikey=127 pitch_keycenter=60")
 
     notes = [
         Stem(start=0.0, dur=0.5, pitch=60, vel=127, chan=0),
@@ -45,12 +42,7 @@ def _write_sample(path: Path, freq: float = 440.0, sr: int = 22050) -> None:
     dur = 0.1
     frames = int(sr * dur)
     samples = [math.sin(2 * math.pi * freq * i / sr) for i in range(frames)]
-    pcm = [int(s * 32767) for s in samples]
-    with wave.open(str(path), "w") as wf:
-        wf.setnchannels(1)
-        wf.setsampwidth(2)
-        wf.setframerate(sr)
-        wf.writeframes(struct.pack("<" + "h" * len(pcm), *pcm))
+    sf.write(path, samples, sr)
 
 
 def test_group_and_trailing_definitions(tmp_path):


### PR DESCRIPTION
## Summary
- switch sampler tests to write FLAC samples using soundfile
- render piano tests against FLAC sample and SFZ
- add dedicated regression ensuring FLAC-backed SFZ renders

## Testing
- `pytest tests/test_sfz_sampler.py tests/test_render_piano.py tests/test_flac_reference.py -q` *(fails: 3 skipped; missing soundfile dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5d428c6483259b780c36cf27c1b6