### PR TITLE
Add preset/style config options and preview/dry-run rendering

### DIFF
--- a/assets/presets/default.json
+++ b/assets/presets/default.json
@@ -1,0 +1,53 @@
+{
+  "piano_sfz": "assets/sfz/Piano/SplendidGrandPiano/Splendid Grand Piano.sfz",
+  "sample_paths": {
+    "drums": "assets/sfz/Drums",
+    "bass": "assets/sfz/Bass/LatelyBass/LatelyBass.sfz",
+    "keys": "assets/sfz/Piano/SplendidGrandPiano/Splendid Grand Piano.sfz",
+    "pads": "assets/sfz/Pads/SynthPadChoir/SynthPadChoir.sfz"
+  },
+  "tracks": {
+    "drums": {
+      "gain": -3.0,
+      "pan": 0.0,
+      "reverb_send": 0.1,
+      "eq": {"freq": 1000.0, "gain": 0.0, "q": 1.0}
+    },
+    "bass": {
+      "gain": -6.0,
+      "pan": -0.1,
+      "reverb_send": 0.05,
+      "eq": {"freq": 1000.0, "gain": 0.0, "q": 1.0}
+    },
+    "keys": {
+      "gain": -3.0,
+      "pan": 0.1,
+      "reverb_send": 0.25,
+      "eq": {"freq": 1000.0, "gain": 0.0, "q": 1.0}
+    },
+    "pads": {
+      "gain": -6.0,
+      "pan": 0.0,
+      "reverb_send": 0.4,
+      "eq": {"freq": 1000.0, "gain": 0.0, "q": 1.0}
+    }
+  },
+  "reverb": {
+    "decay": 0.6,
+    "wet": 0.3
+  },
+  "master": {
+    "compressor": {
+      "enabled": true,
+      "threshold": -6.0,
+      "ratio": 2.0,
+      "attack": 0.01,
+      "release": 0.1
+    },
+    "limiter": {
+      "enabled": true,
+      "threshold": -0.1,
+      "release": 0.2
+    }
+  }
+}

--- a/core/preset.py
+++ b/core/preset.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+"""Helpers for loading mix preset data."""
+
+from pathlib import Path
+from typing import Any, Mapping
+import json
+
+
+def load_preset(name_or_path: str | Path) -> Mapping[str, Any]:
+    """Return preset dictionary loaded from ``name_or_path``.
+
+    ``name_or_path`` may be the name of a preset JSON located in
+    ``assets/presets`` (without extension) or a direct path to a JSON file.
+    """
+    p = Path(name_or_path)
+    if not p.suffix:
+        p = Path("assets/presets") / f"{p.name}.json"
+    if not p.exists():
+        raise FileNotFoundError(f"Unknown preset specification: {name_or_path}")
+    with p.open("r", encoding="utf-8") as fh:
+        return json.load(fh)


### PR DESCRIPTION
## Summary
- support `--preset` and `--style` to load templates from assets
- allow extra `--mix-config` and `--arrange-config` JSON overrides with CLI taking precedence
- add `--dry-run` (MIDI only) and `--preview` bar-limited render options and print effective config when bundling or verbose

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1c4a460d4832581fec7025119ee10