### PR TITLE
Add arrangement duration control and outro options

### DIFF
--- a/main_render.py
+++ b/main_render.py
@@ -78,6 +78,11 @@ if __name__ == "__main__":
         help="Directory to write individual stem WAVs",
     )
     ap.add_argument(
+        "--minutes",
+        type=float,
+        help="Target song length in minutes; sections are looped as needed",
+    )
+    ap.add_argument(
         "--keys-sfz",
         dest="keys_sfz",
         help="Path to keys SFZ file or directory. If omitted, uses render_config.json",
@@ -104,7 +109,13 @@ if __name__ == "__main__":
             cfg = json.load(fh)
 
     stems = build_stems_for_song(spec, seed=args.seed)
-    stems = arrange_song(spec, stems, style=cfg.get("style", {}), seed=args.seed)
+    stems = arrange_song(
+        spec,
+        stems,
+        style=cfg.get("style", {}),
+        seed=args.seed,
+        minutes=args.minutes,
+    )
 
     sample_paths = dict(cfg.get("sample_paths", {}))
     if "keys" not in sample_paths and cfg.get("piano_sfz"):

--- a/tests/test_arranger_minutes_outro.py
+++ b/tests/test_arranger_minutes_outro.py
@@ -1,0 +1,55 @@
+"""Tests for arranger minute-based looping and outro behaviour."""
+
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.arranger import arrange_song
+from core.song_spec import SongSpec, Section
+from core.stems import Stem, bars_to_beats, beats_to_secs
+
+
+def test_arranger_minutes_and_final_hit():
+    spec = SongSpec(
+        tempo=120,
+        meter="4/4",
+        sections=[Section("A", 2), Section("B", 2)],
+    )
+    beats_per_bar = bars_to_beats(spec.meter)
+    sec_per_bar = beats_to_secs(spec.tempo) * beats_per_bar
+    stems = {
+        "drums": [
+            Stem(start=0.0, dur=0.25, pitch=36, vel=100, chan=9),
+            Stem(start=2 * sec_per_bar, dur=0.25, pitch=36, vel=100, chan=9),
+        ]
+    }
+    out = arrange_song(spec, stems, style={"outro": "hit"}, seed=1, minutes=0.5)
+    end = max(n.start + n.dur for n in out["drums"])
+    assert 30 * 0.98 <= end <= 30 * 1.02
+    assert any(n.pitch == 49 for n in out["drums"])
+
+
+def test_arranger_ritard_outro():
+    spec = SongSpec(
+        tempo=120,
+        meter="4/4",
+        sections=[Section("A", 1), Section("B", 1)],
+    )
+    beats_per_bar = bars_to_beats(spec.meter)
+    sec_per_bar = beats_to_secs(spec.tempo) * beats_per_bar
+    stems = {
+        "keys": [
+            Stem(start=0.0, dur=0.5, pitch=60, vel=100, chan=0),
+            Stem(start=sec_per_bar, dur=0.5, pitch=60, vel=100, chan=0),
+            Stem(start=sec_per_bar + 1.0, dur=0.5, pitch=62, vel=100, chan=0),
+        ]
+    }
+    out = arrange_song(
+        spec,
+        stems,
+        style={"outro": {"type": "ritard", "factor": 2.0}},
+        seed=2,
+    )
+    starts = [n.start for n in out["keys"]]
+    assert any(abs(s - 4.0) < 0.05 for s in starts)
+    end = max(n.start + n.dur for n in out["keys"])
+    assert 6.0 * 0.99 <= end <= 6.0 * 1.01


### PR DESCRIPTION
## Summary
- loop song sections to reach a target duration and support ritard or final hit outros
- allow specifying desired minutes on the render CLI
- test minute-based looping and both outro styles

## Testing
- `pytest tests/test_arranger_minutes_outro.py -q`
- `pytest -q` *(fails: test_render_song_custom_patterns, test_drum_fallback_noise, test_render_piano, test_sfz_instruments_render_note_sequence[sfz_path0], test_sfz_instruments_render_note_sequence[sfz_path1])*

------
https://chatgpt.com/codex/tasks/task_e_68c0f021b6108325832a0d239f991ff3