### PR TITLE
test: cover sfz instrument rendering

### DIFF
--- a/tests/test_render_sfz_instruments.py
+++ b/tests/test_render_sfz_instruments.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+import pytest
+
+sf = pytest.importorskip("soundfile")
+
+from core.stems import Stem
+from core.sfz_sampler import SFZSampler
+
+
+@pytest.mark.parametrize(
+    "sfz_path",
+    [
+        Path("assets/sfz/Piano/SplendidGrandPiano/Splendid Grand Piano.sfz"),
+        Path("assets/sfz/Piano/UprightPiano/UprightPiano.sfz"),
+        Path("assets/sfz/Pads/SynthPadChoir/SynthPadChoir.sfz"),
+        Path("assets/sfz/Bass/LatelyBass/LatelyBass.sfz"),
+    ],
+)
+def test_sfz_instruments_render_note_sequence(sfz_path):
+    sampler = SFZSampler(sfz_path)
+    sr = 44100
+    # Four sequential quarter notes at middle C
+    notes = [Stem(start=i * 0.25, dur=0.25, pitch=60, vel=100, chan=0) for i in range(4)]
+    audio = sampler.render(notes, sample_rate=sr)
+    expected_len = int(sr * (notes[-1].start + notes[-1].dur))
+    assert len(audio) == expected_len
+    assert any(abs(x) > 0 for x in audio)


### PR DESCRIPTION
## Summary
- add parametrized test that exercises SFZ instruments (piano, upright piano, pad, bass) by rendering a short note sequence

## Testing
- `pytest tests/test_render_sfz_instruments.py -q` *(fails: soundfile not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c07b511f6c8325b2b376946d77febd