### PR TITLE
Handle phrase model failures with algorithmic fallback

### DIFF
--- a/core/pattern_synth.py
+++ b/core/pattern_synth.py
@@ -14,6 +14,7 @@ be combined to generate musical material.
 
 from typing import Callable, Dict, List, Optional, Sequence
 import hashlib
+import logging
 import random
 
 from .song_spec import SongSpec
@@ -21,6 +22,7 @@ from .theory import parse_chord_symbol, midi_note
 from .utils import Event
 
 generate_phrase: Optional[Callable[..., List[int]]] = None
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -274,6 +276,13 @@ def build_patterns_for_song(
                     timeout=0.5,
                     verbose=verbose,
                 )
+            except (RuntimeError, TimeoutError) as exc:
+                logger.warning(
+                    "Phrase model for %s failed: %s – using algorithmic generator",
+                    inst,
+                    exc,
+                )
+                return fallback()
             except Exception:
                 if use_phrase_model == "yes":
                     raise

--- a/tests/test_phrase_model_sampling.py
+++ b/tests/test_phrase_model_sampling.py
@@ -74,14 +74,14 @@ def test_sampler_seed_reproducibility(monkeypatch):
 
 @pytest.mark.parametrize("exc", [RuntimeError("no model"), TimeoutError("slow")])
 def test_algorithmic_fallback(monkeypatch, exc):
-    """When models fail, algorithmic generators should be used."""
+    """When models fail, algorithmic generators should be used even when forced."""
 
     def _raise(*_a, **_k):
         raise exc
 
     monkeypatch.setattr("core.pattern_synth.generate_phrase", _raise)
     spec = _simple_spec()
-    plan = build_patterns_for_song(spec, seed=7, sampler_seed=7)
+    plan = build_patterns_for_song(spec, seed=7, sampler_seed=7, use_phrase_model="yes")
 
     sec = spec.sections[0]
     density = spec.density_curve[sec.name]


### PR DESCRIPTION
## Summary
- ensure `build_patterns_for_song` falls back to algorithmic generators when the phrase model raises `RuntimeError` or `TimeoutError`
- add logging for phrase model fallbacks
- add regression test covering fallback when phrase models are forced

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch'; RuntimeError: httpx required)*
- `pip install httpx` *(fails: Could not find a version that satisfies the requirement httpx)*
- `pytest tests/test_phrase_model_sampling.py`


------
https://chatgpt.com/codex/tasks/task_e_68c23c50ec8c832586b85464ced01b8c