### PR TITLE
Add render evaluation metrics and JSON export

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -14,6 +14,7 @@ from .stems import (
 )
 from .arranger import arrange_song
 from .dynamics import apply as apply_dynamics
+from .eval_metrics import evaluate_render
 
 __all__ = [
     "SongSpec", "Section",
@@ -22,4 +23,5 @@ __all__ = [
     "Note", "Stem", "Stems",
     "bars_to_beats", "beats_to_secs",
     "enforce_register", "dedupe_collisions",
+    "evaluate_render",
 ]

--- a/core/eval_metrics.py
+++ b/core/eval_metrics.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from typing import Dict, Mapping, Sequence, List
+
+import numpy as np
+
+from .stems import Stem, bars_to_beats
+from .song_spec import SongSpec
+from .theory import parse_chord_symbol, generate_satb
+
+
+def chord_tone_coverage(stems: Mapping[str, Sequence[Stem]], spec: SongSpec) -> float:
+    """Return fraction of bass/keys/pads notes that match the chord."""
+    chords = spec.all_chords()
+    beats_per_bar = bars_to_beats(spec.meter)
+    total = 0
+    matches = 0
+    for inst in ("bass", "keys", "pads"):
+        for n in stems.get(inst, []):
+            bar = int(n.start // beats_per_bar)
+            if bar >= len(chords):
+                continue
+            root, intervals = parse_chord_symbol(chords[bar])
+            pcs = {(root + iv) % 12 for iv in intervals}
+            total += 1
+            if n.pitch % 12 in pcs:
+                matches += 1
+    return matches / total if total else 0.0
+
+
+def voice_leading_smoothness(spec: SongSpec) -> float:
+    """Average absolute interval movement across SATB voices."""
+    chords = spec.all_chords()
+    if len(chords) < 2:
+        return 0.0
+    bass, tenor, alto, soprano = generate_satb(chords)
+    voices = [bass, tenor, alto, soprano]
+    intervals: List[float] = []
+    for voice in voices:
+        intervals.extend(abs(voice[i] - voice[i - 1]) for i in range(1, len(voice)))
+    return float(np.mean(intervals)) if intervals else 0.0
+
+
+def rhythmic_stability(stems: Mapping[str, Sequence[Stem]]) -> Dict[str, float]:
+    """Return IOI variance per instrument."""
+    out: Dict[str, float] = {}
+    for inst, notes in stems.items():
+        starts = sorted(n.start for n in notes)
+        if len(starts) < 2:
+            out[inst] = 0.0
+            continue
+        iois = np.diff(starts)
+        out[inst] = float(np.var(iois))
+    return out
+
+
+def cadence_fill_rate(stems: Mapping[str, Sequence[Stem]], spec: SongSpec) -> float:
+    """Fraction of cadence bars preceded by above-average density."""
+    beats_per_bar = bars_to_beats(spec.meter)
+    cad_map = spec.cadence_bars()
+    pre_cadence = [b - 1 for b in cad_map if b > 0]
+    if not pre_cadence:
+        return 0.0
+    counts: Dict[int, int] = {}
+    for notes in stems.values():
+        for n in notes:
+            bar = int(n.start // beats_per_bar)
+            counts[bar] = counts.get(bar, 0) + 1
+    normal = [cnt for bar, cnt in counts.items() if bar not in pre_cadence]
+    avg_normal = float(np.mean(normal)) if normal else 0.0
+    filled = sum(1 for b in pre_cadence if counts.get(b, 0) > avg_normal)
+    return filled / len(pre_cadence)
+
+
+def density_alignment(stems: Mapping[str, Sequence[Stem]], spec: SongSpec) -> Dict[str, Dict[str, float]]:
+    """Return actual vs. expected note density per section."""
+    beats_per_bar = bars_to_beats(spec.meter)
+    counts: Dict[int, int] = {}
+    for notes in stems.values():
+        for n in notes:
+            bar = int(n.start // beats_per_bar)
+            counts[bar] = counts.get(bar, 0) + 1
+    sec_map = spec.bars_by_section()
+    out: Dict[str, Dict[str, float]] = {}
+    for sec in spec.sections:
+        bars = list(sec_map[sec.name])
+        if bars:
+            total = sum(counts.get(b, 0) for b in bars)
+            actual = total / (len(bars) * beats_per_bar)
+        else:
+            actual = 0.0
+        expected = float(spec.density_curve.get(sec.name, 0.0))
+        out[sec.name] = {"expected": expected, "actual": actual}
+    return out
+
+
+def audio_stats(audio: np.ndarray) -> Dict[str, float]:
+    """Return peak and RMS levels in dBFS for ``audio``."""
+    if audio.size == 0:
+        return {"peak_db": float("-inf"), "rms_db": float("-inf")}
+    peak = float(np.max(np.abs(audio)))
+    rms = float(np.sqrt(np.mean(np.square(audio))))
+    peak_db = -np.inf if peak <= 0 else 20 * np.log10(peak)
+    rms_db = -np.inf if rms <= 0 else 20 * np.log10(rms)
+    return {"peak_db": peak_db, "rms_db": rms_db}
+
+
+def evaluate_render(stems: Mapping[str, Sequence[Stem]], spec: SongSpec, audio: np.ndarray) -> Dict[str, object]:
+    """Compute all evaluation metrics for a render."""
+    return {
+        "chord_tone_coverage": chord_tone_coverage(stems, spec),
+        "voice_leading_smoothness": voice_leading_smoothness(spec),
+        "rhythmic_stability": rhythmic_stability(stems),
+        "cadence_fill_rate": cadence_fill_rate(stems, spec),
+        "density_alignment": density_alignment(stems, spec),
+        "audio_stats": audio_stats(audio),
+    }

--- a/main_render.py
+++ b/main_render.py
@@ -44,6 +44,7 @@ from core.style import load_style, style_to_token
 from core.midi_export import stems_to_midi
 from core.render_hash import get_git_commit, render_hash
 from core.loudness import estimate_lufs
+from core.eval_metrics import evaluate_render
 
 
 def _write_wav(path: Path, audio: np.ndarray, sr: int, *, comment: str | None = None) -> None:
@@ -500,6 +501,7 @@ if __name__ == "__main__":
         _log_stage(logs, progress, "mix", t0, peak=mix_peak, loudness_lufs=mix_lufs)
 
         summary, arrange_report = _print_arrangement_summary(spec, mix_audio, 44100)
+        metrics = evaluate_render(stems, spec, mix_audio)
 
         t0 = time.monotonic()
         if args.bundle:
@@ -531,6 +533,8 @@ if __name__ == "__main__":
             (bundle_dir / "arrangement.txt").write_text(summary + "\n", encoding="utf-8")
             with (bundle_dir / "arrange_report.json").open("w", encoding="utf-8") as fh:
                 json.dump(arrange_report, fh, indent=2)
+            with (bundle_dir / "metrics.json").open("w", encoding="utf-8") as fh:
+                json.dump(metrics, fh, indent=2)
 
             cmdline = (
                 "python "

--- a/tests/test_eval_metrics.py
+++ b/tests/test_eval_metrics.py
@@ -1,0 +1,117 @@
+import os, sys
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.stems import Stem
+from core.song_spec import SongSpec
+from core.eval_metrics import (
+    chord_tone_coverage,
+    voice_leading_smoothness,
+    rhythmic_stability,
+    cadence_fill_rate,
+    density_alignment,
+    audio_stats,
+)
+
+
+def _basic_spec() -> SongSpec:
+    return SongSpec.from_dict({
+        "title": "t",
+        "sections": [
+            {"name": "a", "length": 1},
+            {"name": "b", "length": 1},
+        ],
+        "harmony_grid": [
+            {"section": "a", "chords": ["C"]},
+            {"section": "b", "chords": ["F"]},
+        ],
+    })
+
+
+def test_chord_tone_coverage():
+    spec = _basic_spec()
+    stems = {
+        "bass": [
+            Stem(start=0, dur=1, pitch=36, vel=100, chan=0),  # C
+            Stem(start=4, dur=1, pitch=53, vel=100, chan=0),  # F
+            Stem(start=0, dur=1, pitch=37, vel=100, chan=0),  # C# off-chord
+        ]
+    }
+    cov = chord_tone_coverage(stems, spec)
+    assert cov == pytest.approx(2 / 3)
+
+
+def test_voice_leading_smoothness():
+    spec = _basic_spec()
+    # Compute expected directly using generate_satb
+    from core.theory import generate_satb
+
+    bass, tenor, alto, soprano = generate_satb(spec.all_chords())
+    intervals = []
+    for voice in (bass, tenor, alto, soprano):
+        intervals.append(abs(voice[1] - voice[0]))
+    expected = np.mean(intervals)
+    assert voice_leading_smoothness(spec) == expected
+
+
+def test_rhythmic_stability():
+    stems = {
+        "bass": [Stem(start=0, dur=1, pitch=36, vel=100, chan=0),
+                 Stem(start=1, dur=1, pitch=36, vel=100, chan=0),
+                 Stem(start=2, dur=1, pitch=36, vel=100, chan=0)],
+        "keys": [Stem(start=0, dur=1, pitch=60, vel=100, chan=0),
+                 Stem(start=1, dur=1, pitch=60, vel=100, chan=0),
+                 Stem(start=3, dur=1, pitch=60, vel=100, chan=0)],
+    }
+    stability = rhythmic_stability(stems)
+    assert stability["bass"] == 0.0
+    assert stability["keys"] == pytest.approx(0.25)
+
+
+def test_cadence_fill_rate():
+    spec = SongSpec.from_dict({
+        "sections": [{"name": "a", "length": 4}],
+        "harmony_grid": [{"section": "a", "chords": ["C", "C", "C", "C"]}],
+        "cadences": [{"bar": 3, "type": "final"}],
+    })
+    stems = {
+        "drums": [
+            Stem(start=0, dur=1, pitch=36, vel=100, chan=9),
+            Stem(start=4, dur=1, pitch=36, vel=100, chan=9),
+            Stem(start=8, dur=1, pitch=36, vel=100, chan=9),
+            Stem(start=9, dur=1, pitch=36, vel=100, chan=9),
+            Stem(start=10, dur=1, pitch=36, vel=100, chan=9),
+        ]
+    }
+    rate = cadence_fill_rate(stems, spec)
+    assert rate == pytest.approx(1.0)
+
+
+def test_density_alignment():
+    spec = SongSpec.from_dict({
+        "sections": [{"name": "a", "length": 1}, {"name": "b", "length": 1}],
+        "harmony_grid": [
+            {"section": "a", "chords": ["C"]},
+            {"section": "b", "chords": ["C"]},
+        ],
+        "density_curve": {"a": 0.5, "b": 0.25},
+    })
+    stems = {
+        "bass": [
+            Stem(start=0, dur=1, pitch=36, vel=100, chan=0),
+            Stem(start=4, dur=1, pitch=36, vel=100, chan=0),
+            Stem(start=4.5, dur=1, pitch=36, vel=100, chan=0),
+        ]
+    }
+    align = density_alignment(stems, spec)
+    assert align["a"] == {"expected": 0.5, "actual": 0.25}
+    assert align["b"] == {"expected": 0.25, "actual": 0.5}
+
+
+def test_audio_stats():
+    audio = np.array([0.5, -0.5, 0.0], dtype=float)
+    stats = audio_stats(audio)
+    assert stats["peak_db"] == pytest.approx(-6.0206, abs=1e-3)
+    assert stats["rms_db"] == pytest.approx(-7.7815, abs=1e-3)


### PR DESCRIPTION
## Summary
- add `core.eval_metrics` with chord-tone coverage, voice-leading smoothness, rhythmic stability, cadence fill rate, density alignment, and audio peak/RMS
- expose `evaluate_render` and write `metrics.json` bundles in `main_render`
- cover metrics with unit tests

## Testing
- `pytest tests/test_eval_metrics.py`
- `pytest` *(fails: The starlette.testclient module requires the httpx package to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c302e62e5883258830710a2622c79d