### PR TITLE
Rename song preset flag and add mix preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ instruments along with stereo mix parameters.  Each track exposes gain, pan
 and reverb send values.  A shared reverb bus processes the keys and pads and
 the master mix passes through a peak limiter targeting ``-0.1`` dBFS by
 default.  All paths are relative so the repository works out of the box after
-cloning.
+cloning. Mix presets from `assets/presets` can be selected with `--mix-preset`.
 
 ```bash
 pip install soundfile  # enables FLAC support
@@ -56,7 +56,7 @@ This command renders the keys using the specified SFZ instrument and writes the 
 Alternatively, choose a built‑in song template instead of providing a spec:
 
 ```bash
-python main_render.py --song-preset pop_verse_chorus --mix out/piano.wav
+python main_render.py --preset pop_verse_chorus --mix out/piano.wav
 ```
 
 Available song templates: `pop_verse_chorus`, `lofi_loop`.

--- a/main_render.py
+++ b/main_render.py
@@ -207,7 +207,7 @@ if __name__ == "__main__":
     ap = argparse.ArgumentParser()
     ap.add_argument("--spec", help="Song specification JSON")
     ap.add_argument(
-        "--song-preset",
+        "--preset",
         help="Song template name or JSON file in assets/presets",
     )
     ap.add_argument("--seed", type=int, default=42, help="Random seed")
@@ -226,7 +226,8 @@ if __name__ == "__main__":
         help="Directory to bundle render outputs",
     )
     ap.add_argument(
-        "--preset",
+        "--mix-preset",
+        dest="mix_preset",
         help="Mixing preset name or JSON file in assets/presets",
     )
     ap.add_argument(
@@ -291,16 +292,16 @@ if __name__ == "__main__":
     )
     args = ap.parse_args()
 
-    if not args.spec and not args.song_preset:
-        ap.error("either --spec or --song-preset is required")
+    if not args.spec and not args.preset:
+        ap.error("either --spec or --preset is required")
 
     logs: list = [{"seed": args.seed}]
 
     t0 = time.monotonic()
-    if args.song_preset:
+    if args.preset:
         from core.song_templates import load_song_template
 
-        spec = SongSpec.from_dict(load_song_template(args.song_preset))
+        spec = SongSpec.from_dict(load_song_template(args.preset))
     else:
         spec = SongSpec.from_json(args.spec)
 
@@ -319,10 +320,10 @@ if __name__ == "__main__":
         cfg: dict = {}
         style: dict = {}
 
-        if args.preset:
+        if args.mix_preset:
             from core.preset import load_preset
 
-            cfg = dict(load_preset(args.preset))
+            cfg = dict(load_preset(args.mix_preset))
         else:
             cfg_path = Path("render_config.json")
             if cfg_path.exists():


### PR DESCRIPTION
## Summary
- rename `--song-preset` CLI flag to `--preset`
- add `--mix-preset` flag and update config loading
- document new flags in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1d08cc1e88325aca1a9bf4c3a5166