### PR TITLE
Handle silent audio in audio_stats

### DIFF
--- a/core/eval_metrics.py
+++ b/core/eval_metrics.py
@@ -112,12 +112,14 @@ def density_alignment(stems: Mapping[str, Sequence[Stem]], spec: SongSpec) -> Di
 def audio_stats(audio: np.ndarray) -> Dict[str, float]:
     """Return peak and RMS levels in dBFS for ``audio``."""
     if audio.size == 0:
-        return {"peak_db": float("-inf"), "rms_db": float("-inf")}
+        return {"peak_db": 0.0, "rms_db": 0.0}
     peak = float(np.max(np.abs(audio)))
     rms = float(np.sqrt(np.mean(np.square(audio))))
-    peak_db = -np.inf if peak <= 0 else 20 * np.log10(peak)
-    rms_db = -np.inf if rms <= 0 else 20 * np.log10(rms)
-    return {"peak_db": peak_db, "rms_db": rms_db}
+    if peak <= 0.0 and rms <= 0.0:
+        return {"peak_db": 0.0, "rms_db": 0.0}
+    peak_db = 20 * np.log10(peak) if peak > 0.0 else 0.0
+    rms_db = 20 * np.log10(rms) if rms > 0.0 else 0.0
+    return {"peak_db": float(peak_db), "rms_db": float(rms_db)}
 
 
 def evaluate_render(stems: Mapping[str, Sequence[Stem]], spec: SongSpec, audio: np.ndarray) -> Dict[str, object]:

--- a/tests/test_eval_metrics.py
+++ b/tests/test_eval_metrics.py
@@ -115,3 +115,17 @@ def test_audio_stats():
     stats = audio_stats(audio)
     assert stats["peak_db"] == pytest.approx(-6.0206, abs=1e-3)
     assert stats["rms_db"] == pytest.approx(-7.7815, abs=1e-3)
+
+
+def test_audio_stats_silence():
+    audio = np.zeros(5, dtype=float)
+    stats = audio_stats(audio)
+    assert stats["peak_db"] == 0.0
+    assert stats["rms_db"] == 0.0
+
+
+def test_audio_stats_empty():
+    audio = np.array([], dtype=float)
+    stats = audio_stats(audio)
+    assert stats["peak_db"] == 0.0
+    assert stats["rms_db"] == 0.0


### PR DESCRIPTION
## Summary
- Return 0 dB for peak and RMS when audio is empty or silent
- Test silent and empty audio scenarios for `audio_stats`

## Testing
- `python -m pytest tests/test_eval_metrics.py::test_audio_stats tests/test_eval_metrics.py::test_audio_stats_silence tests/test_eval_metrics.py::test_audio_stats_empty -q`
- `python -m pytest tests/test_eval_metrics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3077c37488325ad6ccee68212e3cd