### PR TITLE
Enable glob-based drum sample loading and pattern config

### DIFF
--- a/tests/test_drum_round_robin.py
+++ b/tests/test_drum_round_robin.py
@@ -2,19 +2,19 @@ import numpy as np
 import soundfile as sf
 from pathlib import Path
 
-from core.render import _load_drum_samples, _render_drums
+from core.render import _load_drum_samples, _render_drums, render_song
 from core.stems import Stem
 
 
 def test_drum_sample_mapping_and_round_robin(tmp_path: Path) -> None:
     sr = 8000
-    # create two distinct samples for the same pitch
+    # create two distinct FLAC samples for the same pitch
     s1 = np.full(100, 0.1, dtype=np.float32)
     s2 = np.full(100, 0.2, dtype=np.float32)
-    sf.write(tmp_path / "a.wav", s1, sr)
-    sf.write(tmp_path / "b.wav", s2, sr)
+    sf.write(tmp_path / "kick_one.flac", s1, sr)
+    sf.write(tmp_path / "kick_two.flac", s2, sr)
 
-    mapping = {"a.wav": 36, "b.wav": 36}
+    mapping = {"kick*.flac": 36}
     loaded = _load_drum_samples(tmp_path, sr, mapping)
     assert 36 in loaded
     assert len(loaded[36]) == 2
@@ -25,8 +25,27 @@ def test_drum_sample_mapping_and_round_robin(tmp_path: Path) -> None:
         Stem(start=0.025, dur=0.0125, pitch=36, vel=127, chan=9),
     ]
     audio = _render_drums(notes, sr, tmp_path, mapping)
-    # ensure round-robin cycling a->b->a
+    # ensure round-robin cycling kick_one->kick_two->kick_one
     assert np.allclose(audio[0:100], s1, atol=1e-4)
     assert np.allclose(audio[100:200], s2, atol=1e-4)
     assert np.allclose(audio[200:300], s1, atol=1e-4)
+
+
+def test_render_song_custom_patterns(tmp_path: Path) -> None:
+    sr = 8000
+    sample = np.full(100, 0.3, dtype=np.float32)
+    sf.write(tmp_path / "bd.flac", sample, sr)
+
+    stems = {
+        "drums": [Stem(start=0.0, dur=0.0125, pitch=36, vel=127, chan=9)]
+    }
+
+    rendered = render_song(
+        stems,
+        sr,
+        sfz_paths={"drums": tmp_path},
+        drum_patterns={"bd.*": 36},
+    )
+
+    assert np.allclose(rendered["drums"][:100], sample, atol=1e-4)
 


### PR DESCRIPTION
## Summary
- allow drum sample loading with glob patterns and any soundfile-supported format
- expose configurable drum sample patterns through `render_song`
- test FLAC drum samples and custom patterns

## Testing
- `pytest -q` *(fails: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68c0924f92d4832585c3f3b30fa15b66