### PR TITLE
Allow variable-length phrase model exports

### DIFF
--- a/training/phrase_models/train_phrase_models.py
+++ b/training/phrase_models/train_phrase_models.py
@@ -101,7 +101,24 @@ def export(model: nn.Module, example: Union[torch.Tensor, Sequence[torch.Tensor]
 
     if not isinstance(example, (list, tuple)):
         example = (example,)
-    torch.onnx.export(model, example, onnx_path, opset_version=12)
+
+    # Allow variable sequence length during inference by marking the time
+    # dimension as dynamic in the exported ONNX graph.
+    input_names = [f"input_{i}" for i in range(len(example))]
+    output_names = ["output"]
+    dynamic_axes = {
+        name: {0: "batch", 1: "time"} for name in [*input_names, *output_names]
+    }
+
+    torch.onnx.export(
+        model,
+        example,
+        onnx_path,
+        opset_version=12,
+        input_names=input_names,
+        output_names=output_names,
+        dynamic_axes=dynamic_axes,
+    )
 
 
 # Main training routine ------------------------------------------------------


### PR DESCRIPTION
## Summary
- allow sequence length to vary by exporting phrase models with dynamic axes

## Testing
- `pytest tests/test_phrase_model_sampling.py::test_sampler_seed_reproducibility -q`
- `python - <<'PY'
from core import phrase_model
import numpy as np

class DummyOnnxSession:
    def __init__(self):
        self._inputs=[type('I', (), {'name':'input'})()]
    def get_inputs(self):
        return self._inputs
    def run(self, _unused, feed):
        inp = feed[self._inputs[0].name]
        seq_len = inp.shape[1]
        return [np.zeros((1, seq_len, 8), dtype=np.float32)]

sess = DummyOnnxSession()
phrase_model.MODEL_CACHE.clear()
phrase_model.load_model = lambda inst, verbose=False: ("onnx", sess)

out_short = phrase_model.generate_phrase('drum', prompt=[0,1], max_steps=1, top_k=1, top_p=1.0)
out_long = phrase_model.generate_phrase('drum', prompt=list(range(10)), max_steps=1, top_k=1, top_p=1.0)
print('short', len(out_short), 'long', len(out_long))
PY`
- ⚠️ `pip install torch --index-url https://download.pytorch.org/whl/cpu` (failed: Could not find a version that satisfies the requirement torch)
- ⚠️ `pip install onnxruntime` (failed: Could not find a version that satisfies the requirement onnxruntime)


------
https://chatgpt.com/codex/tasks/task_e_68c23b572be08325b8e89e784ebfbff5