### PR TITLE
feat: add lookahead peak limiter

### DIFF
--- a/assets/presets/default.json
+++ b/assets/presets/default.json
@@ -53,7 +53,9 @@
     "limiter": {
       "enabled": true,
       "ceiling": -0.8,
-      "oversample": 4
+      "oversample": 4,
+      "attack": 0.001,
+      "release": 0.05
     }
   }
 }

--- a/render_config.json
+++ b/render_config.json
@@ -53,7 +53,9 @@
     "limiter": {
       "enabled": true,
       "ceiling": -0.8,
-      "oversample": 4
+      "oversample": 4,
+      "attack": 0.001,
+      "release": 0.05
     }
   }
 }


### PR DESCRIPTION
## Summary
- replace simple true-peak limiter with lookahead limiter using attack/release smoothing
- expose limiter attack/release config options and update presets
- test limiter preserves average level while keeping peaks under ceiling

## Testing
- `PYTHONPATH=. pytest tests/test_mixer.py::test_gain_pan_limiter tests/test_mixer.py::test_limiter_preserves_level_and_peak tests/test_mix_output_constraints.py::test_duration_limiter_and_stems_nonzero -q`

------
https://chatgpt.com/codex/tasks/task_e_68c2f01cf1e883259946083d40f83158