### PR TITLE
Check Python architecture and document 64-bit requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 Simple demos for algorithmic music pattern generation.
 
-**Python 3.10 required.** The `start.py` helper creates a temporary virtual
-environment, installs the packages from `requirements.txt`, and aborts if
-installation fails. After setup it opens a minimal main menu where clicking the
-music icon launches the renderer UI.
+**64-bit Python 3.10 required.** The `start.py` helper creates a temporary
+virtual environment, installs the packages from `requirements.txt`, and aborts
+if installation fails. After setup it opens a minimal main menu where clicking
+the music icon launches the renderer UI.
 
 ## Dependencies
 
@@ -60,8 +60,8 @@ files.
 
 ### Prerequisites
 
-- Python 3.10 with the `tkinter` module available. On many Linux systems this
-  can be installed via `sudo apt install python3-tk`.
+- 64-bit Python 3.10 with the `tkinter` module available. On many Linux
+  systems this can be installed via `sudo apt install python3-tk`.
 - Optional: [`soundfile`](https://pysoundfile.readthedocs.io/) for FLAC
   support when rendering.
 

--- a/start.py
+++ b/start.py
@@ -11,6 +11,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import struct
 from pathlib import Path
 
 
@@ -27,6 +28,9 @@ def _venv_paths(env_dir: str) -> tuple[Path, Path]:
 def main() -> None:
     if sys.version_info[:2] != (3, 10):
         sys.exit("Python 3.10 required")
+
+    if struct.calcsize("P") * 8 != 64:
+        sys.exit("64-bit Python 3.10 required")
 
     env_dir = tempfile.mkdtemp(prefix="start-env-")
     atexit.register(shutil.rmtree, env_dir, True)


### PR DESCRIPTION
## Summary
- verify Python interpreter is 64-bit before creating the temporary venv
- document the 64-bit Python 3.10 requirement in README

## Testing
- `pytest` *(fails: render-related tests due to missing assets or mismatched outputs)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a797bd388325b2cbf00f25e0dd0f