### PR TITLE
Handle default bundle path and rename config file

### DIFF
--- a/main_render.py
+++ b/main_render.py
@@ -10,6 +10,7 @@ import shlex
 import time
 import random
 from pathlib import Path
+from datetime import datetime
 
 import numpy as np
 
@@ -223,6 +224,8 @@ if __name__ == "__main__":
     )
     ap.add_argument(
         "--bundle",
+        nargs="?",
+        const=True,
         help="Directory to bundle render outputs",
     )
     ap.add_argument(
@@ -290,6 +293,10 @@ if __name__ == "__main__":
         help="Render only the first N bars",
     )
     args = ap.parse_args()
+
+    if args.bundle is True:
+        default_dir = Path("export") / f"Render_{datetime.now().strftime('%Y%m%d_%H%M')}"
+        args.bundle = str(default_dir)
 
     if not args.spec and not args.song_preset:
         ap.error("either --spec or --song-preset is required")
@@ -468,7 +475,7 @@ if __name__ == "__main__":
             shutil.copy(args.spec, bundle_dir / "song.json")
             stems_to_midi(stems, spec.tempo, spec.meter, bundle_dir / "stems.mid")
 
-            with (bundle_dir / "config.json").open("w", encoding="utf-8") as fh:
+            with (bundle_dir / "render_config.json").open("w", encoding="utf-8") as fh:
                 json.dump(cfg, fh, indent=2)
 
             (bundle_dir / "arrangement.txt").write_text(summary + "\n", encoding="utf-8")
@@ -514,7 +521,7 @@ if __name__ == "__main__":
             bundle_dir.mkdir(parents=True, exist_ok=True)
             shutil.copy(args.spec, bundle_dir / "song.json")
             stems_to_midi(stems, spec.tempo, spec.meter, bundle_dir / "stems.mid")
-            with (bundle_dir / "config.json").open("w", encoding="utf-8") as fh:
+            with (bundle_dir / "render_config.json").open("w", encoding="utf-8") as fh:
                 json.dump(cfg, fh, indent=2)
             cmdline = (
                 "python "


### PR DESCRIPTION
## Summary
- rename bundle's config.json to render_config.json
- add automatic export path when --bundle is used without an argument
- adjust bundle CLI tests for new config name and default path

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest tests/test_bundle_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c1d09b980483259526214d5bba4960