### PR TITLE
Add FastAPI web interface for rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,19 @@ The window exposes a handful of text fields:
    installs dependencies) and click the icon to open the renderer UI.
 3. Browse to the spec JSON and adjust any desired parameters.
 4. Click **Render** to create the mix and stems in the specified locations.
+
+## Web UI
+
+A minimal FastAPI web interface lives in `webui/app.py`.  It exposes a simple
+form to choose a preset, optional style, seed and target duration.  Submitted
+jobs invoke `main_render.py` under the hood and return a zip bundle containing
+the mix and stems for download.
+
+Launch the server with:
+
+```bash
+uvicorn webui.app:app
+```
+
+Visit `http://localhost:8000/` in your browser to render audio directly from
+the browser.  A health‑check endpoint is available at `/health`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ numpy
 soundfile
 scipy
 pytest
+fastapi
+uvicorn

--- a/tests/test_webui_health.py
+++ b/tests/test_webui_health.py
@@ -1,0 +1,8 @@
+from fastapi.testclient import TestClient
+from webui.app import app
+
+def test_health_check():
+    client = TestClient(app)
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}

--- a/webui/app.py
+++ b/webui/app.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import shutil
+from pathlib import Path
+
+from fastapi import FastAPI, Form
+from fastapi.responses import HTMLResponse, Response
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MAIN_RENDER = REPO_ROOT / "main_render.py"
+ASSETS_DIR = REPO_ROOT / "assets"
+
+app = FastAPI()
+
+
+def _options(kind: str) -> list[str]:
+    base = ASSETS_DIR / kind
+    return [p.stem for p in base.glob("*.json")]
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    """Simple health check endpoint."""
+    return {"status": "ok"}
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index() -> HTMLResponse:
+    """Render a small HTML form to trigger rendering."""
+    presets = "".join(f'<option value="{p}">{p}</option>' for p in _options("presets"))
+    styles = "".join(f'<option value="{s}">{s}</option>' for s in _options("styles"))
+    html = f"""
+    <html><body>
+    <form action="/render" method="post">
+        <label>Preset <select name="preset">{presets}</select></label><br>
+        <label>Style <select name="style"><option value="">(default)</option>{styles}</select></label><br>
+        <label>Seed <input type="number" name="seed" value="42"/></label><br>
+        <label>Minutes <input type="number" step="0.1" name="minutes"/></label><br>
+        <button type="submit">Render</button>
+    </form>
+    </body></html>
+    """
+    return HTMLResponse(html)
+
+
+@app.post("/render")
+async def render(
+    preset: str = Form(...),
+    style: str = Form(""),
+    seed: int = Form(42),
+    minutes: float | None = Form(None),
+) -> Response:
+    """Run the main renderer and return a zip bundle."""
+    tmpdir = Path(tempfile.mkdtemp())
+    try:
+        cmd = [
+            sys.executable,
+            str(MAIN_RENDER),
+            "--preset",
+            preset,
+            "--seed",
+            str(seed),
+            "--bundle",
+            str(tmpdir),
+        ]
+        if style:
+            cmd += ["--style", style]
+        if minutes is not None:
+            cmd += ["--minutes", str(minutes)]
+        subprocess.run(cmd, check=True)
+        archive = shutil.make_archive(tmpdir / "bundle", "zip", tmpdir)
+        data = Path(archive).read_bytes()
+        headers = {"Content-Disposition": "attachment; filename=bundle.zip"}
+        return Response(content=data, media_type="application/zip", headers=headers)
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)


### PR DESCRIPTION
## Summary
- provide a simple FastAPI app with form and health endpoint
- document how to run the new web UI
- add basic health-check test and dependencies

## Testing
- `pip install fastapi uvicorn` *(fails: Could not connect to proxy)*
- `pytest tests/test_webui_health.py -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68c1d762f86483259ba28a936984c4e0