### PR TITLE
Add cadence and final conditioning tokens

### DIFF
--- a/tests/test_event_vocab.py
+++ b/tests/test_event_vocab.py
@@ -18,6 +18,8 @@ def test_round_trip_encode_decode():
         chord="C",
         seed=1234,
         cadence=True,
+        cadence_soon=True,
+        final=True,
     )
     decoded, meta = event_vocab.decode(tokens)
     assert decoded == notes
@@ -27,3 +29,5 @@ def test_round_trip_encode_decode():
     assert meta["chord"] == event_vocab.CHORD_TO_ID["C"]
     assert meta["seed"] == (1234 & 0xFFFF)
     assert meta["cadence"] == 1
+    assert meta["cadence_soon"] == 1
+    assert meta["final"] == 1


### PR DESCRIPTION
## Summary
- add `CADENCE_SOON` and `FINAL` token identifiers
- support `cadence_soon` and `final` flags in `encode`/`decode`
- test round-trip encoding/decoding with the new flags

## Testing
- `pytest tests/test_event_vocab.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c240c678708325bb969fee448f7c82