### PR TITLE
Add dataset builder script and deterministic split test

### DIFF
--- a/data/__init__.py
+++ b/data/__init__.py
@@ -1,0 +1,1 @@
+"""Dataset utilities package."""

--- a/data/build_dataset.py
+++ b/data/build_dataset.py
@@ -1,0 +1,124 @@
+"""Utilities for building tokenized training datasets.
+
+This script collects note stems and optional MIDI files, tokenizes them
+using :mod:`core.event_vocab`, performs a deterministic train/validation
+split, and writes the sequences out as JSONL files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from pathlib import Path
+from typing import Iterable, List, Sequence, Tuple, Dict, Any
+
+from core import event_vocab, midi_load
+from core.stems import Stem, beats_to_secs
+
+
+def _load_stem_json(path: Path) -> Tuple[List[Stem], Dict[str, Any]]:
+    """Load note stems and metadata from ``path``.
+
+    The JSON file is expected to contain a ``"notes"`` list describing the
+    events and an optional ``"meta"`` mapping with conditioning fields.
+    """
+
+    data = json.loads(path.read_text())
+    notes = [Stem(**n) for n in data.get("notes", [])]
+    meta = data.get("meta", {})
+    return notes, meta
+
+
+def _load_midi(path: Path) -> Tuple[List[Stem], Dict[str, Any]]:
+    """Load a MIDI file and return notes in beats along with metadata."""
+
+    notes_sec, tempo, meter = midi_load.load_melody_midi(path)
+    sec_per_beat = beats_to_secs(tempo)
+    notes = [
+        Stem(start=n.start / sec_per_beat, dur=n.dur / sec_per_beat, pitch=n.pitch, vel=n.vel, chan=n.chan)
+        for n in notes_sec
+    ]
+    meta = {
+        "section": "A",
+        "meter": meter,
+        "density": 0.5,
+        "chord": "C",
+        "seed": 0,
+    }
+    return notes, meta
+
+
+def _tokenize(notes: Sequence[Stem], meta: Dict[str, Any]) -> List[Tuple[int, int]]:
+    """Encode ``notes`` into token/value pairs using ``meta`` fields."""
+
+    return event_vocab.encode(
+        notes,
+        section=str(meta.get("section", "A")),
+        meter=str(meta.get("meter", "4/4")),
+        density=float(meta.get("density", 0.5)),
+        chord=str(meta.get("chord", "C")),
+        seed=int(meta.get("seed", 0)),
+        cadence=bool(meta.get("cadence", False)),
+    )
+
+
+def gather_songs(stems_dir: Path, midi_dir: Path | None) -> List[Dict[str, Any]]:
+    """Collect and tokenize songs from ``stems_dir`` and ``midi_dir``."""
+
+    songs: List[Dict[str, Any]] = []
+
+    for path in sorted(stems_dir.glob("*.json")):
+        notes, meta = _load_stem_json(path)
+        tokens = _tokenize(notes, meta)
+        songs.append({"tokens": tokens, "source": str(path)})
+
+    if midi_dir and midi_dir.exists():
+        for path in sorted(midi_dir.glob("*.mid")):
+            notes, meta = _load_midi(path)
+            tokens = _tokenize(notes, meta)
+            songs.append({"tokens": tokens, "source": str(path)})
+
+    return songs
+
+
+def split_train_val(items: Sequence[Any], val_ratio: float, seed: int) -> Tuple[List[Any], List[Any]]:
+    """Split ``items`` into train/validation subsets.
+
+    The split is deterministic for a given ``seed``.
+    """
+
+    rng = random.Random(seed)
+    indices = list(range(len(items)))
+    rng.shuffle(indices)
+    val_count = int(round(len(items) * val_ratio))
+    val_set = set(indices[:val_count])
+    train = [items[i] for i in range(len(items)) if i not in val_set]
+    val = [items[i] for i in range(len(items)) if i in val_set]
+    return train, val
+
+
+def _save_jsonl(path: Path, records: Iterable[Dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        for rec in records:
+            fh.write(json.dumps(rec) + "\n")
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--stems-dir", type=Path, default=Path("out"), help="Directory containing stem JSON files")
+    parser.add_argument("--midi-dir", type=Path, default=None, help="Optional directory of MIDI files")
+    parser.add_argument("--val-ratio", type=float, default=0.1, help="Validation split ratio")
+    parser.add_argument("--seed", type=int, default=0, help="Random seed for splits")
+    parser.add_argument("--out-dir", type=Path, default=Path("data"), help="Output directory for JSONL files")
+    args = parser.parse_args(argv)
+
+    songs = gather_songs(args.stems_dir, args.midi_dir)
+    train, val = split_train_val(songs, args.val_ratio, args.seed)
+    _save_jsonl(args.out_dir / "train.jsonl", train)
+    _save_jsonl(args.out_dir / "val.jsonl", val)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -1,0 +1,29 @@
+# Dataset preparation
+
+`data/build_dataset.py` converts note stems or MIDI files into token
+sequences consumable by the model.  It writes two JSONL files containing
+lists of token/value pairs.
+
+## Usage
+
+```bash
+python data/build_dataset.py --stems-dir out/stems \
+    --midi-dir curated_midis \
+    --val-ratio 0.1 \
+    --seed 42 \
+    --out-dir data
+```
+
+### Parameters
+
+* `--stems-dir`: Directory containing `.json` stem descriptions.  Defaults to
+  `out`.
+* `--midi-dir`: Optional directory of `.mid` files that will be converted and
+  appended to the dataset.
+* `--val-ratio`: Fraction of examples reserved for validation.  The default is
+  `0.1` (10%).
+* `--seed`: Random seed used for the deterministic train/validation split.
+* `--out-dir`: Destination directory for `train.jsonl` and `val.jsonl`.
+
+Each record in the output files contains a `tokens` field with the token
+sequence and a `source` field pointing to the originating file.

--- a/tests/test_dataset_split.py
+++ b/tests/test_dataset_split.py
@@ -1,0 +1,12 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from data.build_dataset import split_train_val
+
+
+def test_deterministic_split():
+    items = list(range(10))
+    train1, val1 = split_train_val(items, val_ratio=0.3, seed=123)
+    train2, val2 = split_train_val(items, val_ratio=0.3, seed=123)
+    assert train1 == train2
+    assert val1 == val2


### PR DESCRIPTION
## Summary
- add `data/build_dataset.py` for tokenizing stems or MIDI into JSONL datasets
- document dataset creation in `docs/datasets.md`
- test deterministic train/validation splits

## Testing
- `pytest -q` *(fails: missing httpx)*
- `pytest tests/test_dataset_split.py tests/test_event_vocab.py tests/test_sfz_sampler.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1ea07bb8083258898604546b8609f