### PR TITLE
Add optional phrase model flag for rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ Providing both makes runs fully repeatable (the sampler seed defaults to `0`).
 
 Small recurrent networks can replace the deterministic pattern generators.  The
 optional models live in the `models/` directory and are loaded automatically by
-`main_synth.py` and `main_render.py`.
+`main_synth.py` and `main_render.py`.  The `--use-phrase-model` flag controls
+their usage: the default `auto` mode tries to load models and falls back to the
+algorithmic generators if unavailable.  Passing `--use-phrase-model no`
+disables model loading entirely, while `--use-phrase-model yes` requires that
+models are present.
 
 ### Training prerequisites and dataset
 

--- a/main_render.py
+++ b/main_render.py
@@ -219,6 +219,12 @@ if __name__ == "__main__":
         help="Seed for phrase model sampling",
     )
     ap.add_argument(
+        "--use-phrase-model",
+        choices=["auto", "yes", "no"],
+        default="auto",
+        help="Use neural phrase models: auto, yes, or no (default: auto)",
+    )
+    ap.add_argument(
         "--mix",
         default="out/mix.wav",
         help="Output path for the master mix WAV",
@@ -389,7 +395,11 @@ if __name__ == "__main__":
 
     t0 = time.monotonic()
     build_patterns_for_song(
-        spec, seed=args.seed, sampler_seed=args.sampler_seed, verbose=args.verbose
+        spec,
+        seed=args.seed,
+        sampler_seed=args.sampler_seed,
+        verbose=args.verbose,
+        use_phrase_model=args.use_phrase_model,
     )
     _log_stage(logs, progress, "patterns", t0)
 


### PR DESCRIPTION
## Summary
- allow toggling phrase model usage via `--use-phrase-model`
- skip model import when disabled and fall back to algorithmic generation
- document phrase model flag

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68c22031d9248325808ca24960682c21