### PR TITLE
Add song template loader and CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ python main_render.py --spec path/to/spec.json --keys-sfz /path/to/custom/keys.s
 
 This command renders the keys using the specified SFZ instrument and writes the mix to `out/piano.wav`.
 
+Alternatively, choose a built‑in song template instead of providing a spec:
+
+```bash
+python main_render.py --song-preset pop_verse_chorus --mix out/piano.wav
+```
+
+Available song templates: `pop_verse_chorus`, `lofi_loop`.
+
 ## Basic UI
 
 For quick experiments the project includes a small Tkinter based user interface

--- a/assets/presets/lofi_loop.json
+++ b/assets/presets/lofi_loop.json
@@ -1,0 +1,19 @@
+{
+  "title": "Lofi Loop",
+  "tempo": 80,
+  "meter": "4/4",
+  "sections": [
+    {"name": "loop", "length": 4}
+  ],
+  "harmony_grid": [
+    {"section": "loop", "chords": ["Dm", "G", "C", "C"]}
+  ],
+  "density_curve": {
+    "loop": 0.25
+  },
+  "register_policy": {
+    "bass": [28, 48],
+    "keys": [48, 72],
+    "pads": [60, 84]
+  }
+}

--- a/assets/presets/pop_verse_chorus.json
+++ b/assets/presets/pop_verse_chorus.json
@@ -1,0 +1,22 @@
+{
+  "title": "Pop Verse Chorus",
+  "tempo": 110,
+  "meter": "4/4",
+  "sections": [
+    {"name": "verse", "length": 8},
+    {"name": "chorus", "length": 8}
+  ],
+  "harmony_grid": [
+    {"section": "verse", "chords": ["C", "G", "Am", "F", "C", "G", "Am", "F"]},
+    {"section": "chorus", "chords": ["F", "G", "Em", "Am", "F", "G", "C", "C"]}
+  ],
+  "density_curve": {
+    "verse": 0.3,
+    "chorus": 0.6
+  },
+  "register_policy": {
+    "bass": [28, 48],
+    "keys": [48, 72],
+    "pads": [60, 84]
+  }
+}

--- a/core/song_templates.py
+++ b/core/song_templates.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+"""Helpers for loading song template data."""
+
+from pathlib import Path
+from typing import Any, Mapping
+import json
+
+
+def load_song_template(name_or_path: str | Path) -> Mapping[str, Any]:
+    """Return SongSpec dictionary loaded from ``name_or_path``.
+
+    ``name_or_path`` may be the name of a template JSON located in
+    ``assets/presets`` (without extension) or a direct path to a JSON file.
+    """
+    p = Path(name_or_path)
+    if not p.suffix:
+        p = Path("assets/presets") / f"{p.name}.json"
+    if not p.exists():
+        raise FileNotFoundError(f"Unknown song template: {name_or_path}")
+    with p.open("r", encoding="utf-8") as fh:
+        return json.load(fh)

--- a/main_render.py
+++ b/main_render.py
@@ -189,7 +189,11 @@ def _log_stage(logs: list, progress: tqdm, name: str, start: float, **extra) -> 
 
 if __name__ == "__main__":
     ap = argparse.ArgumentParser()
-    ap.add_argument("--spec", required=True, help="Song specification JSON")
+    ap.add_argument("--spec", help="Song specification JSON")
+    ap.add_argument(
+        "--song-preset",
+        help="Song template name or JSON file in assets/presets",
+    )
     ap.add_argument("--seed", type=int, default=42, help="Random seed")
     ap.add_argument(
         "--mix",
@@ -271,10 +275,18 @@ if __name__ == "__main__":
     )
     args = ap.parse_args()
 
+    if not args.spec and not args.song_preset:
+        ap.error("either --spec or --song-preset is required")
+
     logs: list = [{"seed": args.seed}]
 
     t0 = time.monotonic()
-    spec = SongSpec.from_json(args.spec)
+    if args.song_preset:
+        from core.song_templates import load_song_template
+
+        spec = SongSpec.from_dict(load_song_template(args.song_preset))
+    else:
+        spec = SongSpec.from_json(args.spec)
 
     def _load_json(path: Path) -> dict:
         with path.open("r", encoding="utf-8") as fh:


### PR DESCRIPTION
## Summary
- add pop and lofi song template JSONs
- implement loader for song templates
- support `--song-preset` in `main_render.py`
- document built-in templates and new flag

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1c8683060832582f31ee430c919cc