### PR TITLE
docs: add phrase model training notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,42 @@ Two parameters influence randomness:
 
 Providing both makes runs fully repeatable (the sampler seed defaults to `0`).
 
+## Neural phrase models
+
+Small recurrent networks can replace the deterministic pattern generators.  The
+optional models live in the `models/` directory and are loaded automatically by
+`main_synth.py` and `main_render.py`.
+
+### Training prerequisites and dataset
+
+Training requires [PyTorch](https://pytorch.org/) and, for ONNX export,
+`onnxruntime`.  Datasets consist of token sequences stored in `train.jsonl` and
+`val.jsonl` which can be created with `data/build_dataset.py` (see
+[`docs/datasets.md`](docs/datasets.md)).  Running
+
+```bash
+python training/phrase_models/train_phrase_models.py
+```
+
+trains toy GRU models and writes checkpoints.
+
+### Export and placement
+
+The training script uses `torch.jit.script` and `torch.onnx.export` to emit
+`<inst>_phrase.ts.pt` and `<inst>_phrase.onnx` files into `models/`.  Place the
+files there so they can be picked up at runtime.
+
+### Sampler seeding
+
+The `--sampler-seed` CLI option seeds Python, NumPy and PyTorch RNGs used during
+phrase sampling.  Providing this flag makes neural generation reproducible.
+
+### Missing models
+
+If a model file is absent or fails to load, the code falls back to the
+deterministic pattern generators.  See
+[`docs/phrase_models.md`](docs/phrase_models.md) for details.
+
 ## Using External Samples
 
 If drum hits are placed under `assets/samples/drums` and simple SFZ instruments

--- a/docs/phrase_models.md
+++ b/docs/phrase_models.md
@@ -1,0 +1,37 @@
+# Phrase models
+
+`core/phrase_model.py` loads optional RNNs to generate phrases for drums, bass
+and keys.  Models reside in the `models/` directory and may be supplied as
+either TorchScript (`.ts.pt`) or ONNX (`.onnx`) files.
+
+## Training prerequisites and dataset
+
+Training depends on [PyTorch](https://pytorch.org/) and, for ONNX export,
+`onnxruntime`.  The models consume token sequences stored in `train.jsonl` and
+`val.jsonl`.  These files can be produced from rendered stems or MIDI data via
+`data/build_dataset.py` (see [datasets.md](datasets.md)).
+
+## Training and export
+
+Run the demonstration script to create tiny GRU models and export them to both
+formats:
+
+```bash
+python training/phrase_models/train_phrase_models.py
+```
+
+Inside the script the `export()` helper uses `torch.jit.script` and
+`torch.onnx.export` (opset 12) to write `<name>.ts.pt` and `<name>.onnx` files in
+the `models/` directory.
+
+## Placement and seeding
+
+Place the exported files (`drum_phrase.ts.pt`, `drum_phrase.onnx`, etc.) in
+`models/` so `main_synth` and `main_render` can locate them.  Sampling can be
+made deterministic by passing `--sampler-seed` to the CLI, which seeds Python,
+NumPy and PyTorch RNGs.
+
+## Missing models
+
+If a model is missing or fails to load the application falls back to the
+built‑in deterministic pattern generators.


### PR DESCRIPTION
## Summary
- document neural phrase model training and export steps
- explain sampler seeding and model placement in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pytest -q $(ls tests | grep -v test_webui_health.py | sed -e 's#^#tests/#' | tr '\n' ' ')`


------
https://chatgpt.com/codex/tasks/task_e_68c1f1a8f9708325b97f20c72e47b3c2