### PR TITLE
Document start.py launcher and update UI guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 Simple demos for algorithmic music pattern generation.
 
-**Python 3.10 required.** A small launcher script, `start.py`, bootstraps a
-temporary virtual environment and installs the required packages. The launcher
-then opens a minimal main menu where clicking the music icon starts
-the renderer UI.
+**Python 3.10 required.** The `start.py` helper creates a temporary virtual
+environment, installs the packages from `requirements.txt`, and aborts if
+installation fails. After setup it opens a minimal main menu where clicking the
+music icon launches the renderer UI.
 
 ## Dependencies
 
@@ -67,15 +67,18 @@ files.
 
 ### Launching
 
-The easiest way to try the project is via the menu launched by `start.py`:
+Launch the interface through the bootstrapper:
 
 ```bash
 python start.py
 ```
 
-The script ensures dependencies are installed and then presents a window with a
-music icon. Clicking the icon opens the familiar rendering interface. The UI
-can still be invoked directly with:
+The script sets up a throwaway virtual environment, installs dependencies,
+and then presents a window with a music icon. Clicking the icon opens the
+rendering interface.
+
+If you already have the requirements installed, the UI can still be invoked
+directly:
 
 ```bash
 python ui.py
@@ -97,7 +100,8 @@ The window exposes a handful of text fields:
 ### Example workflow
 
 1. Prepare a song specification such as `song.json`.
-2. Start the launcher with `python start.py` and click the icon to open the
+2. Start the launcher with `python start.py` (it creates a temporary
+   environment and installs dependencies) and click the icon to open the
    renderer UI.
 3. Browse to the spec JSON and adjust any desired parameters.
 4. Click **Render** to create the mix and stems in the specified locations.

--- a/start.py
+++ b/start.py
@@ -1,3 +1,10 @@
+"""Bootstraps the demo in a temporary virtual environment.
+
+The launcher creates an isolated environment, installs ``requirements.txt``
+dependencies, and refuses to continue if installation fails.  Once setup
+completes it opens the small Tkinter menu used to access the renderer UI.
+"""
+
 import atexit
 import os
 import shutil
@@ -33,7 +40,7 @@ def main() -> None:
         print("Failed to install dependencies", file=sys.stderr)
         sys.exit(1)
 
-    subprocess.run([str(python_path), "-m", "main_menu"], check=True)
+    subprocess.run([str(python_path), "-m", "menu"], check=True)
 
 
 if __name__ == "__main__":

--- a/ui.py
+++ b/ui.py
@@ -1,3 +1,10 @@
+"""Tkinter interface for rendering music.
+
+The UI is typically launched via ``start.py`` which sets up a temporary
+virtual environment and installs dependencies automatically.  Direct execution
+is still supported when the required packages are already available.
+"""
+
 import sys
 if sys.version_info[:2] != (3, 10):
     raise RuntimeError("Blossom requires Python 3.10")


### PR DESCRIPTION
## Summary
- explain start.py bootstrapper and route launch through menu module
- clarify in README how start.py sets up a temp virtual environment and opens the UI
- note in ui.py docstring that start.py is the preferred launcher

## Testing
- `pytest -q` *(fails: No region for pitch 60; Missing SFZ sample(s); FileNotFoundError: 'assets/sfz/piano.sfz'; AssertionError in drum tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a5bb37e08325b484f95c28550eb6