### PR TITLE
Update sample paths to new asset directories

### DIFF
--- a/render_config.json
+++ b/render_config.json
@@ -1,10 +1,10 @@
 {
-  "piano_sfz": "assets/sf2/keys.sfz",
+  "piano_sfz": "assets/samples/Piano/SplendidGrandPiano/SplendidGrandPiano.sfz",
   "sample_paths": {
-    "drums": "assets/samples/drums",
-    "bass": "assets/sf2/bass.sfz",
-    "keys": "assets/sf2/keys.sfz",
-    "pads": "assets/sf2/pads.sfz"
+    "drums": "assets/samples/Drums",
+    "bass": "assets/samples/Bass/LatelyBass/LatelyBass.sfz",
+    "keys": "assets/samples/Piano/SplendidGrandPiano/SplendidGrandPiano.sfz",
+    "pads": "assets/samples/Pads/SynthPadChoir/SynthPadChoir.sfz"
   },
   "tracks": {
     "drums": {"gain": -3.0, "pan": 0.0, "reverb_send": 0.10},


### PR DESCRIPTION
## Summary
- update `piano_sfz` to use SplendidGrandPiano in assets/samples
- point instrument sample paths at new `assets/samples` locations

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'soundfile')*


------
https://chatgpt.com/codex/tasks/task_e_68c074faeda083259a86ee09f8c8e730