### PR TITLE
Add Tauri frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+src-tauri/target
+src-tauri/Cargo.lock

--- a/README.md
+++ b/README.md
@@ -144,3 +144,23 @@ uvicorn webui.app:app
 
 Visit `http://localhost:8000/` in your browser to render audio directly from
 the browser.  A health‑check endpoint is available at `/health`.
+
+## Tauri UI
+
+An experimental desktop interface is provided via [Tauri](https://tauri.app/). It lives in the `src-tauri` folder and renders a small window with a centered music note icon and heading.
+
+### Building
+
+1. Install the development dependencies:
+
+```bash
+npm install
+```
+
+2. Start the UI in development mode:
+
+```bash
+npm run tauri dev
+```
+
+Click **Render** to invoke the bundled command that runs `start.py` and triggers rendering through Python.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "blossom-music-gen",
+  "private": true,
+  "scripts": {
+    "tauri": "tauri"
+  },
+  "devDependencies": {
+    "@tauri-apps/cli": "^1"
+  }
+}

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "blossom_tauri"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tauri = { version = "1" }
+
+[build-dependencies]
+tauri-build = { version = "1" }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,0 +1,24 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+use std::process::Command;
+
+#[tauri::command]
+fn run_python_script(script: &str) -> Result<String, String> {
+    let output = Command::new("python")
+        .arg(script)
+        .output()
+        .map_err(|e| e.to_string())?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    } else {
+        Err(String::from_utf8_lossy(&output.stderr).to_string())
+    }
+}
+
+fn main() {
+    tauri::Builder::default()
+        .invoke_handler(tauri::generate_handler![run_python_script])
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../node_modules/@tauri-apps/cli/schema.json",
+  "package": {
+    "productName": "Blossom Music Generator",
+    "version": "0.1.0"
+  },
+  "tauri": {
+    "build": {
+      "distDir": "../tauri-ui",
+      "devPath": "../tauri-ui"
+    },
+    "windows": [
+      {
+        "title": "Music Generator",
+        "width": 800,
+        "height": 600
+      }
+    ]
+  }
+}

--- a/tauri-ui/index.html
+++ b/tauri-ui/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Music Generator</title>
+    <style>
+      body {
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        height: 100vh;
+        font-family: sans-serif;
+      }
+      svg {
+        width: 80px;
+        height: 80px;
+      }
+      h1 {
+        margin-top: 1rem;
+      }
+      button {
+        margin-top: 1rem;
+        padding: 0.5rem 1rem;
+      }
+    </style>
+  </head>
+  <body>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor">
+      <path d="M9 13.5V3h4V1H8v10.5a3.5 3.5 0 1 0 1 0z"/>
+    </svg>
+    <h1>Music Generator</h1>
+    <button id="render">Render</button>
+    <script>
+      document.getElementById('render').addEventListener('click', async () => {
+        try {
+          await window.__TAURI__.invoke('run_python_script', { script: 'start.py' });
+        } catch (e) {
+          console.error(e);
+        }
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- scaffold a basic Tauri desktop wrapper with Rust command to call Python scripts
- add simple HTML front-end with centered music icon and heading
- document how to run the Tauri UI

## Testing
- `pytest tests/test_webui_health.py -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pip install httpx` *(fails: Could not find a version that satisfies the requirement httpx)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tauri-apps%2fcli)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e8430efc832581528d4de82a7c1f