### PR TITLE
Add basic arranger step and wire into rendering pipeline

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -12,11 +12,12 @@ from .stems import (
     dedupe_collisions,
     build_stems_for_song,
 )
+from .arranger import arrange_song
 
 __all__ = [
     "SongSpec", "Section",
     "generate_satb", "parse_chord_symbol",
-    "build_patterns_for_song", "build_stems_for_song",
+    "build_patterns_for_song", "build_stems_for_song", "arrange_song",
     "Note", "Stem", "Stems",
     "bars_to_beats", "beats_to_secs",
     "enforce_register", "dedupe_collisions",

--- a/core/arranger.py
+++ b/core/arranger.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+"""Simple arrangement helpers."""
+
+from typing import Dict, List, Mapping
+import random
+
+from .song_spec import SongSpec
+from .stems import Stem, bars_to_beats, beats_to_secs, _steps_per_beat
+
+
+def _section_index(spec: SongSpec, bar: int) -> int | None:
+    """Return the index of ``spec.sections`` containing ``bar``."""
+    cursor = 0
+    for idx, sec in enumerate(spec.sections):
+        if cursor <= bar < cursor + sec.length:
+            return idx
+        cursor += sec.length
+    return None
+
+
+def arrange_song(
+    spec: SongSpec,
+    stems: Mapping[str, List[Stem]],
+    style: Mapping[str, object] | None,
+    seed: int,
+) -> Dict[str, List[Stem]]:
+    """Return arranged copy of ``stems`` according to ``spec`` and ``style``.
+
+    Parameters
+    ----------
+    spec:
+        Song specification describing structure and cadences.
+    stems:
+        Mapping of instrument name to note events as produced by
+        :func:`core.stems.build_stems_for_song`.
+    style:
+        Arrangement style dictionary.  ``style['onoff']`` may provide a
+        mapping of instrument name to lists of truthy values describing whether
+        the instrument is active for each section.
+    seed:
+        Random seed for deterministic humanisation of added events.
+    """
+
+    beats_per_bar = bars_to_beats(spec.meter)
+    sec_per_beat = beats_to_secs(spec.tempo)
+    sec_per_bar = beats_per_bar * sec_per_beat
+    spb = _steps_per_beat(spec.meter)
+    sec_per_step = sec_per_beat / spb
+
+    onoff: Dict[str, List[int]] = {}
+    if style and isinstance(style.get("onoff"), Mapping):
+        onoff = {k: list(v) for k, v in style["onoff"].items() if isinstance(v, (list, tuple))}
+
+    out: Dict[str, List[Stem]] = {}
+
+    # ------------------------------------------------------------------
+    # Section muting/activation based on style['onoff']
+    # ------------------------------------------------------------------
+    for inst, notes in stems.items():
+        toggles = onoff.get(inst)
+        if not toggles:
+            out[inst] = list(notes)
+            continue
+        filtered: List[Stem] = []
+        for n in notes:
+            bar_idx = int(n.start // sec_per_bar)
+            sec_idx = _section_index(spec, bar_idx)
+            if sec_idx is None or sec_idx >= len(toggles) or toggles[sec_idx]:
+                filtered.append(n)
+        out[inst] = filtered
+
+    rng = random.Random(seed)
+
+    # ------------------------------------------------------------------
+    # Cadence handling: drum fills and bass approach notes
+    # ------------------------------------------------------------------
+    cadences = spec.cadence_bars()
+    if cadences:
+        for bar_idx in sorted(cadences):
+            bar_start = bar_idx * sec_per_bar
+            bar_end = bar_start + sec_per_bar
+            # Drum fill: simple snare hit on the last 16th note of the bar
+            fill_start = bar_end - sec_per_step
+            vel = int(rng.uniform(100, 120))
+            out.setdefault("drums", []).append(
+                Stem(start=fill_start, dur=sec_per_step, pitch=38, vel=vel, chan=9)
+            )
+            # Bass approach: chromatic approach to first note of next bar
+            next_start = (bar_idx + 1) * sec_per_bar
+            next_end = next_start + sec_per_bar
+            target_pitch = None
+            target_vel = 96
+            for bn in out.get("bass", []):
+                if next_start <= bn.start < next_end:
+                    target_pitch = bn.pitch
+                    target_vel = bn.vel
+                    break
+            if target_pitch is not None:
+                approach = target_pitch - 1
+                low, high = spec.register_policy.get("bass", (0, 127))
+                if approach < low:
+                    approach = low
+                if approach > high:
+                    approach = high
+                start = bar_end - sec_per_step
+                vel_b = int(rng.uniform(80, target_vel))
+                out.setdefault("bass", []).append(
+                    Stem(start=start, dur=sec_per_step, pitch=approach, vel=vel_b, chan=0)
+                )
+
+    # ensure deterministic order
+    for notes in out.values():
+        notes.sort(key=lambda n: n.start)
+
+    return out

--- a/main_render.py
+++ b/main_render.py
@@ -12,6 +12,7 @@ import numpy as np
 
 from core.song_spec import SongSpec
 from core.stems import build_stems_for_song
+from core.arranger import arrange_song
 from core.render import render_song
 from core.mixer import mix as mix_stems
 
@@ -103,6 +104,7 @@ if __name__ == "__main__":
             cfg = json.load(fh)
 
     stems = build_stems_for_song(spec, seed=args.seed)
+    stems = arrange_song(spec, stems, style=cfg.get("style", {}), seed=args.seed)
 
     sample_paths = dict(cfg.get("sample_paths", {}))
     if "keys" not in sample_paths and cfg.get("piano_sfz"):

--- a/ui.py
+++ b/ui.py
@@ -17,6 +17,7 @@ from tkinter import filedialog, messagebox
 
 from core.song_spec import SongSpec
 from core.stems import build_stems_for_song
+from core.arranger import arrange_song
 from core.render import render_song
 from core.mixer import mix
 from main_render import _write_wav, _maybe_export_mp3
@@ -109,6 +110,7 @@ def render():
                 cfg = json.load(fh)
 
         stems = build_stems_for_song(spec, seed=seed)
+        stems = arrange_song(spec, stems, style=cfg.get("style", {}), seed=seed)
 
         sfz_map = {}
         if keys_var.get():


### PR DESCRIPTION
## Summary
- add `arrange_song` to control instrument activation per section and add simple cadence embellishments
- expose arranger via `core.__init__`
- insert arrangement stage between stem generation and rendering in CLI and UI pipelines

## Testing
- `pytest` *(fails: FileNotFoundError: Missing SFZ sample(s))*

------
https://chatgpt.com/codex/tasks/task_e_68c0b48aec488325ae2aaec90349f7e9