### PR TITLE
Add configurable stereo mixer with reverb and limiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,12 @@ To render the piano/keys part with a different SFZ, pass the path using the
 `--piano-sfz` flag. The default configuration points to
 `assets/sf2/keys.sfz` in `render_config.json`.
 
-The `render_config.json` file now also defines default sample locations for
-all instruments along with simple mix parameters.  Each track exposes gain,
-pan and reverb send values while the master bus includes a basic limiter
-configuration.  All paths are relative so the repository works out of the box
-after cloning.
+The `render_config.json` file also defines default sample locations for all
+instruments along with stereo mix parameters.  Each track exposes gain, pan
+and reverb send values.  A shared reverb bus processes the keys and pads and
+the master mix passes through a peak limiter targeting ``-0.1`` dBFS by
+default.  All paths are relative so the repository works out of the box after
+cloning.
 
 ```bash
 pip install soundfile  # enables FLAC support

--- a/core/mixer.py
+++ b/core/mixer.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+"""Simple stereo mixing utilities.
+
+This module turns mono instrument stems into a stereo master bus.  Each track
+can specify gain, pan and a reverb send amount via a configuration mapping.
+A shared reverb bus is generated for keys and pads (or any track that sets a
+send amount) and the final mix passes through a basic peak limiter targeting a
+user supplied dBFS threshold (``-0.1`` by default).
+"""
+
+from typing import Any, Mapping, Dict
+import math
+import numpy as np
+
+
+def _apply_gain_pan(signal: np.ndarray, gain_db: float, pan: float) -> np.ndarray:
+    """Apply gain (in dB) and constant‑power pan to ``signal``.
+
+    Parameters
+    ----------
+    signal:
+        Mono input array.
+    gain_db:
+        Gain in decibels.
+    pan:
+        Position in the stereo field, ``-1`` hard left, ``1`` hard right.
+    """
+    gain = 10 ** (gain_db / 20.0)
+    pan = max(-1.0, min(1.0, pan))
+    left = signal * gain * math.sqrt(0.5 * (1.0 - pan))
+    right = signal * gain * math.sqrt(0.5 * (1.0 + pan))
+    return np.stack([left, right], axis=1)
+
+
+def _feedback_delay(signal: np.ndarray, delay: int, decay: float) -> np.ndarray:
+    """Return ``signal`` passed through a simple feedback delay."""
+    out = np.zeros_like(signal)
+    if delay <= 0:
+        return out
+    for i in range(len(signal)):
+        out[i] = signal[i]
+        if i >= delay:
+            out[i] += decay * out[i - delay]
+    return out
+
+
+def _simple_reverb(stereo: np.ndarray, sr: int, decay: float) -> np.ndarray:
+    """Create a small stereo reverb for ``stereo`` input.
+
+    The implementation uses three feedback delays per channel which is cheap
+    but sufficient for adding a bit of spaciousness to the mix.
+    """
+    delays = [int(sr * t) for t in (0.0297, 0.0371, 0.0411)]
+    out = np.zeros_like(stereo)
+    for d in delays:
+        out[:, 0] += _feedback_delay(stereo[:, 0], d, decay)
+        out[:, 1] += _feedback_delay(stereo[:, 1], d, decay)
+    return out / len(delays)
+
+
+def mix(stems: Mapping[str, np.ndarray], sr: int, config: Mapping[str, Any] | None = None) -> np.ndarray:
+    """Mix ``stems`` into a stereo master bus.
+
+    Parameters
+    ----------
+    stems:
+        Mapping of track name to mono audio arrays.
+    sr:
+        Sample rate of the signals.
+    config:
+        Optional configuration mapping.  Recognised keys:
+
+        ``tracks`` -> mapping of track name to ``gain`` (dB), ``pan`` (-1..1)
+        and ``reverb_send`` (0..1).
+        ``reverb`` -> ``decay`` (seconds) and ``wet`` level (0..1).
+        ``master`` -> ``limiter`` mapping with ``enabled`` and ``threshold``.
+
+    Returns
+    -------
+    np.ndarray
+        A stereo float32 buffer.
+    """
+    config = dict(config or {})
+    track_cfg: Dict[str, Any] = config.get("tracks", {})
+    max_len = max((len(a) for a in stems.values()), default=0)
+    mix = np.zeros((max_len, 2), dtype=np.float32)
+    reverb_bus = np.zeros((max_len, 2), dtype=np.float32)
+
+    for name, mono in stems.items():
+        if name == "mix":
+            continue
+        if len(mono) < max_len:
+            mono = np.pad(mono, (0, max_len - len(mono)))
+        mono = mono.astype(np.float32)
+        cfg = track_cfg.get(name, {})
+        gain_db = float(cfg.get("gain", 0.0))
+        pan = float(cfg.get("pan", 0.0))
+        send = float(cfg.get("reverb_send", 0.0))
+        stereo = _apply_gain_pan(mono, gain_db, pan)
+        mix += stereo
+        reverb_bus += stereo * send
+
+    rev_cfg = config.get("reverb", {})
+    decay = float(rev_cfg.get("decay", 0.5))
+    wet = float(rev_cfg.get("wet", 0.3))
+    if wet > 0.0:
+        mix += _simple_reverb(reverb_bus, sr, decay) * wet
+
+    lim_cfg = config.get("master", {}).get("limiter", {})
+    if lim_cfg.get("enabled", True):
+        threshold_db = float(lim_cfg.get("threshold", -0.1))
+        target = 10 ** (threshold_db / 20.0)
+        peak = float(np.max(np.abs(mix))) if mix.size else 0.0
+        if peak > target and peak > 0.0:
+            mix *= target / peak
+    return mix

--- a/core/render.py
+++ b/core/render.py
@@ -210,9 +210,9 @@ def render_song(
     Returns
     -------
     Dict[str, np.ndarray]
-        A dictionary containing one buffer per instrument and an additional
-        ``"mix"`` key with the summed output.  All returned arrays share a
-        common length so they can be processed in parallel.
+        A dictionary containing one buffer per instrument.  All returned
+        arrays share a common length so they can be processed in parallel or
+        fed into a downstream mixer.
     """
     rendered: Dict[str, np.ndarray] = {}
     sfz_paths = dict(sfz_paths or {})
@@ -237,15 +237,6 @@ def render_song(
     for k, arr in rendered.items():
         if len(arr) < max_len:
             rendered[k] = np.pad(arr, (0, max_len - len(arr)))
-
-    if rendered:
-        mix = sum(rendered.values())
-        peak = float(np.max(np.abs(mix))) if len(mix) else 1.0
-        if peak > 1.0:
-            mix /= peak
-    else:
-        mix = np.zeros(0, dtype=np.float32)
-    rendered["mix"] = mix.astype(np.float32)
     return rendered
 
 

--- a/render_config.json
+++ b/render_config.json
@@ -12,7 +12,8 @@
     "keys": {"gain": -3.0, "pan": 0.1, "reverb_send": 0.25},
     "pads": {"gain": -6.0, "pan": 0.0, "reverb_send": 0.40}
   },
+  "reverb": {"decay": 0.6, "wet": 0.3},
   "master": {
-    "limiter": {"enabled": true, "threshold": -1.0, "release": 0.20}
+    "limiter": {"enabled": true, "threshold": -0.1, "release": 0.20}
   }
 }

--- a/tests/test_mixer.py
+++ b/tests/test_mixer.py
@@ -1,0 +1,34 @@
+import numpy as np
+
+from core.mixer import mix
+
+
+def test_gain_pan_limiter():
+    sr = 44100
+    # Loud mono signal to trigger limiter
+    stem = np.ones(1000, dtype=np.float32) * 2.0
+    stems = {"keys": stem}
+    cfg = {
+        "tracks": {"keys": {"gain": -6.0, "pan": 1.0, "reverb_send": 0.0}},
+        "master": {"limiter": {"enabled": True, "threshold": -0.1}},
+    }
+    out = mix(stems, sr, cfg)
+    assert out.shape == (1000, 2)
+    # Hard right pan -> left channel close to zero
+    assert np.max(np.abs(out[:, 0])) < 1e-4
+    target = 10 ** (-0.1 / 20.0)
+    assert np.isclose(np.max(np.abs(out)), target, atol=1e-4)
+
+
+def test_reverb_send_creates_tail():
+    sr = 100
+    stem = np.zeros(100, dtype=np.float32)
+    stem[0] = 1.0
+    stems = {"pads": stem}
+    cfg = {
+        "tracks": {"pads": {"gain": 0.0, "pan": 0.0, "reverb_send": 1.0}},
+        "reverb": {"decay": 0.2, "wet": 1.0},
+    }
+    out = mix(stems, sr, cfg)
+    # Expect some energy in the tail from the reverb
+    assert np.any(np.abs(out[10:, 0]) > 1e-5) or np.any(np.abs(out[10:, 1]) > 1e-5)


### PR DESCRIPTION
## Summary
- add mixer module applying per-track gain, pan and reverb sends
- route pads/keys through a shared reverb bus
- apply master peak limiter at -0.1 dBFS and expose all parameters in config

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy (403 Forbidden))*

------
https://chatgpt.com/codex/tasks/task_e_68c02a003d848325ab725471d2717ffc