### PR TITLE
Add asynchronous web UI with job-based rendering

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ pytest
 fastapi
 httpx
 uvicorn
+
+jinja2

--- a/webui/app.py
+++ b/webui/app.py
@@ -1,24 +1,67 @@
 from __future__ import annotations
 
+import json
+import re
+import shutil
 import subprocess
 import sys
 import tempfile
-import shutil
+import threading
+import uuid
 from pathlib import Path
 
-from fastapi import FastAPI, Form
-from fastapi.responses import HTMLResponse, Response
+from fastapi import (
+    FastAPI,
+    File,
+    Form,
+    HTTPException,
+    Request,
+    UploadFile,
+)
+from fastapi.responses import HTMLResponse, FileResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MAIN_RENDER = REPO_ROOT / "main_render.py"
 ASSETS_DIR = REPO_ROOT / "assets"
 
 app = FastAPI()
+app.mount("/static", StaticFiles(directory=REPO_ROOT / "webui" / "static"), name="static")
+
+templates = Jinja2Templates(directory=REPO_ROOT / "webui" / "templates")
+
+
+jobs: dict[str, dict] = {}
 
 
 def _options(kind: str) -> list[str]:
     base = ASSETS_DIR / kind
     return [p.stem for p in base.glob("*.json")]
+
+
+def _watch(job_id: str) -> None:
+    job = jobs[job_id]
+    proc: subprocess.Popen[str] = job["proc"]
+    for line in proc.stdout:  # type: ignore[attr-defined]
+        job["log"].append(line)
+        m = re.search(r"(\d+)%", line)
+        if m:
+            job["progress"] = int(m.group(1))
+        m = re.search(r"ETA[:\s]+([0-9:]+)", line)
+        if m:
+            job["eta"] = m.group(1)
+    proc.wait()
+    job["returncode"] = proc.returncode
+    job["progress"] = 100
+    if proc.returncode == 0:
+        try:
+            shutil.make_archive(job["tmpdir"] / "bundle", "zip", job["tmpdir"])
+            metrics = job["tmpdir"] / "metrics.json"
+            if metrics.exists():
+                job["metrics"] = json.loads(metrics.read_text())
+        except Exception:
+            pass
 
 
 @app.get("/health")
@@ -28,22 +71,13 @@ async def health() -> dict[str, str]:
 
 
 @app.get("/", response_class=HTMLResponse)
-async def index() -> HTMLResponse:
-    """Render a small HTML form to trigger rendering."""
-    presets = "".join(f'<option value="{p}">{p}</option>' for p in _options("presets"))
-    styles = "".join(f'<option value="{s}">{s}</option>' for s in _options("styles"))
-    html = f"""
-    <html><body>
-    <form action="/render" method="post">
-        <label>Preset <select name="preset">{presets}</select></label><br>
-        <label>Style <select name="style"><option value="">(default)</option>{styles}</select></label><br>
-        <label>Seed <input type="number" name="seed" value="42"/></label><br>
-        <label>Minutes <input type="number" step="0.1" name="minutes"/></label><br>
-        <button type="submit">Render</button>
-    </form>
-    </body></html>
-    """
-    return HTMLResponse(html)
+async def index(request: Request) -> HTMLResponse:
+    presets = _options("presets")
+    styles = _options("styles")
+    return templates.TemplateResponse(
+        "index.html",
+        {"request": request, "presets": presets, "styles": styles},
+    )
 
 
 @app.post("/render")
@@ -52,28 +86,102 @@ async def render(
     style: str = Form(""),
     seed: int = Form(42),
     minutes: float | None = Form(None),
-) -> Response:
-    """Run the main renderer and return a zip bundle."""
+    sections: int | None = Form(None),
+    name: str = Form("output"),
+    mix_config: UploadFile | None = File(None),
+    arrange_config: UploadFile | None = File(None),
+    phrase: bool = Form(False),
+    preview: int | None = Form(None),
+) -> dict:
     tmpdir = Path(tempfile.mkdtemp())
-    try:
-        cmd = [
-            sys.executable,
-            str(MAIN_RENDER),
-            "--preset",
-            preset,
-            "--seed",
-            str(seed),
-            "--bundle",
-            str(tmpdir),
-        ]
-        if style:
-            cmd += ["--style", style]
-        if minutes is not None:
-            cmd += ["--minutes", str(minutes)]
-        subprocess.run(cmd, check=True)
-        archive = shutil.make_archive(tmpdir / "bundle", "zip", tmpdir)
-        data = Path(archive).read_bytes()
-        headers = {"Content-Disposition": "attachment; filename=bundle.zip"}
-        return Response(content=data, media_type="application/zip", headers=headers)
-    finally:
-        shutil.rmtree(tmpdir, ignore_errors=True)
+    mix_path = tmpdir / "mix.wav"
+    stems_dir = tmpdir / "stems"
+    cmd: list[str] = [
+        sys.executable,
+        str(MAIN_RENDER),
+        "--preset",
+        preset,
+        "--seed",
+        str(seed),
+        "--bundle",
+        str(tmpdir),
+        "--mix",
+        str(mix_path),
+        "--stems",
+        str(stems_dir),
+    ]
+    if style:
+        cmd += ["--style", style]
+    if minutes is not None:
+        cmd += ["--minutes", str(minutes)]
+    if sections is not None:
+        cmd += ["--sections", str(sections)]
+    if phrase:
+        cmd += ["--use-phrase-model", "yes"]
+    if preview is not None:
+        cmd += ["--preview", str(preview)]
+    if mix_config is not None:
+        mix_path = tmpdir / "mix_config.json"
+        mix_path.write_bytes(await mix_config.read())
+        cmd += ["--mix-config", str(mix_path)]
+    if arrange_config is not None:
+        arr_path = tmpdir / "arrange_config.json"
+        arr_path.write_bytes(await arrange_config.read())
+        cmd += ["--arrange-config", str(arr_path)]
+
+    proc = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+    )
+    job_id = uuid.uuid4().hex
+    jobs[job_id] = {
+        "proc": proc,
+        "tmpdir": tmpdir,
+        "log": [],
+        "progress": 0,
+        "eta": None,
+        "name": name,
+    }
+    threading.Thread(target=_watch, args=(job_id,), daemon=True).start()
+    return {"job_id": job_id}
+
+
+@app.get("/jobs/{job_id}")
+async def job_status(job_id: str) -> dict:
+    job = jobs.get(job_id)
+    if not job:
+        raise HTTPException(404, "job not found")
+    status = "running"
+    if job.get("returncode") is not None:
+        status = "completed" if job["returncode"] == 0 else "error"
+    return {
+        "status": status,
+        "progress": job.get("progress", 0),
+        "eta": job.get("eta"),
+        "log": job.get("log", []),
+        "metrics": job.get("metrics"),
+    }
+
+
+@app.post("/jobs/{job_id}/cancel")
+async def cancel(job_id: str) -> dict:
+    job = jobs.get(job_id)
+    if not job:
+        raise HTTPException(404, "job not found")
+    proc = job["proc"]
+    if proc.poll() is None:
+        proc.terminate()
+    job["returncode"] = -1
+    return {"status": "cancelled"}
+
+
+@app.get("/jobs/{job_id}/artifact/{name}")
+async def artifact(job_id: str, name: str):
+    job = jobs.get(job_id)
+    if not job:
+        raise HTTPException(404, "job not found")
+    path = job["tmpdir"] / name
+    if not path.exists():
+        raise HTTPException(404, "not found")
+    suffix = Path(name).suffix
+    filename = f"{job.get('name', 'output')}{suffix}"
+    return FileResponse(path, filename=filename)

--- a/webui/static/app.js
+++ b/webui/static/app.js
@@ -1,0 +1,67 @@
+let jobId = null;
+
+function $(id){ return document.getElementById(id); }
+
+$('dice').onclick = () => {
+  $('seed').value = Math.floor(Math.random()*1e9);
+};
+
+$('start').onclick = async () => {
+  const fd = new FormData();
+  fd.append('preset', $('preset').value);
+  fd.append('style', $('style').value);
+  if ($('minutes').value) fd.append('minutes', $('minutes').value);
+  if ($('sections').value) fd.append('sections', $('sections').value);
+  fd.append('seed', $('seed').value);
+  fd.append('name', $('name').value);
+  const mix = $('mix_config').files[0];
+  if (mix) fd.append('mix_config', mix);
+  const arr = $('arrange_config').files[0];
+  if (arr) fd.append('arrange_config', arr);
+  if ($('phrase').checked) fd.append('phrase', 'true');
+  if ($('preview').value) fd.append('preview', $('preview').value);
+
+  const resp = await fetch('/render', {method:'POST', body: fd});
+  const data = await resp.json();
+  jobId = data.job_id;
+  $('start').disabled = true;
+  $('cancel').disabled = false;
+  $('log').textContent = '';
+  $('results').hidden = true;
+  poll();
+};
+
+$('cancel').onclick = async () => {
+  if (!jobId) return;
+  await fetch(`/jobs/${jobId}/cancel`, {method:'POST'});
+};
+
+async function poll(){
+  if (!jobId) return;
+  const resp = await fetch(`/jobs/${jobId}`);
+  if (!resp.ok) return;
+  const data = await resp.json();
+  $('progress').value = data.progress || 0;
+  $('eta').textContent = data.eta ? `ETA: ${data.eta}` : '';
+  $('log').textContent = data.log.join('');
+  if (data.status === 'running'){
+    setTimeout(poll, 1000);
+  } else {
+    $('cancel').disabled = true;
+    $('start').disabled = false;
+    if (data.status === 'completed'){
+      $('results').hidden = false;
+      const links = $('links');
+      links.innerHTML = '';
+      for (const n of ['mix.wav','stems.mid','bundle.zip']){
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        a.href = `/jobs/${jobId}/artifact/${n}`;
+        a.textContent = n;
+        li.appendChild(a);
+        links.appendChild(li);
+      }
+      $('metrics').textContent = JSON.stringify(data.metrics || {}, null, 2);
+    }
+  }
+}

--- a/webui/templates/index.html
+++ b/webui/templates/index.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Blossom Render</title>
+  <style>
+    body { font-family: sans-serif; margin: 1em; }
+    label { display: block; margin-bottom: 0.5em; }
+    #controls { margin-top: 1em; }
+    #log { background: #111; color: #0f0; padding: 0.5em; height: 200px; overflow-y: scroll; }
+    #results { margin-top: 1em; }
+  </style>
+</head>
+<body>
+  <div id="inputs">
+    <label>Preset
+      <select id="preset">
+        {% for p in presets %}<option value="{{ p }}"{% if loop.first %} selected{% endif %}>{{ p }}</option>{% endfor %}
+      </select>
+    </label>
+    <label>Style
+      <select id="style">
+        <option value="">(default)</option>
+        {% for s in styles %}<option value="{{ s }}">{{ s }}</option>{% endfor %}
+      </select>
+    </label>
+    <label>Minutes <input type="number" step="0.1" id="minutes" /></label>
+    <label>Sections <input type="number" id="sections" /></label>
+    <label>Seed <input type="number" id="seed" value="42" /> <button id="dice" type="button">🎲</button></label>
+    <label>Output name <input type="text" id="name" value="output" /></label>
+  </div>
+
+  <details id="advanced">
+    <summary>Advanced</summary>
+    <label>Mix config <input type="file" id="mix_config" /></label>
+    <label>Arrange config <input type="file" id="arrange_config" /></label>
+    <label><input type="checkbox" id="phrase" /> Phrase backend</label>
+    <label>Preview bars <input type="number" id="preview" /></label>
+  </details>
+
+  <div id="controls">
+    <button id="start" type="button">Start</button>
+    <button id="cancel" type="button" disabled>Cancel</button>
+    <progress id="progress" value="0" max="100"></progress>
+    <span id="eta"></span>
+  </div>
+
+  <pre id="log"></pre>
+
+  <div id="results" hidden>
+    <h3>Results</h3>
+    <ul id="links"></ul>
+    <pre id="metrics"></pre>
+  </div>
+
+  <script src="/static/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Build front-end template and script for rendering controls, progress, and results
- Serve static assets and add background job system with polling/cancel endpoints
- Include jinja2 dependency

## Testing
- `pytest` *(fails: AssertionError: jinja2 must be installed)*
- `pip install jinja2` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c3151b76608325b1f444dfe91769b9