### PR TITLE
refactor: centralize style token definitions

### DIFF
--- a/core/phrase_model.py
+++ b/core/phrase_model.py
@@ -24,6 +24,7 @@ import logging
 import numpy as np
 
 from .sampling import sample
+from .style import StyleToken
 
 # Optional dependencies.  The rest of the code guards against them being
 # unavailable so the repository can be used without the heavy ML stacks
@@ -204,7 +205,7 @@ def generate_phrase(
 
     def _sample_loop():  # pragma: no cover - relies on optional deps
         history = list(prompt)
-        style_id = 0 if style is None else int(style)
+        style_id = int(StyleToken.LOFI if style is None else style)
         for _ in range(max_steps):
             if fmt == "torchscript":
                 inp = torch.tensor([history], dtype=torch.long)

--- a/core/style.py
+++ b/core/style.py
@@ -4,13 +4,33 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, Mapping, Union, Dict
+from enum import IntEnum
 import json
 
+
+class StyleToken(IntEnum):
+    """Enumeration of supported style tokens."""
+
+    LOFI = 0
+    ROCK = 1
+    CINEMATIC = 2
+
+
 # Mapping of human readable style names to token IDs used by phrase models
-STYLE_TOKENS = {"lofi": 0, "rock": 1, "cinematic": 2}
+STYLE_TOKENS = {
+    name.lower(): token for name, token in StyleToken.__members__.items()
+}
+
+# Convenience count of available styles
+NUM_STYLES = len(StyleToken)
+
+# Backwards compatible constant aliases
+STYLE_LOFI = StyleToken.LOFI
+STYLE_ROCK = StyleToken.ROCK
+STYLE_CINEMATIC = StyleToken.CINEMATIC
 
 
-def style_to_token(name: Union[str, Path, None]) -> int | None:
+def style_to_token(name: Union[str, Path, None]) -> StyleToken | None:
     """Return token ID for style ``name`` if known."""
     if not name:
         return None

--- a/training/phrase_models/train_phrase_models.py
+++ b/training/phrase_models/train_phrase_models.py
@@ -19,11 +19,7 @@ import torch
 import torch.nn as nn
 
 from core.sampling import sample
-
-STYLE_LOFI = 0
-STYLE_ROCK = 1
-STYLE_CINEMATIC = 2
-NUM_STYLES = 3
+from core.style import StyleToken, NUM_STYLES
 
 REPO_DIR = Path(__file__).resolve().parents[2]
 MODELS_DIR = REPO_DIR / "models"
@@ -145,8 +141,15 @@ def main() -> None:
     torch.save(drum_model.state_dict(), Path(__file__).with_name("drum_phrase.pt"))
     export(drum_model.eval(), (drum_data[:1], drum_styles[:1]), "drum_phrase")
 
-    # Demonstrate sampling with the centralized utilities
-    logits = drum_model(drum_data[:1], drum_styles[:1])[0, -1].detach().cpu().numpy()
+    # Demonstrate sampling with the centralized utilities using a fixed style
+    logits = (
+        drum_model(
+            drum_data[:1], torch.tensor([StyleToken.LOFI], dtype=torch.long)
+        )[0, -1]
+        .detach()
+        .cpu()
+        .numpy()
+    )
     _ = sample(logits, top_k=4, top_p=0.9)
 
     # Bass phrase: chord conditioned


### PR DESCRIPTION
## Summary
- centralize style token constants in `core/style.py`
- reuse shared style constants in training script
- use shared default style token in phrase model sampler

## Testing
- `pytest` *(fails: The starlette.testclient module requires the httpx package to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c2fccac61483258c6547e0f7345b0c