### PR TITLE
Add arrangement report JSON output and tests

### DIFF
--- a/tests/test_bundle_cli.py
+++ b/tests/test_bundle_cli.py
@@ -53,6 +53,12 @@ def test_bundle_creation(tmp_path):
     assert (bundle_dir / "stems.mid").exists()
     assert (bundle_dir / "mix.wav").exists()
     assert (bundle_dir / "arrangement.txt").exists()
+    report_path = bundle_dir / "arrange_report.json"
+    assert report_path.exists()
+    with report_path.open() as fh:
+        report = json.load(fh)
+    assert isinstance(report.get("sections"), list)
+    assert isinstance(report.get("fills"), list)
     assert (bundle_dir / "config.json").exists()
     assert (bundle_dir / "README.txt").exists()
     if (bundle_dir / "stems").exists():


### PR DESCRIPTION
## Summary
- Extend arrangement summary function to emit structured data
- Write `arrange_report.json` alongside `arrangement.txt` in bundle mode
- Test that bundle creation includes arrangement report file

## Testing
- `pytest tests/test_bundle_cli.py -q` (skipped: python3.10 not available)


------
https://chatgpt.com/codex/tasks/task_e_68c1ca1427548325851573dc67efca04