### PR TITLE
docs: clarify optional mido dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ SFZ instruments may reference WAV or FLAC samples. Loading FLAC samples requires
 pip install soundfile
 ```
 
+For enhanced MIDI import and export support, install the optional
+[mido](https://mido.readthedocs.io/) library:
+
+```bash
+pip install mido
+```
+
 ## Generate N minutes of music
 
 1. Create a song specification JSON (see `core/song_spec.py` for fields).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,9 @@ name = "blossom-music-gen"
 version = "0.0.0"
 requires-python = ">=3.10,<3.11"
 
+[project.optional-dependencies]
+midi = ["mido"]
+
 [build-system]
 requires = ["setuptools>=61"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
- document optional `mido` dependency in README for enhanced MIDI import/export
- expose `midi` extras group with `mido` in `pyproject.toml`

## Testing
- `pytest` *(fails: starlette.testclient requires the httpx package to be installed)*
- `pip install httpx` *(fails: Could not find a version that satisfies the requirement httpx; Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e71196e88325b64ce86c21cc8b3f