### PR TITLE
Add temporary launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Simple demos for algorithmic music pattern generation.
 
-**Python 3.10 required.** A small launcher script, `blossom.py`, bootstraps a
-local virtual environment on first run and installs the required packages. The
-launcher then opens a minimal main menu where clicking the music icon starts
+**Python 3.10 required.** A small launcher script, `start.py`, bootstraps a
+temporary virtual environment and installs the required packages. The launcher
+then opens a minimal main menu where clicking the music icon starts
 the renderer UI.
 
 ## Dependencies
@@ -67,10 +67,10 @@ files.
 
 ### Launching
 
-The easiest way to try the project is via the menu launched by `blossom.py`:
+The easiest way to try the project is via the menu launched by `start.py`:
 
 ```bash
-python blossom.py
+python start.py
 ```
 
 The script ensures dependencies are installed and then presents a window with a
@@ -97,7 +97,7 @@ The window exposes a handful of text fields:
 ### Example workflow
 
 1. Prepare a song specification such as `song.json`.
-2. Start the launcher with `python blossom.py` and click the icon to open the
+2. Start the launcher with `python start.py` and click the icon to open the
    renderer UI.
 3. Browse to the spec JSON and adjust any desired parameters.
 4. Click **Render** to create the mix and stems in the specified locations.

--- a/start.py
+++ b/start.py
@@ -1,0 +1,40 @@
+import atexit
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def _venv_paths(env_dir: str) -> tuple[Path, Path]:
+    """Return (python, pip) executables inside the virtual environment."""
+    env_path = Path(env_dir)
+    if os.name == "nt":
+        bin_dir = env_path / "Scripts"
+        return bin_dir / "python.exe", bin_dir / "pip.exe"
+    bin_dir = env_path / "bin"
+    return bin_dir / "python", bin_dir / "pip"
+
+
+def main() -> None:
+    if sys.version_info[:2] != (3, 10):
+        sys.exit("Python 3.10 required")
+
+    env_dir = tempfile.mkdtemp(prefix="start-env-")
+    atexit.register(shutil.rmtree, env_dir, True)
+
+    subprocess.run([sys.executable, "-m", "venv", env_dir], check=True)
+    python_path, pip_path = _venv_paths(env_dir)
+
+    try:
+        subprocess.check_call([str(pip_path), "install", "-r", "requirements.txt"])
+    except subprocess.CalledProcessError:
+        print("Failed to install dependencies", file=sys.stderr)
+        sys.exit(1)
+
+    subprocess.run([str(python_path), "-m", "main_menu"], check=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `start.py` that spins up a temporary venv, installs dependencies, and runs the main menu
- document the new `python start.py` entrypoint in the README

## Testing
- `pytest` *(fails: missing instrument samples and other test assets)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a410468083259da93b746da2c898