### PR TITLE
Add minute-based looping with configurable outros

### DIFF
--- a/core/main_synth.py
+++ b/core/main_synth.py
@@ -1,28 +1,8 @@
 import argparse
 import json
-import math
 
-from core.song_spec import SongSpec, Section
+from core.song_spec import SongSpec, extend_sections_to_minutes
 from core.pattern_synth import build_patterns_for_song
-
-
-def _extend_sections_to_minutes(spec: SongSpec, minutes: float) -> None:
-    """Extend ``spec.sections`` so total bars cover ``minutes`` of music."""
-    num, den = map(int, spec.meter.split("/", 1))
-    bars_needed = math.ceil(minutes * spec.tempo * den / (num * 4))
-    current = spec.total_bars()
-    if bars_needed <= current:
-        return
-    sections = list(spec.sections)
-    cursor = current
-    idx = 0
-    templates = list(spec.sections)
-    while cursor < bars_needed:
-        tmpl = templates[idx % len(templates)]
-        sections.append(Section(name=tmpl.name, length=tmpl.length))
-        cursor += tmpl.length
-        idx += 1
-    spec.sections = sections
 
 
 if __name__ == "__main__":
@@ -37,7 +17,7 @@ if __name__ == "__main__":
     spec.validate()
 
     if args.minutes:
-        _extend_sections_to_minutes(spec, args.minutes)
+        extend_sections_to_minutes(spec, args.minutes)
 
     plan = build_patterns_for_song(spec, seed=args.seed)
 

--- a/main_render.py
+++ b/main_render.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import numpy as np
 
-from core.song_spec import SongSpec
+from core.song_spec import SongSpec, extend_sections_to_minutes
 from core.stems import build_stems_for_song
 from core.arranger import arrange_song
 from core.render import render_song
@@ -98,6 +98,13 @@ if __name__ == "__main__":
         dest="style",
         help="Arrangement style name or JSON file in assets/styles",
     )
+    ap.add_argument("--minutes", type=float, help="Target duration in minutes")
+    ap.add_argument(
+        "--outro",
+        choices=["hit", "ritard"],
+        default="hit",
+        help="Outro style when using --minutes",
+    )
     args = ap.parse_args()
 
     spec = SongSpec.from_json(args.spec)
@@ -114,6 +121,9 @@ if __name__ == "__main__":
         style = cfg.get("style", {})
     if "swing" in style:
         spec.swing = float(style["swing"])
+    if args.minutes:
+        spec.outro = args.outro
+        extend_sections_to_minutes(spec, args.minutes)
     spec.validate()
 
     stems = build_stems_for_song(spec, seed=args.seed, style=style)

--- a/tests/test_minutes_and_outro.py
+++ b/tests/test_minutes_and_outro.py
@@ -1,0 +1,56 @@
+import math
+import pytest
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.song_spec import SongSpec, extend_sections_to_minutes
+from core.arranger import arrange_song
+from core.stems import Stem, bars_to_beats, beats_to_secs
+
+
+def _base_spec():
+    spec = SongSpec.from_dict({
+        "title": "Loop", "tempo": 120, "meter": "4/4",
+        "sections": [{"name": "A", "length": 1}],
+        "harmony_grid": [{"section": "A", "chords": ["C"]}],
+    })
+    spec.validate()
+    return spec
+
+
+def test_loop_to_minutes():
+    spec = _base_spec()
+    spec.outro = "hit"
+    extend_sections_to_minutes(spec, 1.0)
+    bars_needed = math.ceil(1.0 * spec.tempo / 4)
+    assert spec.total_bars() >= bars_needed
+    assert spec.sections[-1].name == "outro"
+    assert len(spec.sections) > 2
+
+
+def test_outro_hit():
+    spec = _base_spec()
+    spec.outro = "hit"
+    extend_sections_to_minutes(spec, 0.01)
+    stems = {"bass": [Stem(start=0.0, dur=1.0, pitch=40, vel=100, chan=0)]}
+    arr = arrange_song(spec, stems, style={}, seed=0)
+    beats = bars_to_beats(spec.meter)
+    sec_per_bar = beats * beats_to_secs(spec.tempo)
+    start_outro = (spec.total_bars() - spec.sections[-1].length) * sec_per_bar
+    times = [n.start for n in arr["bass"] if n.start >= start_outro]
+    assert len(times) == 1
+    assert times[0] == pytest.approx(start_outro, abs=0.01)
+
+
+def test_outro_ritard():
+    spec = _base_spec()
+    spec.outro = "ritard"
+    extend_sections_to_minutes(spec, 0.01)
+    stems = {"bass": [Stem(start=0.0, dur=1.0, pitch=40, vel=100, chan=0)]}
+    arr = arrange_song(spec, stems, style={}, seed=0)
+    beats = bars_to_beats(spec.meter)
+    sec_per_bar = beats * beats_to_secs(spec.tempo)
+    start_outro = (spec.total_bars() - spec.sections[-1].length) * sec_per_bar
+    times = [n.start for n in arr["bass"] if n.start >= start_outro]
+    assert len(times) == 3
+    assert times[1] - times[0] < times[2] - times[1]


### PR DESCRIPTION
## Summary
- allow specifying target duration with `--minutes` in render CLI
- loop song sections to fill requested minutes and add ritard or hit outros
- test minute-based looping and both outro styles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0f2f23ae483258970ff803490a9ec