### PR TITLE
Add chorus effect for pads

### DIFF
--- a/assets/presets/default.json
+++ b/assets/presets/default.json
@@ -29,7 +29,8 @@
       "gain": -6.0,
       "pan": 0.0,
       "reverb_send": 0.4,
-      "eq": {"freq": 1000.0, "gain": 0.0, "q": 1.0}
+      "eq": {"freq": 1000.0, "gain": 0.0, "q": 1.0},
+      "chorus": {"depth": 8.0, "rate": 0.25, "mix": 0.5}
     }
   },
   "reverb": {

--- a/render_config.json
+++ b/render_config.json
@@ -29,7 +29,8 @@
       "gain": -6.0,
       "pan": 0.0,
       "reverb_send": 0.4,
-      "eq": {"freq": 1000.0, "gain": 0.0, "q": 1.0}
+      "eq": {"freq": 1000.0, "gain": 0.0, "q": 1.0},
+      "chorus": {"depth": 8.0, "rate": 0.25, "mix": 0.5}
     }
   },
   "reverb": {


### PR DESCRIPTION
## Summary
- add stereo `_chorus` effect with modulated delay lines
- allow mixer to apply chorus based on track config
- expose chorus parameters for pads in default render config and preset
- test chorus alters signal spectrum and autocorrelation

## Testing
- `PYTHONPATH=. pytest tests/test_mixer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c24f2ac6508325ab613973341bad8b