### PR TITLE
Handle silent audio in stats

### DIFF
--- a/core/eval_metrics.py
+++ b/core/eval_metrics.py
@@ -112,9 +112,11 @@ def density_alignment(stems: Mapping[str, Sequence[Stem]], spec: SongSpec) -> Di
 def audio_stats(audio: np.ndarray) -> Dict[str, float]:
     """Return peak and RMS levels in dBFS for ``audio``."""
     if audio.size == 0:
-        return {"peak_db": float("-inf"), "rms_db": float("-inf")}
+        return {"peak_db": 0.0, "rms_db": 0.0}
     peak = float(np.max(np.abs(audio)))
     rms = float(np.sqrt(np.mean(np.square(audio))))
+    if peak == 0.0 and rms == 0.0:
+        return {"peak_db": 0.0, "rms_db": 0.0}
     peak_db = -np.inf if peak <= 0 else 20 * np.log10(peak)
     rms_db = -np.inf if rms <= 0 else 20 * np.log10(rms)
     return {"peak_db": peak_db, "rms_db": rms_db}

--- a/tests/test_eval_metrics.py
+++ b/tests/test_eval_metrics.py
@@ -118,6 +118,12 @@ def test_audio_stats():
     assert stats["rms_db"] == pytest.approx(-7.7815, abs=1e-3)
 
 
+def test_audio_stats_silence():
+    audio = np.zeros(4, dtype=float)
+    stats = audio_stats(audio)
+    assert stats == {"peak_db": 0.0, "rms_db": 0.0}
+
+
 def test_evaluate_render_structure():
     spec = _basic_spec()
     stems = {


### PR DESCRIPTION
## Summary
- ensure `audio_stats` returns 0 dB values for empty or silent audio
- add regression test for silent audio

## Testing
- `pytest tests/test_eval_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_68c30876f33c832585fae53f9f5512b0