### PR TITLE
feat: add mix/stem rendering CLI

### DIFF
--- a/main_render.py
+++ b/main_render.py
@@ -1,13 +1,14 @@
 import argparse
 import json
+import shutil
+import subprocess
 from pathlib import Path
-from typing import List
 
 import numpy as np
 
 from core.song_spec import SongSpec
-from core.stems import build_stems_for_song, Stem
-from core.render import render_keys
+from core.stems import build_stems_for_song
+from core.render import render_song
 
 
 def _write_wav(path: Path, audio: np.ndarray, sr: int) -> None:
@@ -32,22 +33,55 @@ def _write_wav(path: Path, audio: np.ndarray, sr: int) -> None:
     wavfile.write(path, sr, (data * 32767).astype(np.int16))
 
 
+def _maybe_export_mp3(wav_path: Path) -> None:
+    """Convert ``wav_path`` to MP3 using ``ffmpeg`` if available."""
+
+    if shutil.which("ffmpeg") is None:
+        return
+    mp3_path = wav_path.with_suffix(".mp3")
+    try:
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-loglevel",
+                "error",
+                "-i",
+                str(wav_path),
+                str(mp3_path),
+            ],
+            check=True,
+        )
+    except Exception:
+        # Conversion is best effort only
+        pass
+
+
 if __name__ == "__main__":
     ap = argparse.ArgumentParser()
-    ap.add_argument("--spec", required=True)
+    ap.add_argument("--spec", required=True, help="Song specification JSON")
+    ap.add_argument("--seed", type=int, default=42, help="Random seed")
+    ap.add_argument(
+        "--mix",
+        default="out/mix.wav",
+        help="Output path for the master mix WAV",
+    )
+    ap.add_argument(
+        "--stems",
+        default="out/stems",
+        help="Directory to write individual stem WAVs",
+    )
     ap.add_argument(
         "--piano-sfz",
         dest="piano_sfz",
         help="Path to piano SFZ file or directory. If omitted, uses render_config.json",
     )
-    ap.add_argument("--mix", default="out/piano.wav")
     args = ap.parse_args()
 
     spec = SongSpec.from_json(args.spec)
     spec.validate()
 
-    stems = build_stems_for_song(spec, seed=42)
-    keys: List[Stem] = stems.get("keys", [])
+    stems = build_stems_for_song(spec, seed=args.seed)
 
     if args.piano_sfz:
         sfz_path = Path(args.piano_sfz)
@@ -65,11 +99,16 @@ if __name__ == "__main__":
     if not sfz_path.exists():
         raise SystemExit(f"Missing SFZ instrument: {sfz_path}")
 
-    try:
-        mix = render_keys(keys, sfz_path, sr=44100)
-    except FileNotFoundError as exc:
-        raise SystemExit(f"Missing SFZ asset: {exc}") from exc
+    rendered = render_song(stems, sr=44100, sfz_paths={"keys": sfz_path})
 
-    out_path = Path(args.mix)
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    _write_wav(out_path, mix, 44100)
+    mix_path = Path(args.mix)
+    mix_path.parent.mkdir(parents=True, exist_ok=True)
+    _write_wav(mix_path, rendered.pop("mix"), 44100)
+    _maybe_export_mp3(mix_path)
+
+    stem_dir = Path(args.stems)
+    stem_dir.mkdir(parents=True, exist_ok=True)
+    for name, audio in rendered.items():
+        stem_path = stem_dir / f"{name}.wav"
+        _write_wav(stem_path, audio, 44100)
+        _maybe_export_mp3(stem_path)


### PR DESCRIPTION
## Summary
- expand main_render CLI to render a complete song with optional seed control
- write master mix and individual stems as WAV, optionally exporting MP3 via ffmpeg

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf67fd648883259eb9693c73557b5b