### PR TITLE
Add tests for dynamics, cadence fills, runtime accuracy, and determinism

### DIFF
--- a/tests/test_arranger_cadence_fill.py
+++ b/tests/test_arranger_cadence_fill.py
@@ -1,0 +1,28 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.song_spec import SongSpec, Section
+from core.arranger import arrange_song
+from core.stems import Stem, bars_to_beats, beats_to_secs, _steps_per_beat
+
+
+def test_drum_fill_added_at_cadence():
+    spec = SongSpec(
+        tempo=120,
+        meter="4/4",
+        sections=[Section("A", 2)],
+        cadences=[{"bar": 1, "type": "sec"}],
+    )
+    stems = {"drums": []}
+    out = arrange_song(spec, stems, style={}, seed=0)
+
+    beats = bars_to_beats(spec.meter)
+    sec_per_beat = beats_to_secs(spec.tempo)
+    sec_per_bar = beats * sec_per_beat
+    spb = _steps_per_beat(spec.meter)
+    sec_per_step = sec_per_beat / spb
+    fill_start = 2 * sec_per_bar - sec_per_step
+
+    drum_notes = out.get("drums", [])
+    tol = 0.02
+    assert any(abs(n.start - fill_start) < tol and n.pitch == 38 for n in drum_notes)

--- a/tests/test_dynamics_rms.py
+++ b/tests/test_dynamics_rms.py
@@ -1,0 +1,30 @@
+import math
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.song_spec import SongSpec, Section
+from core.stems import Stem, bars_to_beats, beats_to_secs
+from core import dynamics
+
+
+def test_chorus_louder_than_verse():
+    spec = SongSpec(
+        tempo=120,
+        meter="4/4",
+        sections=[Section("verse", 1), Section("chorus", 1)],
+    )
+    sec_per_bar = bars_to_beats(spec.meter) * beats_to_secs(spec.tempo)
+    stems = {
+        "keys": [
+            Stem(start=0.0, dur=0.5, pitch=60, vel=80, chan=0),
+            Stem(start=sec_per_bar, dur=0.5, pitch=60, vel=80, chan=0),
+        ]
+    }
+    processed = dynamics.apply(spec, stems, seed=0)
+    verse_vels = [n.vel for n in processed["keys"] if n.start < sec_per_bar]
+    chorus_vels = [n.vel for n in processed["keys"] if n.start >= sec_per_bar]
+
+    def rms(vals):
+        return math.sqrt(sum(v * v for v in vals) / len(vals))
+
+    assert rms(chorus_vels) > rms(verse_vels)

--- a/tests/test_minutes_and_outro.py
+++ b/tests/test_minutes_and_outro.py
@@ -54,3 +54,15 @@ def test_outro_ritard():
     times = [n.start for n in arr["bass"] if n.start >= start_outro]
     assert len(times) == 3
     assert times[1] - times[0] < times[2] - times[1]
+
+
+def test_runtime_within_tolerance():
+    spec = _base_spec()
+    spec.outro = "hit"
+    minutes = 1.5
+    extend_sections_to_minutes(spec, minutes)
+    beats = bars_to_beats(spec.meter)
+    sec_per_bar = beats * beats_to_secs(spec.tempo)
+    total_time = spec.total_bars() * sec_per_bar
+    target = minutes * 60.0
+    assert abs(total_time - target) <= target * 0.02

--- a/tests/test_pipeline_determinism.py
+++ b/tests/test_pipeline_determinism.py
@@ -1,0 +1,44 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.song_spec import SongSpec
+from core.stems import build_stems_for_song
+from core.arranger import arrange_song
+from core import dynamics
+
+
+def test_pipeline_deterministic_output():
+    spec = SongSpec.from_dict({
+        "title": "Determinism",
+        "seed": 42,
+        "key": "C",
+        "mode": "ionian",
+        "tempo": 120,
+        "meter": "4/4",
+        "sections": [
+            {"name": "A", "length": 2},
+            {"name": "B", "length": 2},
+        ],
+        "harmony_grid": [
+            {"section": "A", "chords": ["C", "F"]},
+            {"section": "B", "chords": ["G", "C"]},
+        ],
+        "density_curve": {"A": 1.0, "B": 1.0},
+        "register_policy": {
+            "drums": [36, 50],
+            "bass": [40, 60],
+            "keys": [60, 72],
+            "pads": [60, 72],
+        },
+    })
+    spec.validate()
+    seed = spec.seed
+    stems1 = build_stems_for_song(spec, seed=seed)
+    arr1 = arrange_song(spec, stems1, style={}, seed=seed)
+    proc1 = dynamics.apply(spec, arr1, seed)
+
+    stems2 = build_stems_for_song(spec, seed=seed)
+    arr2 = arrange_song(spec, stems2, style={}, seed=seed)
+    proc2 = dynamics.apply(spec, arr2, seed)
+
+    assert proc1 == proc2


### PR DESCRIPTION
## Summary
- add RMS-based test asserting chorus sections are louder than verses
- verify drum fills are inserted at cadence bars
- ensure runtime aligns with `--minutes` within ±2%
- check full generation pipeline is deterministic for fixed seeds

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0f902d27c8325b221f697b61b2aaa