### PR TITLE
feat: apply style-based synth and drum defaults

### DIFF
--- a/assets/styles/cinematic.json
+++ b/assets/styles/cinematic.json
@@ -1,5 +1,11 @@
 {
   "swing": 0.0,
+  "drums": {"swing": 0.0},
+  "synth_defaults": {
+    "lpf_cutoff": 12000.0,
+    "chorus": 0.1,
+    "saturation": 0.05
+  },
   "bass": {"tendencies": ["pedal", "root"]},
   "sections": ["intro", "theme", "development", "climax", "outro"]
 }

--- a/assets/styles/lofi.json
+++ b/assets/styles/lofi.json
@@ -1,5 +1,11 @@
 {
   "swing": 0.1,
+  "drums": {"swing": 0.05},
+  "synth_defaults": {
+    "lpf_cutoff": 3000.0,
+    "chorus": 0.4,
+    "saturation": 0.3
+  },
   "bass": {"tendencies": ["roots", "fifths"]},
   "sections": ["intro", "verse", "chorus", "verse", "chorus", "outro"]
 }

--- a/assets/styles/rock.json
+++ b/assets/styles/rock.json
@@ -1,5 +1,11 @@
 {
   "swing": 0.0,
+  "drums": {"swing": 0.0},
+  "synth_defaults": {
+    "lpf_cutoff": 8000.0,
+    "chorus": 0.2,
+    "saturation": 0.1
+  },
   "bass": {"tendencies": ["roots", "octaves"]},
   "sections": ["intro", "verse", "chorus", "verse", "chorus", "bridge", "chorus"]
 }

--- a/main_render.py
+++ b/main_render.py
@@ -493,7 +493,7 @@ if __name__ == "__main__":
         _log_stage(logs, progress, "render", t0, peaks=stem_peaks)
 
         t0 = time.monotonic()
-        mix_audio = mix_stems(rendered, 44100, cfg)
+        mix_audio = mix_stems(rendered, 44100, cfg, style=style)
         mix_peak = float(np.max(np.abs(mix_audio)))
         mix_lufs = estimate_lufs(mix_audio, 44100)
         cfg["loudness_lufs"] = round(float(mix_lufs), 1)

--- a/tests/test_style_defaults.py
+++ b/tests/test_style_defaults.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+from core.style import load_style
+from core.mixer import mix
+
+
+def test_style_loader_fields():
+    style = load_style("assets/styles/lofi.json")
+    assert "synth_defaults" in style
+    assert "drums" in style and "swing" in style["drums"]
+
+
+def test_mixer_style_defaults_apply():
+    sr = 44100
+    tone = np.ones(sr, dtype=np.float32)
+    stems = {"keys": tone}
+    style = {"synth_defaults": {"chorus": 1.0, "saturation": 1.0}}
+    wet = mix(stems, sr, {}, style=style)
+    dry = mix(stems, sr, {}, style={})
+    assert wet.shape == (sr, 2)
+    assert not np.allclose(wet, dry)

--- a/ui.py
+++ b/ui.py
@@ -151,8 +151,8 @@ def render():
             if p.exists():
                 sfz_map["drums"] = p
         rhash = render_hash(spec, cfg, sfz_map, seed, None)
-        rendered = render_song(stems, sr=44100, sfz_paths=sfz_map)
-        mix_audio = mix(rendered, 44100, cfg)
+        rendered = render_song(stems, sr=44100, sfz_paths=sfz_map, style=style)
+        mix_audio = mix(rendered, 44100, cfg, style=style)
 
         mix_path.parent.mkdir(parents=True, exist_ok=True)
         _write_wav(mix_path, mix_audio, 44100, comment=rhash)


### PR DESCRIPTION
## Summary
- extend style specs with `synth_defaults` (LPF cutoff, chorus mix, saturation) and `drums.swing`
- load and validate new style fields and use them in rendering and mixing
- pass style through CLI/UI so defaults are applied automatically

## Testing
- `pytest` *(fails: httpx dependency missing)*
- `pip install httpx` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f800b90c8325aed8ebf6ca556ae1