### PR TITLE
feat: add lookahead RMS bus compressor

### DIFF
--- a/assets/presets/default.json
+++ b/assets/presets/default.json
@@ -44,9 +44,10 @@
     "compressor": {
       "enabled": true,
       "threshold": -6.0,
-      "ratio": 2.0,
       "attack": 0.01,
-      "release": 0.1
+      "release": 0.1,
+      "knee_db": 6.0,
+      "lookahead_ms": 5.0
     },
     "limiter": {
       "enabled": true,

--- a/render_config.json
+++ b/render_config.json
@@ -44,9 +44,10 @@
     "compressor": {
       "enabled": true,
       "threshold": -6.0,
-      "ratio": 2.0,
       "attack": 0.01,
-      "release": 0.1
+      "release": 0.1,
+      "knee_db": 6.0,
+      "lookahead_ms": 5.0
     },
     "limiter": {
       "enabled": true,


### PR DESCRIPTION
## Summary
- replace peak detector with RMS envelope and fixed 2:1 ratio
- support soft-knee and lookahead options in bus compressor
- document compressor settings and extend mixer tests

## Testing
- `pytest -q` *(fails: The starlette.testclient module requires the httpx package to be installed)*
- `PYTHONPATH=. pytest tests/test_mixer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c2dd8f32ac8325bfe5e945fffe4894