### PR TITLE
Expand song structure and add register policy

### DIFF
--- a/song.json
+++ b/song.json
@@ -5,6 +5,21 @@
   "mode": "ionian",
   "tempo": 120,
   "meter": "4/4",
-  "sections": [{"name": "A", "length": 4}],
-  "harmony_grid": [{"section": "A", "chords": ["C", "F", "G", "C"]}]
+  "sections": [
+    {"name": "A", "length": 8},
+    {"name": "B", "length": 8}
+  ],
+  "harmony_grid": [
+    {"section": "A", "chords": ["C", "Am", "F", "G", "C", "Em", "F", "G"]},
+    {"section": "B", "chords": ["Am", "F", "C", "G", "Am", "F", "C", "G"]}
+  ],
+  "density_curve": [
+    {"section": "A", "curve": [0.2, 0.3, 0.4, 0.5, 0.4, 0.3, 0.2, 0.1]},
+    {"section": "B", "curve": [0.3, 0.4, 0.5, 0.6, 0.5, 0.4, 0.3, 0.2]}
+  ],
+  "register_policy": {
+    "bass": [28, 48],
+    "keys": [48, 72],
+    "pads": [60, 84]
+  }
 }


### PR DESCRIPTION
## Summary
- extend song sections to 8-bar A/B with detailed chord progressions
- add register policy to control instrument pitch ranges
- shape arrangement using density curves for each section

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'soundfile')*


------
https://chatgpt.com/codex/tasks/task_e_68c08c7aa7b483259042e92121d990c1