### PR TITLE
Check 64-bit Python and document requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Simple demos for algorithmic music pattern generation.
 
-**Python 3.10 required.** The `start.py` helper creates a temporary virtual
+**64-bit Python 3.10 required.** The `start.py` helper creates a temporary virtual
 environment, installs the packages from `requirements.txt`, and aborts if
 installation fails. After setup it opens a minimal main menu where clicking the
 music icon launches the renderer UI.
@@ -60,7 +60,7 @@ files.
 
 ### Prerequisites
 
-- Python 3.10 with the `tkinter` module available. On many Linux systems this
+- 64-bit Python 3.10 with the `tkinter` module available. On many Linux systems this
   can be installed via `sudo apt install python3-tk`.
 - Optional: [`soundfile`](https://pysoundfile.readthedocs.io/) for FLAC
   support when rendering.

--- a/start.py
+++ b/start.py
@@ -11,6 +11,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import struct
 from pathlib import Path
 
 
@@ -27,6 +28,9 @@ def _venv_paths(env_dir: str) -> tuple[Path, Path]:
 def main() -> None:
     if sys.version_info[:2] != (3, 10):
         sys.exit("Python 3.10 required")
+
+    if struct.calcsize("P") * 8 != 64:
+        sys.exit("64-bit Python 3.10 required")
 
     env_dir = tempfile.mkdtemp(prefix="start-env-")
     atexit.register(shutil.rmtree, env_dir, True)


### PR DESCRIPTION
## Summary
- Ensure start.py aborts unless running under 64-bit Python 3.10
- Document the new 64-bit architecture requirement in README

## Testing
- `pytest -q` *(fails: assert False, ValueError: expected non-negative integer, FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a75fa8588325ac78bf0045a57ea1