### PR TITLE
Add launcher and main menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 Simple demos for algorithmic music pattern generation.
 
-**Python 3.10 required.**
+**Python 3.10 required.** A small launcher script, `blossom.py`, bootstraps a
+local virtual environment on first run and installs the required packages. The
+launcher then opens a minimal main menu where clicking the music icon starts
+the renderer UI.
 
 ## Dependencies
 
@@ -64,7 +67,15 @@ files.
 
 ### Launching
 
-Run the UI from the repository root:
+The easiest way to try the project is via the menu launched by `blossom.py`:
+
+```bash
+python blossom.py
+```
+
+The script ensures dependencies are installed and then presents a window with a
+music icon. Clicking the icon opens the familiar rendering interface. The UI
+can still be invoked directly with:
 
 ```bash
 python ui.py
@@ -86,6 +97,7 @@ The window exposes a handful of text fields:
 ### Example workflow
 
 1. Prepare a song specification such as `song.json`.
-2. Start the interface with `python ui.py`.
+2. Start the launcher with `python blossom.py` and click the icon to open the
+   renderer UI.
 3. Browse to the spec JSON and adjust any desired parameters.
 4. Click **Render** to create the mix and stems in the specified locations.

--- a/blossom.py
+++ b/blossom.py
@@ -1,0 +1,40 @@
+"""Project launcher that manages a Python 3.10 virtual environment and deps."""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+VENV_DIR = ROOT / ".venv"
+
+
+def _venv_paths() -> tuple[Path, Path]:
+    """Return (python, pip) executables inside the virtual environment."""
+    if os.name == "nt":
+        bin_dir = VENV_DIR / "Scripts"
+        return bin_dir / "python.exe", bin_dir / "pip.exe"
+    bin_dir = VENV_DIR / "bin"
+    return bin_dir / "python", bin_dir / "pip"
+
+
+def _ensure_venv() -> Path:
+    """Create venv and install dependencies if necessary."""
+    py_path, pip_path = _venv_paths()
+    if not VENV_DIR.exists():
+        subprocess.check_call([sys.executable, "-m", "venv", str(VENV_DIR)])
+    subprocess.check_call([str(pip_path), "install", "-r", str(ROOT / "requirements.txt")])
+    return py_path
+
+
+def main() -> None:
+    if sys.version_info[:2] != (3, 10):
+        sys.exit("Blossom requires Python 3.10")
+    py_path = _ensure_venv()
+    subprocess.check_call([str(py_path), str(ROOT / "menu.py")])
+
+
+if __name__ == "__main__":
+    main()

--- a/menu.py
+++ b/menu.py
@@ -1,0 +1,29 @@
+import sys
+if sys.version_info[:2] != (3, 10):
+    raise RuntimeError("Blossom requires Python 3.10")
+
+from pathlib import Path
+import tkinter as tk
+import subprocess
+
+ROOT = Path(__file__).resolve().parent
+ICON_PATH = ROOT / "assets" / "images" / "icon.png"
+
+
+def _open_renderer() -> None:
+    subprocess.Popen([sys.executable, str(ROOT / "ui.py")])
+    root.destroy()
+
+
+root = tk.Tk()
+root.title("Music Generator")
+
+_img = tk.PhotoImage(file=str(ICON_PATH))
+btn = tk.Label(root, image=_img, cursor="hand2")
+btn.image = _img  # keep a reference so image persists
+btn.pack(padx=20, pady=10)
+btn.bind("<Button-1>", lambda _e: _open_renderer())
+
+tk.Label(root, text="Music Generator", font=("Helvetica", 16)).pack(pady=(0, 20))
+
+root.mainloop()


### PR DESCRIPTION
## Summary
- Add Tkinter-based main menu with music icon that opens the existing renderer UI
- Provide `blossom.py` launcher which sets up a Python 3.10 virtualenv, installs requirements, and runs the menu
- Update documentation for new launcher workflow

## Testing
- `pytest` *(fails: Missing SFZ sample assets)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a2fa1ea883258ff7011d146186bd