### PR TITLE
Add default mix settings to render_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ To render the piano/keys part with a different SFZ, pass the path using the
 `--piano-sfz` flag. The default configuration points to
 `assets/sf2/keys.sfz` in `render_config.json`.
 
+The `render_config.json` file now also defines default sample locations for
+all instruments along with simple mix parameters.  Each track exposes gain,
+pan and reverb send values while the master bus includes a basic limiter
+configuration.  All paths are relative so the repository works out of the box
+after cloning.
+
 ```bash
 pip install soundfile  # enables FLAC support
 python main_render.py --spec path/to/spec.json --piano-sfz /path/to/custom/piano.sfz --mix out/piano.wav

--- a/render_config.json
+++ b/render_config.json
@@ -1,3 +1,18 @@
 {
-  "piano_sfz": "assets/sf2/keys.sfz"
+  "piano_sfz": "assets/sf2/keys.sfz",
+  "sample_paths": {
+    "drums": "assets/samples/drums",
+    "bass": "assets/sf2/bass.sfz",
+    "keys": "assets/sf2/keys.sfz",
+    "pads": "assets/sf2/pads.sfz"
+  },
+  "tracks": {
+    "drums": {"gain": -3.0, "pan": 0.0, "reverb_send": 0.10},
+    "bass": {"gain": -6.0, "pan": -0.1, "reverb_send": 0.05},
+    "keys": {"gain": -3.0, "pan": 0.1, "reverb_send": 0.25},
+    "pads": {"gain": -6.0, "pan": 0.0, "reverb_send": 0.40}
+  },
+  "master": {
+    "limiter": {"enabled": true, "threshold": -1.0, "release": 0.20}
+  }
 }


### PR DESCRIPTION
## Summary
- Define default sample paths and mix parameters in `render_config.json`
- Document render config mix options in the README

## Testing
- `pytest -q` *(fails: No module named 'soundfile')*

------
https://chatgpt.com/codex/tasks/task_e_68bfa1c2ae0c83259556d3af39decebe