### PR TITLE
Signal upcoming cadences and align fills

### DIFF
--- a/core/arranger.py
+++ b/core/arranger.py
@@ -83,7 +83,10 @@ def arrange_song(
     cadences = spec.cadence_bars()
     if cadences:
         for bar_idx in sorted(cadences):
-            bar_start = bar_idx * sec_per_bar
+            if bar_idx <= 0:
+                continue
+            pre_bar = bar_idx - 1
+            bar_start = pre_bar * sec_per_bar
             bar_end = bar_start + sec_per_bar
             # Drum fill: simple snare hit on the last 16th note of the bar
             fill_start = bar_end - sec_per_step
@@ -107,8 +110,8 @@ def arrange_song(
                 out.setdefault("fx", []).append(
                     Stem(start=bar_start, dur=sec_per_bar, pitch=0, vel=vel_n, chan=15)
                 )
-            # Bass approach: chromatic approach to first note of next bar
-            next_start = (bar_idx + 1) * sec_per_bar
+            # Bass approach: chromatic approach to first note of cadence bar
+            next_start = bar_idx * sec_per_bar
             next_end = next_start + sec_per_bar
             target_pitch = None
             target_vel = 96

--- a/tests/test_arranger_cadence_fill.py
+++ b/tests/test_arranger_cadence_fill.py
@@ -21,7 +21,7 @@ def test_drum_fill_added_at_cadence():
     sec_per_bar = beats * sec_per_beat
     spb = _steps_per_beat(spec.meter)
     sec_per_step = sec_per_beat / spb
-    fill_start = 2 * sec_per_bar - sec_per_step
+    fill_start = 1 * sec_per_bar - sec_per_step
 
     drum_notes = out.get("drums", [])
     tol = 0.02

--- a/tests/test_arranger_fx.py
+++ b/tests/test_arranger_fx.py
@@ -49,7 +49,7 @@ def test_arranger_effects():
 
     out = arrange_song(spec, stems, style=style, seed=1)
 
-    cadence_start = 3 * sec_per_bar
+    cadence_start = 2 * sec_per_bar
     tol = 0.02  # allow for micro-timing jitter applied by dynamics
     # Noise sweep added to FX instrument
     fx_notes = out.get("fx", [])
@@ -58,7 +58,7 @@ def test_arranger_effects():
         for n in fx_notes
     )
 
-    # Tom roll should add tom pitches within cadence bar
+    # Tom roll should add tom pitches within pre-cadence bar
     drum_notes = out.get("drums", [])
     assert any(
         cadence_start - tol <= n.start < cadence_start + sec_per_bar + tol

--- a/tests/test_cadence_prompt.py
+++ b/tests/test_cadence_prompt.py
@@ -1,0 +1,31 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.song_spec import SongSpec, Section
+from core.pattern_synth import build_patterns_for_song
+
+
+def test_cadence_tokens_passed_to_phrase_model(monkeypatch):
+    calls = []
+
+    def fake_generate_phrase(inst, *, cadence_soon, final, **kwargs):
+        calls.append((inst, cadence_soon, final))
+        return []
+
+    monkeypatch.setattr("core.pattern_synth.generate_phrase", fake_generate_phrase)
+
+    spec = SongSpec(
+        tempo=120,
+        meter="4/4",
+        sections=[Section("A", 3)],
+        harmony_grid=[{"section": "A", "chords": ["C", "F", "G"]}],
+        cadences=[{"bar": 1, "type": "sec"}, {"bar": 2, "type": "final"}],
+    )
+
+    build_patterns_for_song(spec, seed=0, use_phrase_model="yes")
+
+    assert calls, "phrase model was not invoked"
+    for _inst, cadence_soon, final in calls:
+        assert cadence_soon == [1, 1, 0]
+        assert final == [0, 1, 0]
+


### PR DESCRIPTION
## Summary
- Flag bars preceding cadences in pattern synthesis and pass CADENCE_SOON/FINAL to phrase models
- Shift arranger fills, tom rolls, noise sweeps and bass approaches to the bar before each cadence
- Test cadence token injection and pre‑cadence fill behaviour

## Testing
- `pytest -q` *(fails: No module named 'torch'; httpx missing)*
- `pip install httpx torch -q` *(fails: ProxyError: Tunnel connection failed: 403 Forbidden)*
- `pytest tests/test_arranger_cadence_fill.py tests/test_arranger_fx.py tests/test_cadence_prompt.py tests/test_phrase_model_sampling.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c243f4f6ec83258224665bdc9b9048