### PR TITLE
Add sampler seed for reproducible phrase sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,19 @@ pip install mido
 
 ```bash
 pip install soundfile  # enables FLAC support
-python -m core.main_synth --spec path/to/spec.json --minutes 3 --seed 42 --print-stats > plan.json
+python -m core.main_synth --spec path/to/spec.json --minutes 3 --seed 42 --sampler-seed 0 --print-stats > plan.json
 ```
 
 `main_synth.py` will extend the section list to meet the requested duration and print a JSON plan of events for each instrument.  The example above generates at least three minutes of material and writes it to `plan.json` while printing instrument event counts to the console.
+
+### Reproducibility
+
+Two parameters influence randomness:
+
+* `--seed` controls deterministic pattern and stem generation.
+* `--sampler-seed` seeds Python, NumPy and PyTorch RNGs used for phrase model sampling.
+
+Providing both makes runs fully repeatable (the sampler seed defaults to `0`).
 
 ## Using External Samples
 

--- a/core/main_synth.py
+++ b/core/main_synth.py
@@ -9,6 +9,7 @@ if __name__ == "__main__":
     ap = argparse.ArgumentParser()
     ap.add_argument("--spec", required=True)
     ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--sampler-seed", type=int, default=0)
     ap.add_argument("--minutes", type=float)
     ap.add_argument("--print-stats", action="store_true")
     args = ap.parse_args()
@@ -19,7 +20,9 @@ if __name__ == "__main__":
     if args.minutes:
         extend_sections_to_minutes(spec, args.minutes)
 
-    plan = build_patterns_for_song(spec, seed=args.seed)
+    plan = build_patterns_for_song(
+        spec, seed=args.seed, sampler_seed=args.sampler_seed
+    )
 
     if args.print_stats:
         counts = {}

--- a/core/pattern_synth.py
+++ b/core/pattern_synth.py
@@ -231,7 +231,7 @@ def gen_pads(chords: Sequence[str], meter: str, density: float, rng: random.Rand
 # Orchestration helper
 # ---------------------------------------------------------------------------
 
-def build_patterns_for_song(spec: SongSpec, seed: int) -> Dict:
+def build_patterns_for_song(spec: SongSpec, seed: int, sampler_seed: int | None = None) -> Dict:
     """Generate patterns for all sections/instruments using ``spec``."""
     plan: Dict = {"sections": []}
     meter = spec.meter
@@ -248,7 +248,7 @@ def build_patterns_for_song(spec: SongSpec, seed: int) -> Dict:
                     meter=meter,
                     chords=chords,
                     density=density,
-                    seed=seed,
+                    seed=sampler_seed if sampler_seed is not None else seed,
                     timeout=0.5,
                 )
             except Exception:

--- a/core/phrase_model.py
+++ b/core/phrase_model.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Iterable, List, Optional, Sequence, Tuple
 import threading
 import time
+import random
 
 import numpy as np
 
@@ -149,6 +150,7 @@ def _run_with_timeout(func, timeout: float, *args, **kwargs):
 def generate_phrase(
     inst: str,
     *,
+    seed: int | None = None,
     prompt: Sequence[int] | None = None,
     max_steps: int = 128,
     top_p: float = 0.9,
@@ -170,6 +172,15 @@ def generate_phrase(
     fmt, model = load_model(inst)
     if model is None:
         raise RuntimeError(f"no model available for {inst}")
+
+    if seed is not None:
+        random.seed(seed)
+        np.random.seed(seed)
+        if torch is not None:
+            try:  # pragma: no cover - depends on optional torch
+                torch.manual_seed(seed)
+            except Exception:
+                pass
 
     prompt = list(prompt or [])
 

--- a/main_render.py
+++ b/main_render.py
@@ -213,6 +213,12 @@ if __name__ == "__main__":
     )
     ap.add_argument("--seed", type=int, default=42, help="Random seed")
     ap.add_argument(
+        "--sampler-seed",
+        type=int,
+        default=0,
+        help="Seed for phrase model sampling",
+    )
+    ap.add_argument(
         "--mix",
         default="out/mix.wav",
         help="Output path for the master mix WAV",
@@ -307,7 +313,7 @@ if __name__ == "__main__":
     if not args.spec and not args.preset:
         ap.error("either --spec or --preset is required")
 
-    logs: list = [{"seed": args.seed}]
+    logs: list = [{"seed": args.seed, "sampler_seed": args.sampler_seed}]
 
     t0 = time.monotonic()
     if args.preset:
@@ -382,7 +388,7 @@ if __name__ == "__main__":
     _log_stage(logs, progress, "voicing", t0)
 
     t0 = time.monotonic()
-    build_patterns_for_song(spec, seed=args.seed)
+    build_patterns_for_song(spec, seed=args.seed, sampler_seed=args.sampler_seed)
     _log_stage(logs, progress, "patterns", t0)
 
     t0 = time.monotonic()


### PR DESCRIPTION
## Summary
- add `--sampler-seed` option to render and synth CLIs
- initialize Python, NumPy, and PyTorch RNGs in `phrase_model` from sampler seed
- document reproducibility behavior in README

## Testing
- `pytest --ignore=tests/test_webui_health.py -q`
- `pip install httpx` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c1efcbfd508325b1718e72ac85cd20