### PR TITLE
Add default instrument assets with drum sample support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,15 @@ python -m core.main_synth --spec path/to/spec.json --minutes 3 --seed 42 --print
 
 `main_synth.py` will extend the section list to meet the requested duration and print a JSON plan of events for each instrument.  The example above generates at least three minutes of material and writes it to `plan.json` while printing instrument event counts to the console.
 
-## Using External Piano Samples
+## Using External Samples
 
-To render the piano part with external SFZ samples, pass the path using the `--piano-sfz` flag. The default configuration points to `assets/sfz/piano.sfz` in `render_config.json`.
+If drum hits are placed under `assets/samples/drums` and simple SFZ instruments
+for bass, keys and pads live in `assets/sf2/`, the renderer will pick these up
+automatically. Missing assets trigger tiny built‑in synthesiser fallbacks.
+
+To render the piano/keys part with a different SFZ, pass the path using the
+`--piano-sfz` flag. The default configuration points to
+`assets/sf2/keys.sfz` in `render_config.json`.
 
 ```bash
 pip install soundfile  # enables FLAC support

--- a/assets/sf2/bass.sfz
+++ b/assets/sf2/bass.sfz
@@ -1,0 +1,5 @@
+<region>
+sample=bass.wav
+lokey=0
+hikey=127
+pitch_keycenter=36

--- a/assets/sf2/keys.sfz
+++ b/assets/sf2/keys.sfz
@@ -1,0 +1,5 @@
+<region>
+sample=keys.wav
+lokey=0
+hikey=127
+pitch_keycenter=60

--- a/assets/sf2/pads.sfz
+++ b/assets/sf2/pads.sfz
@@ -1,0 +1,5 @@
+<region>
+sample=pads.wav
+lokey=0
+hikey=127
+pitch_keycenter=60

--- a/main_render.py
+++ b/main_render.py
@@ -83,6 +83,8 @@ if __name__ == "__main__":
 
     stems = build_stems_for_song(spec, seed=args.seed)
 
+    sfz_map = {}
+    sfz_path: Path | None = None
     if args.piano_sfz:
         sfz_path = Path(args.piano_sfz)
     else:
@@ -90,16 +92,18 @@ if __name__ == "__main__":
         if cfg_path.exists():
             with cfg_path.open("r", encoding="utf-8") as fh:
                 cfg = json.load(fh)
-            sfz_path = Path(cfg.get("piano_sfz", "assets/sfz"))
+            sfz_path = Path(cfg.get("piano_sfz", "assets/sf2/keys.sfz"))
         else:
-            sfz_path = Path("assets/sfz")
+            sfz_path = Path("assets/sf2/keys.sfz")
 
     if sfz_path.is_dir():
-        sfz_path = sfz_path / "piano.sfz"
-    if not sfz_path.exists():
+        sfz_path = sfz_path / "keys.sfz"
+    if sfz_path.exists():
+        sfz_map["keys"] = sfz_path
+    elif args.piano_sfz:
         raise SystemExit(f"Missing SFZ instrument: {sfz_path}")
 
-    rendered = render_song(stems, sr=44100, sfz_paths={"keys": sfz_path})
+    rendered = render_song(stems, sr=44100, sfz_paths=sfz_map)
 
     mix_path = Path(args.mix)
     mix_path.parent.mkdir(parents=True, exist_ok=True)

--- a/render_config.json
+++ b/render_config.json
@@ -1,3 +1,3 @@
 {
-  "piano_sfz": "E:\\Instruments\\UprightPianoKW-SFZ+FLAC-20220221"
+  "piano_sfz": "assets/sf2/keys.sfz"
 }

--- a/tests/test_render_assets.py
+++ b/tests/test_render_assets.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.render import render_song, _noise_burst
+from core.stems import Stem
+
+
+def test_drum_fallback_noise():
+    sr = 44100
+    note = Stem(start=0.0, dur=0.5, pitch=36, vel=127, chan=9)
+    stems = {"drums": [note]}
+    audio = render_song(stems, sr)
+    rendered = audio["drums"].tolist()
+    expected = _noise_burst(note, sr).tolist()
+    assert rendered == expected


### PR DESCRIPTION
## Summary
- remove bundled WAV files and rely on built-in noise/synth fallbacks
- document optional asset locations for drums and SFZ instruments
- update drum test to verify fallback behaviour without samples

## Testing
- `pytest -q` *(fails: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68bf73df041483258803c0c17cc91bf5