### PR TITLE
feat: add track EQ and bus compressor

### DIFF
--- a/core/mixer.py
+++ b/core/mixer.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 """Simple stereo mixing utilities.
 
 This module turns mono instrument stems into a stereo master bus.  Each track
-can specify gain, pan and a reverb send amount via a configuration mapping.
-A shared reverb bus is generated for keys and pads (or any track that sets a
-send amount) and the final mix passes through a basic peak limiter targeting a
-user supplied dBFS threshold (``-0.1`` by default).
+can specify gain, pan, a single-band EQ and a reverb send amount via a
+configuration mapping.  A shared reverb bus is generated for keys and pads (or
+any track that sets a send amount) and the final mix passes through a light bus
+compressor followed by a basic peak limiter targeting a user supplied dBFS
+threshold (``-0.1`` by default).
 """
 
 from typing import Any, Mapping, Dict
@@ -33,6 +34,56 @@ def _apply_gain_pan(signal: np.ndarray, gain_db: float, pan: float) -> np.ndarra
     return np.stack([left, right], axis=1)
 
 
+def _apply_peaking_eq(
+    signal: np.ndarray, sr: int, freq: float, gain_db: float, q: float = 1.0
+) -> np.ndarray:
+    """Apply a simple peaking EQ filter.
+
+    Parameters
+    ----------
+    signal:
+        Mono input array.
+    sr:
+        Sample rate of ``signal``.
+    freq:
+        Centre frequency of the bell filter.
+    gain_db:
+        Gain at ``freq`` in decibels. Zero leaves ``signal`` unchanged.
+    q:
+        Quality factor controlling bandwidth of the boost/cut.
+    """
+
+    if gain_db == 0.0 or freq <= 0.0 or freq >= sr / 2:
+        return signal
+
+    a = 10 ** (gain_db / 40.0)
+    w0 = 2.0 * math.pi * freq / sr
+    alpha = math.sin(w0) / (2.0 * q)
+    cos_w0 = math.cos(w0)
+
+    b0 = 1.0 + alpha * a
+    b1 = -2.0 * cos_w0
+    b2 = 1.0 - alpha * a
+    a0 = 1.0 + alpha / a
+    a1 = -2.0 * cos_w0
+    a2 = 1.0 - alpha / a
+
+    b0 /= a0
+    b1 /= a0
+    b2 /= a0
+    a1 /= a0
+    a2 /= a0
+
+    out = np.zeros_like(signal, dtype=np.float32)
+    x1 = x2 = y1 = y2 = 0.0
+    for i, x0 in enumerate(signal):
+        y0 = b0 * x0 + b1 * x1 + b2 * x2 - a1 * y1 - a2 * y2
+        out[i] = y0
+        x2, x1 = x1, x0
+        y2, y1 = y1, y0
+    return out
+
+
 def _feedback_delay(signal: np.ndarray, delay: int, decay: float) -> np.ndarray:
     """Return ``signal`` passed through a simple feedback delay."""
     out = np.zeros_like(signal)
@@ -57,6 +108,46 @@ def _simple_reverb(stereo: np.ndarray, sr: int, decay: float) -> np.ndarray:
         out[:, 0] += _feedback_delay(stereo[:, 0], d, decay)
         out[:, 1] += _feedback_delay(stereo[:, 1], d, decay)
     return out / len(delays)
+
+
+def _compress_bus(
+    stereo: np.ndarray,
+    sr: int,
+    threshold_db: float,
+    ratio: float,
+    attack: float,
+    release: float,
+) -> np.ndarray:
+    """Apply a simple stereo bus compressor."""
+
+    if ratio <= 1.0:
+        return stereo
+
+    attack = max(1e-4, attack)
+    release = max(1e-4, release)
+    a_coeff = math.exp(-1.0 / (sr * attack))
+    r_coeff = math.exp(-1.0 / (sr * release))
+
+    env = 0.0
+    out = np.zeros_like(stereo, dtype=np.float32)
+    for i, (l, r) in enumerate(stereo):
+        x = max(abs(l), abs(r))
+        if x > env:
+            env = a_coeff * env + (1.0 - a_coeff) * x
+        else:
+            env = r_coeff * env + (1.0 - r_coeff) * x
+
+        env_db = 20.0 * math.log10(env + 1e-12)
+        if env_db > threshold_db:
+            gain_db = threshold_db + (env_db - threshold_db) / ratio - env_db
+            gain = 10 ** (gain_db / 20.0)
+        else:
+            gain = 1.0
+
+        out[i, 0] = l * gain
+        out[i, 1] = r * gain
+
+    return out
 
 
 def mix(stems: Mapping[str, np.ndarray], sr: int, config: Mapping[str, Any] | None = None) -> np.ndarray:
@@ -97,6 +188,12 @@ def mix(stems: Mapping[str, np.ndarray], sr: int, config: Mapping[str, Any] | No
         gain_db = float(cfg.get("gain", 0.0))
         pan = float(cfg.get("pan", 0.0))
         send = float(cfg.get("reverb_send", 0.0))
+        eq_cfg = cfg.get("eq")
+        if eq_cfg:
+            freq = float(eq_cfg.get("freq", 0.0))
+            eq_gain = float(eq_cfg.get("gain", 0.0))
+            q = float(eq_cfg.get("q", 1.0))
+            mono = _apply_peaking_eq(mono, sr, freq, eq_gain, q)
         stereo = _apply_gain_pan(mono, gain_db, pan)
         mix += stereo
         reverb_bus += stereo * send
@@ -106,6 +203,14 @@ def mix(stems: Mapping[str, np.ndarray], sr: int, config: Mapping[str, Any] | No
     wet = float(rev_cfg.get("wet", 0.3))
     if wet > 0.0:
         mix += _simple_reverb(reverb_bus, sr, decay) * wet
+
+    comp_cfg = config.get("master", {}).get("compressor", {})
+    if comp_cfg.get("enabled", True):
+        threshold_db = float(comp_cfg.get("threshold", -6.0))
+        ratio = float(comp_cfg.get("ratio", 2.0))
+        attack = float(comp_cfg.get("attack", 0.01))
+        release = float(comp_cfg.get("release", 0.1))
+        mix = _compress_bus(mix, sr, threshold_db, ratio, attack, release)
 
     lim_cfg = config.get("master", {}).get("limiter", {})
     if lim_cfg.get("enabled", True):

--- a/core/render.py
+++ b/core/render.py
@@ -58,6 +58,10 @@ def _schedule(
     for idx, n in enumerate(notes):
         start = starts[idx]
         data = render_note(n)
+        if start < 0:
+            cut = min(len(data), -start)
+            data = data[cut:]
+            start = 0
         end = start + len(data)
         if end > len(out):
             out = np.pad(out, (0, end - len(out)))
@@ -78,7 +82,9 @@ def _noise_burst(note: Stem, sr: int) -> np.ndarray:
     n = int(round(dur * sr))
     if n <= 0:
         return np.zeros(0, dtype=np.float32)
-    rng = np.random.default_rng(int(note.start * sr) + note.pitch)
+    seed = int(note.start * sr) + note.pitch
+    seed = int(seed % (2 ** 32))
+    rng = np.random.default_rng(seed)
     data = rng.standard_normal(n).astype(np.float32)
     env = np.exp(-np.linspace(0, 6, n)).astype(np.float32)
     return (note.vel / 127.0) * data * env

--- a/render_config.json
+++ b/render_config.json
@@ -10,22 +10,26 @@
     "drums": {
       "gain": -3.0,
       "pan": 0.0,
-      "reverb_send": 0.1
+      "reverb_send": 0.1,
+      "eq": {"freq": 1000.0, "gain": 0.0, "q": 1.0}
     },
     "bass": {
       "gain": -6.0,
       "pan": -0.1,
-      "reverb_send": 0.05
+      "reverb_send": 0.05,
+      "eq": {"freq": 1000.0, "gain": 0.0, "q": 1.0}
     },
     "keys": {
       "gain": -3.0,
       "pan": 0.1,
-      "reverb_send": 0.25
+      "reverb_send": 0.25,
+      "eq": {"freq": 1000.0, "gain": 0.0, "q": 1.0}
     },
     "pads": {
       "gain": -6.0,
       "pan": 0.0,
-      "reverb_send": 0.4
+      "reverb_send": 0.4,
+      "eq": {"freq": 1000.0, "gain": 0.0, "q": 1.0}
     }
   },
   "reverb": {
@@ -33,6 +37,13 @@
     "wet": 0.3
   },
   "master": {
+    "compressor": {
+      "enabled": true,
+      "threshold": -6.0,
+      "ratio": 2.0,
+      "attack": 0.01,
+      "release": 0.1
+    },
     "limiter": {
       "enabled": true,
       "threshold": -0.1,

--- a/tests/test_mixer.py
+++ b/tests/test_mixer.py
@@ -10,7 +10,10 @@ def test_gain_pan_limiter():
     stems = {"keys": stem}
     cfg = {
         "tracks": {"keys": {"gain": -6.0, "pan": 1.0, "reverb_send": 0.0}},
-        "master": {"limiter": {"enabled": True, "threshold": -0.1}},
+        "master": {
+            "compressor": {"enabled": False},
+            "limiter": {"enabled": True, "threshold": -0.1},
+        },
     }
     out = mix(stems, sr, cfg)
     assert out.shape == (1000, 2)
@@ -28,7 +31,63 @@ def test_reverb_send_creates_tail():
     cfg = {
         "tracks": {"pads": {"gain": 0.0, "pan": 0.0, "reverb_send": 1.0}},
         "reverb": {"decay": 0.2, "wet": 1.0},
+        "master": {"compressor": {"enabled": False}},
     }
     out = mix(stems, sr, cfg)
     # Expect some energy in the tail from the reverb
     assert np.any(np.abs(out[10:, 0]) > 1e-5) or np.any(np.abs(out[10:, 1]) > 1e-5)
+
+
+def test_track_eq_boosts_frequency():
+    sr = 44100
+    t = np.arange(int(sr * 0.1)) / sr
+    sine = 0.25 * np.sin(2 * np.pi * 1000 * t).astype(np.float32)
+    stems = {"keys": sine}
+    cfg_no = {"tracks": {"keys": {"gain": 0.0, "pan": 0.0, "reverb_send": 0.0}}, "master": {"compressor": {"enabled": False}}}
+    cfg_eq = {
+        "tracks": {
+            "keys": {
+                "gain": 0.0,
+                "pan": 0.0,
+                "reverb_send": 0.0,
+                "eq": {"freq": 1000.0, "gain": 6.0, "q": 1.0},
+            }
+        },
+        "master": {"compressor": {"enabled": False}},
+    }
+    out_no = mix(stems, sr, cfg_no)
+    out_eq = mix(stems, sr, cfg_eq)
+    amp_no = np.max(np.abs(out_no[100:, 0]))
+    amp_eq = np.max(np.abs(out_eq[100:, 0]))
+    assert amp_eq > amp_no * 1.5
+
+
+def test_bus_compressor_reduces_peak():
+    sr = 44100
+    stem = np.ones(int(sr * 0.1), dtype=np.float32)
+    stems = {"keys": stem}
+    cfg_no = {
+        "tracks": {"keys": {"gain": 0.0, "pan": 0.0, "reverb_send": 0.0}},
+        "master": {"compressor": {"enabled": False}, "limiter": {"enabled": False}},
+    }
+    cfg_comp = {
+        "tracks": {"keys": {"gain": 0.0, "pan": 0.0, "reverb_send": 0.0}},
+        "master": {
+            "compressor": {
+                "enabled": True,
+                "threshold": -20.0,
+                "ratio": 4.0,
+                "attack": 0.001,
+                "release": 0.05,
+            },
+            "limiter": {"enabled": False},
+        },
+    }
+    out_no = mix(stems, sr, cfg_no)
+    out_comp = mix(stems, sr, cfg_comp)
+    peak_no = float(np.max(np.abs(out_no)))
+    steady = int(len(stem) * 0.8)
+    peak_comp = float(np.max(np.abs(out_comp[steady:])))
+    target = 10 ** ((-20 + (0 - (-20)) / 4) / 20)
+    assert peak_no > peak_comp
+    assert np.isclose(peak_comp, target, atol=0.02)


### PR DESCRIPTION
## Summary
- add simple per-track EQ and master bus compressor
- expose EQ and compressor parameters in `render_config.json`
- test EQ and compression paths and adjust mix duration check
- sanitize note scheduling for negative starts

## Testing
- `PYTHONPATH=. pytest tests/test_mixer.py tests/test_mix_output_constraints.py -q`
- `PYTHONPATH=. pytest -q` *(fails: missing SFZ assets)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b263ed148325863be53eb8535676