### PR TITLE
Refactor Tauri build config

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,11 +4,11 @@
     "productName": "Blossom Music Generator",
     "version": "0.1.0"
   },
+  "build": {
+    "distDir": "../tauri-ui",
+    "devPath": "../tauri-ui"
+  },
   "tauri": {
-    "build": {
-      "distDir": "../tauri-ui",
-      "devPath": "../tauri-ui"
-    },
     "windows": [
       {
         "title": "Music Generator",


### PR DESCRIPTION
## Summary
- move `build` configuration from `tauri` section to top level of Tauri config
- ensure `tauri` section only retains window settings

## Testing
- `pytest` *(fails: Form data requires "python-multipart" to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c30ddfb2e483259987618017cfd0d2