### PR TITLE
Remove scipy from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 numpy
 soundfile
-scipy
 pytest
 fastapi
 uvicorn


### PR DESCRIPTION
## Summary
- remove scipy from requirements

## Testing
- `python -m pip install -r requirements.txt`
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68c1e71368548325b1708bca5c9d45aa