### PR TITLE
Expose sampler seed controls in CLI

### DIFF
--- a/core/main_synth.py
+++ b/core/main_synth.py
@@ -9,7 +9,12 @@ if __name__ == "__main__":
     ap = argparse.ArgumentParser()
     ap.add_argument("--spec", required=True)
     ap.add_argument("--seed", type=int, default=42)
-    ap.add_argument("--sampler-seed", type=int, default=0)
+    ap.add_argument(
+        "--sampler-seed",
+        type=int,
+        default=None,
+        help="Seed for phrase model sampling (defaults to --seed)",
+    )
     ap.add_argument("--minutes", type=float)
     ap.add_argument("--print-stats", action="store_true")
     ap.add_argument("--verbose", action="store_true")

--- a/core/pattern_synth.py
+++ b/core/pattern_synth.py
@@ -240,7 +240,18 @@ def build_patterns_for_song(
     verbose: bool = False,
     use_phrase_model: str = "auto",
 ) -> Dict:
-    """Generate patterns for all sections/instruments using ``spec``."""
+    """Generate patterns for all sections/instruments using ``spec``.
+
+    Parameters
+    ----------
+    spec:
+        Song specification driving pattern generation.
+    seed:
+        Global seed controlling deterministic pattern generators.
+    sampler_seed:
+        Optional seed for phrase model sampling.  If ``None`` the global
+        ``seed`` is used instead.
+    """
     plan: Dict = {"sections": []}
     meter = spec.meter
     for sec in spec.sections:

--- a/core/phrase_model.py
+++ b/core/phrase_model.py
@@ -221,7 +221,8 @@ def generate_phrase(
     if seed is None:
         return _run_with_timeout(_sample_loop, timeout)
 
-    # Snapshot RNG states so seeding does not leak outside this function.
+    # Snapshot Python, NumPy and (if available) torch RNG states so seeding
+    # does not leak outside this function.
     py_state = random.getstate()
     np_state = np.random.get_state()
     torch_state = None

--- a/main_render.py
+++ b/main_render.py
@@ -215,8 +215,8 @@ if __name__ == "__main__":
     ap.add_argument(
         "--sampler-seed",
         type=int,
-        default=0,
-        help="Seed for phrase model sampling",
+        default=None,
+        help="Seed for phrase model sampling (defaults to --seed)",
     )
     ap.add_argument(
         "--use-phrase-model",


### PR DESCRIPTION
## Summary
- allow providing `--sampler-seed` in `main_render.py` and `core/main_synth.py`
- document sampler seed handling in `build_patterns_for_song`
- clarify RNG snapshotting in phrase model generation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install httpx torch --quiet` *(fails: Could not find a version that satisfies the requirement httpx)*
- `pytest tests/test_phrase_model_sampling.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c23cdfe3748325b27c7fe1cd8675d3