### PR TITLE
Normalize density metrics to 0-1 range

### DIFF
--- a/tests/test_eval_metrics.py
+++ b/tests/test_eval_metrics.py
@@ -106,8 +106,8 @@ def test_density_alignment():
         ]
     }
     align = density_alignment(stems, spec)
-    assert align["a"] == {"expected": 0.5, "actual": 0.25}
-    assert align["b"] == {"expected": 0.25, "actual": 0.5}
+    assert align["a"] == {"expected": 0.5, "actual": 0.5}
+    assert align["b"] == {"expected": 0.25, "actual": 1.0}
 
 
 def test_audio_stats():


### PR DESCRIPTION
## Summary
- Normalize section note density by highest observed value
- Clamp density metrics to [0,1]
- Update density alignment tests for normalized results

## Testing
- `pytest tests/test_eval_metrics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c306764e808325954bf4e782a1e83d