### PR TITLE
Require Python 3.10 for Blossom

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Simple demos for algorithmic music pattern generation.
 
+**Python 3.10 required.**
+
 ## Dependencies
 
 SFZ instruments may reference WAV or FLAC samples. Loading FLAC samples requires the
@@ -55,8 +57,8 @@ files.
 
 ### Prerequisites
 
-- Python 3 with the `tkinter` module available. On many Linux systems this can
-  be installed via `sudo apt install python3-tk`.
+- Python 3.10 with the `tkinter` module available. On many Linux systems this
+  can be installed via `sudo apt install python3-tk`.
 - Optional: [`soundfile`](https://pysoundfile.readthedocs.io/) for FLAC
   support when rendering.
 

--- a/main_render.py
+++ b/main_render.py
@@ -1,3 +1,7 @@
+import sys
+if sys.version_info[:2] != (3, 10):
+    raise RuntimeError("Blossom requires Python 3.10")
+
 import argparse
 import json
 import shutil

--- a/main_stems.py
+++ b/main_stems.py
@@ -1,3 +1,7 @@
+import sys
+if sys.version_info[:2] != (3, 10):
+    raise RuntimeError("Blossom requires Python 3.10")
+
 import argparse
 
 from core.song_spec import SongSpec

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "blossom-music-gen"
+version = "0.0.0"
+requires-python = ">=3.10,<3.11"
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"

--- a/tester.py
+++ b/tester.py
@@ -1,7 +1,10 @@
 # tester.py
+import sys
+if sys.version_info[:2] != (3, 10):
+    raise RuntimeError("Blossom requires Python 3.10")
+
 import pathlib
 import subprocess
-import sys
 
 
 def main() -> None:

--- a/ui.py
+++ b/ui.py
@@ -1,3 +1,7 @@
+import sys
+if sys.version_info[:2] != (3, 10):
+    raise RuntimeError("Blossom requires Python 3.10")
+
 import json
 from pathlib import Path
 import tkinter as tk


### PR DESCRIPTION
## Summary
- enforce Python 3.10 at runtime for CLI and UI entry points
- declare Python 3.10 support range via `pyproject.toml`
- document the Python 3.10 requirement in README

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement numpy)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68c098af3c00832587776923cebad0a7