### PR TITLE
feat: add mix preset flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,14 @@ This command renders the keys using the specified SFZ instrument and writes the 
 Alternatively, choose a built‑in song template instead of providing a spec:
 
 ```bash
-python main_render.py --song-preset pop_verse_chorus --mix out/piano.wav
+python main_render.py --preset pop_verse_chorus --mix out/piano.wav
+```
+
+Mix settings can also be loaded from a preset file in `assets/presets` using
+`--mix-preset`:
+
+```bash
+python main_render.py --spec path/to/spec.json --mix-preset default
 ```
 
 Available song templates: `pop_verse_chorus`, `lofi_loop`.

--- a/main_render.py
+++ b/main_render.py
@@ -208,7 +208,7 @@ if __name__ == "__main__":
     ap = argparse.ArgumentParser()
     ap.add_argument("--spec", help="Song specification JSON")
     ap.add_argument(
-        "--song-preset",
+        "--preset",
         help="Song template name or JSON file in assets/presets",
     )
     ap.add_argument("--seed", type=int, default=42, help="Random seed")
@@ -229,7 +229,8 @@ if __name__ == "__main__":
         help="Directory to bundle render outputs",
     )
     ap.add_argument(
-        "--preset",
+        "--mix-preset",
+        dest="mix_preset",
         help="Mixing preset name or JSON file in assets/presets",
     )
     ap.add_argument(
@@ -303,16 +304,16 @@ if __name__ == "__main__":
         default_dir = Path("export") / f"Render_{datetime.now().strftime('%Y%m%d_%H%M')}"
         args.bundle = str(default_dir)
 
-    if not args.spec and not args.song_preset:
-        ap.error("either --spec or --song-preset is required")
+    if not args.spec and not args.preset:
+        ap.error("either --spec or --preset is required")
 
     logs: list = [{"seed": args.seed}]
 
     t0 = time.monotonic()
-    if args.song_preset:
+    if args.preset:
         from core.song_templates import load_song_template
 
-        spec = SongSpec.from_dict(load_song_template(args.song_preset))
+        spec = SongSpec.from_dict(load_song_template(args.preset))
     else:
         spec = SongSpec.from_json(args.spec)
 
@@ -331,10 +332,10 @@ if __name__ == "__main__":
         cfg: dict = {}
         style: dict = {}
 
-        if args.preset:
+        if args.mix_preset:
             from core.preset import load_preset
 
-            cfg = dict(load_preset(args.preset))
+            cfg = dict(load_preset(args.mix_preset))
         else:
             cfg_path = Path("render_config.json")
             if cfg_path.exists():


### PR DESCRIPTION
## Summary
- rename `--song-preset` to `--preset`
- add `--mix-preset` CLI flag and load mix presets from assets
- document new flag usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c1d2ccabcc8325ad55104cbba1b6a6