### PR TITLE
test: verify dynamics increase chorus loudness in audio

### DIFF
--- a/tests/test_dynamics_rms.py
+++ b/tests/test_dynamics_rms.py
@@ -1,18 +1,27 @@
 import math
 import os, sys
+import numpy as np
+import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from core.song_spec import SongSpec, Section
 from core.stems import Stem, bars_to_beats, beats_to_secs
 from core import dynamics
+from core.render import render_song
+from core.mixer import mix
 
 
-def test_chorus_louder_than_verse():
-    spec = SongSpec(
+@pytest.fixture
+def song_spec() -> SongSpec:
+    return SongSpec(
         tempo=120,
         meter="4/4",
         sections=[Section("verse", 1), Section("chorus", 1)],
     )
+
+
+def test_chorus_louder_than_verse(song_spec: SongSpec):
+    spec = song_spec
     sec_per_bar = bars_to_beats(spec.meter) * beats_to_secs(spec.tempo)
     stems = {
         "keys": [
@@ -28,3 +37,15 @@ def test_chorus_louder_than_verse():
         return math.sqrt(sum(v * v for v in vals) / len(vals))
 
     assert rms(chorus_vels) > rms(verse_vels)
+
+    sr = 44100
+    rendered = render_song(processed, sr)
+    mixed = mix(rendered, sr)
+    bar_samples = int(sec_per_bar * sr)
+    verse_audio = mixed[:bar_samples]
+    chorus_audio = mixed[bar_samples : 2 * bar_samples]
+
+    def audio_rms(buf: np.ndarray) -> float:
+        return float(np.sqrt(np.mean(np.square(buf))))
+
+    assert audio_rms(chorus_audio) > audio_rms(verse_audio)


### PR DESCRIPTION
## Summary
- extend dynamics RMS test to render stems and mix audio
- ensure chorus RMS exceeds verse RMS after rendering
- add tempo/meter fixture for deterministic timing

## Testing
- `python -m pytest tests/test_dynamics_rms.py::test_chorus_louder_than_verse -q`

------
https://chatgpt.com/codex/tasks/task_e_68c2f06c5700832592ed3fa1e7a3827e