### PR TITLE
Add timeout handling for phrase model loading and sampling

### DIFF
--- a/core/pattern_synth.py
+++ b/core/pattern_synth.py
@@ -271,7 +271,7 @@ def build_patterns_for_song(
                     chords=chords,
                     density=density,
                     seed=sampler_seed if sampler_seed is not None else seed,
-                    timeout=0.5,
+                    timeout=1.0,
                     verbose=verbose,
                 )
             except Exception:

--- a/tests/test_phrase_model_sampling.py
+++ b/tests/test_phrase_model_sampling.py
@@ -64,7 +64,9 @@ def test_sampler_seed_reproducibility(monkeypatch):
     """Identical sampler seed should yield identical patterns."""
 
     monkeypatch.setattr(
-        phrase_model, "load_model", lambda inst: ("onnx", DummyOnnxSession())
+        phrase_model,
+        "load_model",
+        lambda inst, *, timeout=1.0, verbose=False: ("onnx", DummyOnnxSession()),
     )
     spec = _simple_spec()
     plan1 = build_patterns_for_song(spec, seed=0, sampler_seed=123)


### PR DESCRIPTION
## Summary
- Run model loading and sampling through a shared `_run_with_timeout` helper
- Allow callers to specify a `timeout` when loading models and generating phrases
- Pass a sensible timeout from `build_patterns_for_song`

## Testing
- `pytest tests/test_phrase_model_sampling.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch'; RuntimeError: The starlette.testclient module requires the httpx package to be installed)*
- `pip install httpx -q` *(fails: Could not find a version that satisfies the requirement httpx)*
- `pip install torch -q` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_68c23c42f2f48325ae1990b16b0ecabe