### PR TITLE
Add model loading validation tests

### DIFF
--- a/.github/workflows/model-validation.yml
+++ b/.github/workflows/model-validation.yml
@@ -1,0 +1,25 @@
+name: Validate exported models
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  load-models:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install torch onnxruntime
+      - name: Run model load tests
+        run: |
+          pytest tests/test_exported_models.py

--- a/tests/test_exported_models.py
+++ b/tests/test_exported_models.py
@@ -1,0 +1,21 @@
+import pytest
+from pathlib import Path
+
+import torch
+import onnxruntime as ort
+
+MODELS_DIR = Path(__file__).resolve().parents[1] / "models"
+MODEL_NAMES = ["bass_phrase", "drum_phrase", "keys_phrase"]
+
+@pytest.mark.parametrize("name", MODEL_NAMES)
+def test_torchscript_model_loads(name):
+    """Each TorchScript model should be loadable on CPU."""
+    ts_path = MODELS_DIR / f"{name}.ts.pt"
+    torch.jit.load(ts_path.as_posix(), map_location="cpu")
+
+
+@pytest.mark.parametrize("name", MODEL_NAMES)
+def test_onnx_model_loads(name):
+    """Each ONNX model should create an inference session."""
+    onnx_path = MODELS_DIR / f"{name}.onnx"
+    ort.InferenceSession(onnx_path.as_posix(), providers=["CPUExecutionProvider"])


### PR DESCRIPTION
## Summary
- add tests to load exported models via TorchScript and ONNX Runtime
- run tests in CI across Linux, macOS, and Windows

## Testing
- `pytest tests/test_exported_models.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68c1f6a7155c8325ae1bfc10c814e36f