### PR TITLE
Add Tauri-based launcher and simple home screen

### DIFF
--- a/start.py
+++ b/start.py
@@ -74,7 +74,12 @@ def main() -> None:
     else:
         python_path, _ = _venv_paths(str(env_dir))
 
-    subprocess.run([str(python_path), "-m", "main_render", *sys.argv[1:]], check=True)
+    os.environ["PATH"] = f"{python_path.parent}{os.pathsep}{os.environ['PATH']}"
+    try:
+        subprocess.run(["npm", "run", "tauri", "dev"], check=True)
+    except subprocess.CalledProcessError:
+        print("Failed to launch Tauri UI", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tauri-ui/index.html
+++ b/tauri-ui/index.html
@@ -6,58 +6,23 @@
     <style>
       body {
         margin: 0;
+        height: 100vh;
         display: flex;
         flex-direction: column;
+        justify-content: center;
         align-items: center;
+        background-color: #000;
+        color: #fff;
         font-family: sans-serif;
-        padding: 1rem;
       }
-      label {
-        display: block;
-        margin-top: 0.5rem;
-      }
-      input {
-        width: 300px;
-      }
-      button {
-        margin-top: 1rem;
-        padding: 0.5rem 1rem;
+      .icon {
+        font-size: 64px;
+        margin-bottom: 1rem;
       }
     </style>
   </head>
   <body>
-    <h1>Music Generator</h1>
-    <label>Song Spec <input id="spec" value="song.json" /></label>
-    <label>Keys SFZ <input id="keys" /></label>
-    <label>Pads SFZ <input id="pads" /></label>
-    <label>Bass SFZ <input id="bass" /></label>
-    <label>Drums SFZ <input id="drums" /></label>
-    <label>Seed <input id="seed" type="number" value="42" /></label>
-    <label>Mix Path <input id="mix" value="out/mix.wav" /></label>
-    <label>Stems Dir <input id="stems" value="out/stems" /></label>
-    <button id="render">Render</button>
-    <script>
-      document.getElementById('render').addEventListener('click', async () => {
-        const args = [
-          '--spec', document.getElementById('spec').value,
-          '--seed', document.getElementById('seed').value,
-          '--mix', document.getElementById('mix').value,
-          '--stems', document.getElementById('stems').value,
-        ];
-        const keys = document.getElementById('keys').value;
-        if (keys) args.push('--keys-sfz', keys);
-        const pads = document.getElementById('pads').value;
-        if (pads) args.push('--pads-sfz', pads);
-        const bass = document.getElementById('bass').value;
-        if (bass) args.push('--bass-sfz', bass);
-        const drums = document.getElementById('drums').value;
-        if (drums) args.push('--drums-sfz', drums);
-        try {
-          await window.__TAURI__.invoke('run_python_script', { script: 'start.py', args });
-        } catch (e) {
-          console.error(e);
-        }
-      });
-    </script>
+    <div class="icon">🎵</div>
+    <div>Music Generator</div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Launch Tauri UI from `start.py` instead of CLI renderer
- Centered black home screen with music note icon

## Testing
- `pytest tests/test_webui_health.py::test_health_check -q` *(fails: The starlette.testclient module requires the httpx package to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c305707d348325a64dd758bfa94bca