### PR TITLE
Add cadence_soon and final metadata to dataset tools

### DIFF
--- a/data/build_dataset.py
+++ b/data/build_dataset.py
@@ -60,6 +60,8 @@ def _tokenize(notes: Sequence[Stem], meta: Dict[str, Any]) -> List[Tuple[int, in
         chord=str(meta.get("chord", "C")),
         seed=int(meta.get("seed", 0)),
         cadence=bool(meta.get("cadence", False)),
+        cadence_soon=bool(meta.get("cadence_soon", False)),
+        final=bool(meta.get("final", False)),
     )
 
 

--- a/data/dataset_stats.py
+++ b/data/dataset_stats.py
@@ -25,6 +25,8 @@ TOKEN_ID_TO_NAME: Dict[int, str] = {
     event_vocab.CADENCE: "CADENCE",
     event_vocab.METER: "METER",
     event_vocab.SEED: "SEED",
+    event_vocab.CADENCE_SOON: "CADENCE_SOON",
+    event_vocab.FINAL: "FINAL",
 }
 
 # Tokens considered conditioning metadata
@@ -35,6 +37,8 @@ CONDITIONING_TOKENS = {
     event_vocab.CHORD,
     event_vocab.SEED,
     event_vocab.CADENCE,
+    event_vocab.CADENCE_SOON,
+    event_vocab.FINAL,
 }
 
 # Optional mappings from token value to human-readable name

--- a/tests/test_dataset_stats.py
+++ b/tests/test_dataset_stats.py
@@ -11,8 +11,25 @@ from data.dataset_stats import compute_stats
 def _write_sample_dataset(path: Path) -> None:
     notes1 = [Stem(start=0.0, dur=1.0, pitch=60, vel=100, chan=0)]
     notes2 = [Stem(start=0.0, dur=1.0, pitch=64, vel=90, chan=1)]
-    tokens1 = event_vocab.encode(notes1, section="A", meter="4/4", density=0.5, chord="C", seed=0)
-    tokens2 = event_vocab.encode(notes2, section="B", meter="3/4", density=0.25, chord="G", seed=1)
+    tokens1 = event_vocab.encode(
+        notes1,
+        section="A",
+        meter="4/4",
+        density=0.5,
+        chord="C",
+        seed=0,
+    )
+    tokens2 = event_vocab.encode(
+        notes2,
+        section="B",
+        meter="3/4",
+        density=0.25,
+        chord="G",
+        seed=1,
+        cadence=True,
+        cadence_soon=True,
+        final=True,
+    )
     with path.open("w", encoding="utf-8") as fh:
         for tokens in (tokens1, tokens2):
             fh.write(json.dumps({"tokens": tokens}) + "\n")
@@ -23,7 +40,13 @@ def test_compute_stats(tmp_path):
     _write_sample_dataset(dataset)
     stats = compute_stats([dataset])
     assert stats["songs"] == 2
-    assert stats["total_tokens"] == 26
+    assert stats["total_tokens"] == 30
     assert stats["token_type_counts"]["NOTE_ON"] == 2
     assert stats["conditioning_frequencies"]["SECTION"]["A"] == 1
     assert stats["conditioning_frequencies"]["SECTION"]["B"] == 1
+    assert stats["token_type_counts"]["CADENCE_SOON"] == 2
+    assert stats["token_type_counts"]["FINAL"] == 2
+    assert stats["conditioning_frequencies"]["CADENCE_SOON"]["0"] == 1
+    assert stats["conditioning_frequencies"]["CADENCE_SOON"]["1"] == 1
+    assert stats["conditioning_frequencies"]["FINAL"]["0"] == 1
+    assert stats["conditioning_frequencies"]["FINAL"]["1"] == 1


### PR DESCRIPTION
## Summary
- pass cadence_soon and final metadata to event encoder during dataset build
- map CADENCE_SOON and FINAL tokens in dataset stats and include them in conditioning stats
- update dataset stats tests for the new conditioning token counts

## Testing
- `pytest tests/test_dataset_stats.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c241d778308325857a6c9ae1f17e1f