### PR TITLE
Handle preset bundling without spec file

### DIFF
--- a/main_render.py
+++ b/main_render.py
@@ -490,7 +490,11 @@ if __name__ == "__main__":
                     _write_wav(stem_path, audio, 44100, comment=rhash)
                     _maybe_export_mp3(stem_path)
 
-            shutil.copy(args.spec, bundle_dir / "song.json")
+            if args.spec:
+                shutil.copy(args.spec, bundle_dir / "song.json")
+            else:
+                with (bundle_dir / "song.json").open("w", encoding="utf-8") as fh:
+                    json.dump(spec.to_dict(), fh, indent=2)
             stems_to_midi(stems, spec.tempo, spec.meter, bundle_dir / "stems.mid")
 
             with (bundle_dir / "render_config.json").open("w", encoding="utf-8") as fh:
@@ -537,7 +541,11 @@ if __name__ == "__main__":
         if args.bundle:
             bundle_dir = Path(args.bundle)
             bundle_dir.mkdir(parents=True, exist_ok=True)
-            shutil.copy(args.spec, bundle_dir / "song.json")
+            if args.spec:
+                shutil.copy(args.spec, bundle_dir / "song.json")
+            else:
+                with (bundle_dir / "song.json").open("w", encoding="utf-8") as fh:
+                    json.dump(spec.to_dict(), fh, indent=2)
             stems_to_midi(stems, spec.tempo, spec.meter, bundle_dir / "stems.mid")
             with (bundle_dir / "render_config.json").open("w", encoding="utf-8") as fh:
                 json.dump(cfg, fh, indent=2)

--- a/tests/test_bundle_cli.py
+++ b/tests/test_bundle_cli.py
@@ -162,3 +162,31 @@ def test_bundle_default_path(tmp_path):
     assert (bundle_dir / "mix.wav").exists()
 
     shutil.rmtree(export_root)
+
+
+def test_bundle_with_preset(tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+
+    py310 = Path(sys.executable).resolve().parent.parent / "3.10.17/bin/python"
+    if not py310.exists():
+        pytest.skip("python3.10 not available")
+
+    bundle_dir = tmp_path / "bundle"
+    cmd = [
+        str(py310),
+        "main_render.py",
+        "--preset",
+        "lofi_loop",
+        "--bundle",
+        str(bundle_dir),
+        "--arrange",
+        "off",
+    ]
+    subprocess.run(cmd, cwd=repo_root, check=True)
+
+    song_json = bundle_dir / "song.json"
+    assert song_json.exists()
+    with song_json.open() as fh:
+        data = json.load(fh)
+    assert data.get("title") == "Lofi Loop"
+    assert (bundle_dir / "mix.wav").exists()


### PR DESCRIPTION
## Summary
- serialize preset-derived song specs into `song.json` when bundling
- test CLI bundling via `--preset` to ensure song spec is captured

## Testing
- `pytest tests/test_bundle_cli.py::test_bundle_with_preset -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68c1e27184008325afe71f0680939775