### PR TITLE
Document soundfile requirement for FLAC samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,12 @@ Simple demos for algorithmic music pattern generation.
 
 ## Dependencies
 
-This project uses the [soundfile](https://pysoundfile.readthedocs.io/) library to load
-WAV and FLAC samples for the SFZ sampler.
+SFZ instruments may reference WAV or FLAC samples. Loading FLAC samples requires the
+[soundfile](https://pysoundfile.readthedocs.io/) library, which can be installed with:
+
+```bash
+pip install soundfile
+```
 
 ## Generate N minutes of music
 
@@ -13,6 +17,7 @@ WAV and FLAC samples for the SFZ sampler.
 2. Run the synth and specify the number of minutes you want:
 
 ```bash
+pip install soundfile  # enables FLAC support
 python -m core.main_synth --spec path/to/spec.json --minutes 3 --seed 42 --print-stats > plan.json
 ```
 
@@ -23,6 +28,7 @@ python -m core.main_synth --spec path/to/spec.json --minutes 3 --seed 42 --print
 To render the piano part with external SFZ samples, pass the path using the `--piano-sfz` flag. The default configuration points to `assets/sfz/piano.sfz` in `render_config.json`.
 
 ```bash
+pip install soundfile  # enables FLAC support
 python main_render.py --spec path/to/spec.json --piano-sfz /path/to/custom/piano.sfz --mix out/piano.wav
 ```
 


### PR DESCRIPTION
## Summary
- Document that SFZ instruments may use WAV or FLAC samples
- Note that FLAC support needs the soundfile library and show how to install it
- Update example commands to install `soundfile` before running scripts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf5e8cc43083258aae1dcb4fa303bc