### PR TITLE
feat: add flexible drum sample patterns

### DIFF
--- a/tests/test_render_assets.py
+++ b/tests/test_render_assets.py
@@ -1,9 +1,10 @@
 import os
 import sys
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from core.render import render_song, _noise_burst
+from core.render import render_song, _noise_burst, _load_drum_samples
 from core.stems import Stem
 
 
@@ -15,3 +16,23 @@ def test_drum_fallback_noise():
     rendered = audio["drums"].tolist()
     expected = _noise_burst(note, sr).tolist()
     assert rendered == expected
+
+
+def test_drum_flac_sample_loaded(tmp_path):
+    sf = pytest.importorskip("soundfile")
+    sr = 44100
+    # Create a simple FLAC kick sample
+    sample_path = tmp_path / "kick.flac"
+    sf.write(sample_path, [0.1] * 10, sr)
+    mapping = _load_drum_samples(tmp_path, sr)
+    assert 36 in mapping and len(mapping[36]) == 10
+
+
+def test_custom_drum_pattern(tmp_path):
+    sf = pytest.importorskip("soundfile")
+    sr = 44100
+    # Sample file with a non-standard name
+    sample_path = tmp_path / "bd.flac"
+    sf.write(sample_path, [0.2] * 5, sr)
+    mapping = _load_drum_samples(tmp_path, sr, {36: "bd.flac"})
+    assert 36 in mapping and len(mapping[36]) == 5


### PR DESCRIPTION
## Summary
- allow `_load_drum_samples` to search using glob patterns (kick.*, snare.*, hat.*) and load any soundfile-supported format
- expose configurable drum sample patterns through render pipeline
- test FLAC drum samples and custom patterns

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68c08f3a89d08325915e261b6007be40