### PR TITLE
Validate register_policy type

### DIFF
--- a/core/song_spec.py
+++ b/core/song_spec.py
@@ -143,6 +143,10 @@ class SongSpec:
 
     def _validate_policies(self) -> None:
         # register_policy ranges should be valid MIDI note numbers (0..127) and low<high
+        if not isinstance(self.register_policy, dict):
+            raise ValueError(
+                "register_policy must be an object mapping instrument→[low, high]."
+            )
         for inst, rng in (self.register_policy or {}).items():
             if not (isinstance(rng, list) and len(rng) == 2 and all(isinstance(x, int) for x in rng)):
                 raise ValueError(f"register_policy[{inst!r}] must be [low, high] MIDI ints.")


### PR DESCRIPTION
## Summary
- guard against non-dict `register_policy` in `SongSpec`
- confirm `song.json` uses a well-formed `register_policy` object

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68c0982978588325895fa4731b5f77d2