### PR TITLE
Use ab_eval.json for A/B evaluation results

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ the specified output directory:
 python scripts/ab_eval.py --spec path/to/spec.json --seed 42 --out ab_bundle
 ```
 
-The resulting bundle contains WAV files, stem JSON and `metrics.json` /
+The resulting bundle contains WAV files, stem JSON and `ab_eval.json` /
 `metrics.csv` summaries.  These metrics cover note diversity, inter-onset
 interval histograms, cadence fill rates and section-wise loudness. See
 [`docs/ab_harness.md`](docs/ab_harness.md) for details on the metrics and

--- a/docs/ab_harness.md
+++ b/docs/ab_harness.md
@@ -25,9 +25,9 @@ ab_bundle/
 ├── algorithmic_stems.json
 ├── learned.wav
 ├── learned_stems.json
-├── metrics.json
+├── ab_eval.json
 └── metrics.csv
 ```
 
-`metrics.json` stores structured data while `metrics.csv` provides a flattened table for quick inspection.
+`ab_eval.json` stores structured data while `metrics.csv` provides a flattened table for quick inspection.
 

--- a/scripts/ab_eval.py
+++ b/scripts/ab_eval.py
@@ -227,7 +227,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     results["learned"] = _evaluate_variant("learned", spec, "yes", args.out)
 
     # Structured JSON
-    (args.out / "metrics.json").write_text(json.dumps(results, indent=2))
+    (args.out / "ab_eval.json").write_text(json.dumps(results, indent=2))
 
     # Flattened CSV for quick inspection
     rows = []

--- a/tests/test_ab_eval.py
+++ b/tests/test_ab_eval.py
@@ -45,10 +45,10 @@ def test_ab_eval(tmp_path):
         check=True,
     )
 
-    for name in ["algorithmic.wav", "learned.wav", "metrics.json", "metrics.csv"]:
+    for name in ["algorithmic.wav", "learned.wav", "ab_eval.json", "metrics.csv"]:
         assert (out_dir / name).exists()
 
-    metrics = json.loads((out_dir / "metrics.json").read_text())
+    metrics = json.loads((out_dir / "ab_eval.json").read_text())
     for variant in metrics.values():
         for key in ["note_diversity", "ioi_histogram", "cadence_density", "section_loudness"]:
             assert key in variant


### PR DESCRIPTION
## Summary
- Store structured A/B evaluation metrics in `ab_eval.json`
- Update A/B harness documentation and README to reference `ab_eval.json`
- Adjust tests to expect new `ab_eval.json` schema

## Testing
- `pytest tests/test_ab_eval.py::test_ab_eval -q`


------
https://chatgpt.com/codex/tasks/task_e_68c315048400832585ae4b41f89c8ec5