### PR TITLE
Document style profiles and A/B evaluation harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ If a model file is absent or fails to load, the code falls back to the
 deterministic pattern generators.  See
 [`docs/phrase_models.md`](docs/phrase_models.md) for details.
 
+## Style profiles
+
+Built-in arrangement styles adjust swing and mixing defaults. See
+[`docs/style_profiles.md`](docs/style_profiles.md) for the current token IDs
+and guidance on adding new styles.
+
 ## Cadence fill evaluation
 
 The repository includes a small helper to inspect note densities around
@@ -119,7 +125,9 @@ python scripts/ab_eval.py --spec path/to/spec.json --seed 42 --out ab_bundle
 
 The resulting bundle contains WAV files, stem JSON and `metrics.json` /
 `metrics.csv` summaries.  These metrics cover note diversity, inter-onset
-interval histograms, cadence fill rates and section-wise loudness.
+interval histograms, cadence fill rates and section-wise loudness. See
+[`docs/ab_harness.md`](docs/ab_harness.md) for details on the metrics and
+output bundle structure.
 
 
 ## Using External Samples

--- a/docs/ab_harness.md
+++ b/docs/ab_harness.md
@@ -1,0 +1,33 @@
+# A/B evaluation harness
+
+`scripts/ab_eval.py` renders a song twice—once with deterministic pattern synthesis (labelled **algorithmic**) and once using the optional neural phrase models (**learned**). It collects audio, note data and several metrics for side-by-side comparison.
+
+## Usage
+
+```bash
+python scripts/ab_eval.py --spec path/to/spec.json --seed 42 --out ab_bundle
+```
+
+## Metrics
+
+- **note_diversity** – histogram of note pitches per instrument.
+- **ioi_histogram** – distribution of inter-onset intervals in seconds.
+- **cadence_density** – average note density before cadence bars versus other bars.
+- **section_loudness** – RMS dB and LUFS values for each song section.
+
+## Output bundle
+
+The output directory contains:
+
+```
+ab_bundle/
+├── algorithmic.wav
+├── algorithmic_stems.json
+├── learned.wav
+├── learned_stems.json
+├── metrics.json
+└── metrics.csv
+```
+
+`metrics.json` stores structured data while `metrics.csv` provides a flattened table for quick inspection.
+

--- a/docs/style_profiles.md
+++ b/docs/style_profiles.md
@@ -1,0 +1,35 @@
+# Style profiles
+
+Built-in arrangement styles adapt swing behaviour and apply mix defaults for different genres. Style data lives in `assets/styles/` and is referenced by name or token when rendering.
+
+## Available styles
+
+| Name | Token ID | Mix defaults |
+| --- | --- | --- |
+| lofi | 0 | lpf_cutoff 3000 Hz, chorus 0.4, saturation 0.3, drums swing 0.05 |
+| rock | 1 | lpf_cutoff 8000 Hz, chorus 0.2, saturation 0.1, drums swing 0.0 |
+| cinematic | 2 | lpf_cutoff 12000 Hz, chorus 0.1, saturation 0.05, drums swing 0.0 |
+
+The top-level `swing` field in each JSON sets overall arrangement swing. Nested `drums.swing` applies an additional swing factor to drum patterns.
+
+## Adding a new style
+
+1. Create a JSON file in `assets/styles/<name>.json` following the existing structure:
+
+```json
+{
+  "swing": 0.0,
+  "drums": {"swing": 0.0},
+  "synth_defaults": {
+    "lpf_cutoff": 8000.0,
+    "chorus": 0.2,
+    "saturation": 0.1
+  },
+  "sections": ["intro", "verse", "chorus"]
+}
+```
+
+2. Register the style in `core/style.py` by adding an entry to the `StyleToken` enum.
+3. Update any logic that depends on the number of styles (e.g. training utilities).
+4. Refer to the new style by name via command-line `--style` arguments or configuration files.
+


### PR DESCRIPTION
## Summary
- Add `style_profiles.md` explaining built-in styles, token IDs and defaults
- Document `scripts/ab_eval.py` metrics and output in `ab_harness.md`
- Link new docs from README

## Testing
- `pytest -q` *(fails: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68c300af6bc08325ba8a98ed428ecfdd