### PR TITLE
Correct sample asset paths in render configuration

### DIFF
--- a/render_config.json
+++ b/render_config.json
@@ -1,19 +1,42 @@
 {
-  "piano_sfz": "assets/samples/Piano/SplendidGrandPiano/SplendidGrandPiano.sfz",
+  "piano_sfz": "assets/sfz/Piano/SplendidGrandPiano/Splendid Grand Piano.sfz",
   "sample_paths": {
-    "drums": "assets/samples/Drums",
-    "bass": "assets/samples/Bass/LatelyBass/LatelyBass.sfz",
-    "keys": "assets/samples/Piano/SplendidGrandPiano/SplendidGrandPiano.sfz",
-    "pads": "assets/samples/Pads/SynthPadChoir/SynthPadChoir.sfz"
+    "drums": "assets/sfz/Drums",
+    "bass": "assets/sfz/Bass/LatelyBass/LatelyBass.sfz",
+    "keys": "assets/sfz/Piano/SplendidGrandPiano/Splendid Grand Piano.sfz",
+    "pads": "assets/sfz/Pads/SynthPadChoir/SynthPadChoir.sfz"
   },
   "tracks": {
-    "drums": {"gain": -3.0, "pan": 0.0, "reverb_send": 0.10},
-    "bass": {"gain": -6.0, "pan": -0.1, "reverb_send": 0.05},
-    "keys": {"gain": -3.0, "pan": 0.1, "reverb_send": 0.25},
-    "pads": {"gain": -6.0, "pan": 0.0, "reverb_send": 0.40}
+    "drums": {
+      "gain": -3.0,
+      "pan": 0.0,
+      "reverb_send": 0.1
+    },
+    "bass": {
+      "gain": -6.0,
+      "pan": -0.1,
+      "reverb_send": 0.05
+    },
+    "keys": {
+      "gain": -3.0,
+      "pan": 0.1,
+      "reverb_send": 0.25
+    },
+    "pads": {
+      "gain": -6.0,
+      "pan": 0.0,
+      "reverb_send": 0.4
+    }
   },
-  "reverb": {"decay": 0.6, "wet": 0.3},
+  "reverb": {
+    "decay": 0.6,
+    "wet": 0.3
+  },
   "master": {
-    "limiter": {"enabled": true, "threshold": -0.1, "release": 0.20}
+    "limiter": {
+      "enabled": true,
+      "threshold": -0.1,
+      "release": 0.2
+    }
   }
 }


### PR DESCRIPTION
## Summary
- point render configuration to sfz assets under `assets/sfz`
- add placeholder drums directory so its sample path resolves

## Testing
- `pytest` *(fails: No module named 'numpy')*
- `pip install numpy` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c0864b050c832581751d6df87b5c2c