### PR TITLE
Simplify density curve in song spec

### DIFF
--- a/song.json
+++ b/song.json
@@ -6,20 +6,59 @@
   "tempo": 120,
   "meter": "4/4",
   "sections": [
-    {"name": "A", "length": 8},
-    {"name": "B", "length": 8}
+    {
+      "name": "A",
+      "length": 8
+    },
+    {
+      "name": "B",
+      "length": 8
+    }
   ],
   "harmony_grid": [
-    {"section": "A", "chords": ["C", "Am", "F", "G", "C", "Em", "F", "G"]},
-    {"section": "B", "chords": ["Am", "F", "C", "G", "Am", "F", "C", "G"]}
+    {
+      "section": "A",
+      "chords": [
+        "C",
+        "Am",
+        "F",
+        "G",
+        "C",
+        "Em",
+        "F",
+        "G"
+      ]
+    },
+    {
+      "section": "B",
+      "chords": [
+        "Am",
+        "F",
+        "C",
+        "G",
+        "Am",
+        "F",
+        "C",
+        "G"
+      ]
+    }
   ],
-  "density_curve": [
-    {"section": "A", "curve": [0.2, 0.3, 0.4, 0.5, 0.4, 0.3, 0.2, 0.1]},
-    {"section": "B", "curve": [0.3, 0.4, 0.5, 0.6, 0.5, 0.4, 0.3, 0.2]}
-  ],
+  "density_curve": {
+    "A": 0.35,
+    "B": 0.45
+  },
   "register_policy": {
-    "bass": [28, 48],
-    "keys": [48, 72],
-    "pads": [60, 84]
+    "bass": [
+      28,
+      48
+    ],
+    "keys": [
+      48,
+      72
+    ],
+    "pads": [
+      60,
+      84
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- replace density_curve list with simple per-section mapping

## Testing
- `python - <<'PY'
from core.song_spec import SongSpec
SongSpec.from_json('song.json').validate()
print('validation passed')
PY`
- `pytest` *(fails: assert np.allclose(...); ValueError: expected non-negative integer; assert [-0.405194133...]; FileNotFoundError: [Errno 2] No such file or directory: 'assets/sfz/piano.sfz'; ValueError: No region for pitch 60; FileNotFoundError: Missing SFZ sample(s): assets/sfz/Piano/UprightPiano/samples/A0vL.flac, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c0afaa1dac83258d172b540a7363f5