### PR TITLE
Log phrase model load failures and expose verbose flag

### DIFF
--- a/core/main_synth.py
+++ b/core/main_synth.py
@@ -12,6 +12,7 @@ if __name__ == "__main__":
     ap.add_argument("--sampler-seed", type=int, default=0)
     ap.add_argument("--minutes", type=float)
     ap.add_argument("--print-stats", action="store_true")
+    ap.add_argument("--verbose", action="store_true")
     args = ap.parse_args()
 
     spec = SongSpec.from_json(args.spec)
@@ -21,7 +22,7 @@ if __name__ == "__main__":
         extend_sections_to_minutes(spec, args.minutes)
 
     plan = build_patterns_for_song(
-        spec, seed=args.seed, sampler_seed=args.sampler_seed
+        spec, seed=args.seed, sampler_seed=args.sampler_seed, verbose=args.verbose
     )
 
     if args.print_stats:

--- a/core/pattern_synth.py
+++ b/core/pattern_synth.py
@@ -231,7 +231,13 @@ def gen_pads(chords: Sequence[str], meter: str, density: float, rng: random.Rand
 # Orchestration helper
 # ---------------------------------------------------------------------------
 
-def build_patterns_for_song(spec: SongSpec, seed: int, sampler_seed: int | None = None) -> Dict:
+def build_patterns_for_song(
+    spec: SongSpec,
+    seed: int,
+    sampler_seed: int | None = None,
+    *,
+    verbose: bool = False,
+) -> Dict:
     """Generate patterns for all sections/instruments using ``spec``."""
     plan: Dict = {"sections": []}
     meter = spec.meter
@@ -250,6 +256,7 @@ def build_patterns_for_song(spec: SongSpec, seed: int, sampler_seed: int | None 
                     density=density,
                     seed=sampler_seed if sampler_seed is not None else seed,
                     timeout=0.5,
+                    verbose=verbose,
                 )
             except Exception:
                 return fallback()

--- a/main_render.py
+++ b/main_render.py
@@ -388,7 +388,9 @@ if __name__ == "__main__":
     _log_stage(logs, progress, "voicing", t0)
 
     t0 = time.monotonic()
-    build_patterns_for_song(spec, seed=args.seed, sampler_seed=args.sampler_seed)
+    build_patterns_for_song(
+        spec, seed=args.seed, sampler_seed=args.sampler_seed, verbose=args.verbose
+    )
     _log_stage(logs, progress, "patterns", t0)
 
     t0 = time.monotonic()


### PR DESCRIPTION
## Summary
- add logging for missing or corrupt phrase models and note fallback to deterministic patterns
- expose `verbose` flag in phrase generation and pattern synthesis, with CLI support

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68c1f407bc9c8325a146b80b90e6366f