### PR TITLE
Resize menu icon and fix window size

### DIFF
--- a/menu.py
+++ b/menu.py
@@ -17,8 +17,10 @@ def _open_renderer() -> None:
 
 root = tk.Tk()
 root.title("Music Generator")
+root.geometry("400x400")
 
 _img = tk.PhotoImage(file=str(ICON_PATH))
+_img = _img.subsample(2, 2)
 btn = tk.Label(root, image=_img, cursor="hand2")
 btn.image = _img  # keep a reference so image persists
 btn.pack(padx=20, pady=10)


### PR DESCRIPTION
## Summary
- Reduce menu icon by subsampling the loaded image.
- Set a fixed 400x400 window size before packing widgets to keep the window consistent.

## Testing
- `pytest` *(fails: missing SFZ assets and seed error)*
- `python menu.py` *(fails: Blossom requires Python 3.10)*

------
https://chatgpt.com/codex/tasks/task_e_68c0acf72b28832584e0afea4d49a4e2