### PR TITLE
feat: add interactive Tauri UI

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2021"
 
 [dependencies]
 tauri = { version = "1" }
+regex = "1"
+tempfile = "3"
 
 [build-dependencies]
 tauri-build = { version = "1" }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,25 +1,175 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use std::process::Command;
+use std::{
+    fs,
+    io::{BufRead, BufReader},
+    path::Path,
+    process::{Command, Stdio},
+    sync::{Arc, Mutex},
+    thread,
+};
+
+use regex::Regex;
+use tauri::{State, Window};
+
+struct PidState {
+    pid: Arc<Mutex<Option<u32>>>,
+}
+
+fn list_from_dir(dir: &Path) -> Result<Vec<String>, String> {
+    let mut items = Vec::new();
+    for entry in fs::read_dir(dir).map_err(|e| e.to_string())? {
+        let entry = entry.map_err(|e| e.to_string())?;
+        if let Some(stem) = entry.path().file_stem().and_then(|s| s.to_str()) {
+            items.push(stem.to_string());
+        }
+    }
+    Ok(items)
+}
 
 #[tauri::command]
-fn run_python_script(script: &str, args: Vec<String>) -> Result<String, String> {
-    let output = Command::new("python")
-        .arg(script)
-        .args(args)
-        .output()
+fn list_presets() -> Result<Vec<String>, String> {
+    list_from_dir(Path::new("assets/presets"))
+}
+
+#[tauri::command]
+fn list_styles() -> Result<Vec<String>, String> {
+    list_from_dir(Path::new("assets/styles"))
+}
+
+#[tauri::command]
+fn start_render(
+    window: Window,
+    state: State<PidState>,
+    preset: String,
+    style: Option<String>,
+    seed: i32,
+    minutes: Option<f32>,
+) -> Result<(), String> {
+    let bundle_dir = tempfile::tempdir()
+        .map_err(|e| e.to_string())?
+        .into_path();
+
+    let mut args = vec![
+        "main_render.py".into(),
+        "--preset".into(),
+        preset,
+        "--seed".into(),
+        seed.to_string(),
+        "--bundle".into(),
+        bundle_dir.to_string_lossy().into_owned(),
+        "--verbose".into(),
+    ];
+    if let Some(style) = style {
+        if !style.is_empty() {
+            args.push("--style".into());
+            args.push(style);
+        }
+    }
+    if let Some(m) = minutes {
+        args.push("--minutes".into());
+        args.push(m.to_string());
+    }
+
+    let mut child = Command::new("python")
+        .args(&args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
         .map_err(|e| e.to_string())?;
 
-    if output.status.success() {
-        Ok(String::from_utf8_lossy(&output.stdout).to_string())
-    } else {
-        Err(String::from_utf8_lossy(&output.stderr).to_string())
+    let pid = child.id();
+    {
+        let mut lock = state.pid.lock().unwrap();
+        *lock = Some(pid);
     }
+
+    if let Some(stdout) = child.stdout.take() {
+        let win = window.clone();
+        thread::spawn(move || {
+            let reader = BufReader::new(stdout);
+            let re = Regex::new(r"(\d+)/(\d+)").ok();
+            for line in reader.lines().flatten() {
+                let _ = win.emit("log", line.clone());
+                if let Some(re) = &re {
+                    if let Some(caps) = re.captures(&line) {
+                        if let (Ok(cur), Ok(total)) =
+                            (caps[1].parse::<u64>(), caps[2].parse::<u64>())
+                        {
+                            let pct = cur as f64 / total as f64 * 100.0;
+                            let _ = win.emit("progress", pct);
+                        }
+                    }
+                }
+                if let Some(start) = line.find('<') {
+                    if let Some(end) = line[start + 1..].find(',') {
+                        let eta = line[start + 1..start + 1 + end].trim().to_string();
+                        let _ = win.emit("eta", eta);
+                    }
+                }
+            }
+        });
+    }
+
+    if let Some(stderr) = child.stderr.take() {
+        let win = window.clone();
+        thread::spawn(move || {
+            let reader = BufReader::new(stderr);
+            for line in reader.lines().flatten() {
+                let _ = win.emit("log", line);
+            }
+        });
+    }
+
+    let win = window.clone();
+    thread::spawn(move || {
+        let status = child.wait();
+        if let Ok(status) = status {
+            if status.success() {
+                let zip_path = bundle_dir.with_extension("zip");
+                let _ = Command::new("python")
+                    .args([
+                        "-c",
+                        "import shutil,sys; shutil.make_archive(sys.argv[1], 'zip', sys.argv[1])",
+                        bundle_dir.to_str().unwrap(),
+                    ])
+                    .output();
+                let _ = win.emit("result", zip_path.to_string_lossy().to_string());
+                let _ = fs::remove_dir_all(&bundle_dir);
+            } else {
+                let _ = win.emit("error", "render failed");
+            }
+        } else {
+            let _ = win.emit("error", "render failed");
+        }
+    });
+
+    Ok(())
+}
+
+#[tauri::command]
+fn cancel_render(state: State<PidState>) -> Result<(), String> {
+    let pid_opt = { state.pid.lock().unwrap().take() };
+    if let Some(pid) = pid_opt {
+        #[cfg(unix)]
+        let _ = Command::new("kill").arg(pid.to_string()).output();
+        #[cfg(windows)]
+        let _ = Command::new("taskkill").args(["/PID", &pid.to_string(), "/F"]).output();
+    }
+    Ok(())
 }
 
 fn main() {
     tauri::Builder::default()
-        .invoke_handler(tauri::generate_handler![run_python_script])
+        .manage(PidState {
+            pid: Arc::new(Mutex::new(None)),
+        })
+        .invoke_handler(tauri::generate_handler![
+            list_presets,
+            list_styles,
+            start_render,
+            cancel_render
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/tauri-ui/index.html
+++ b/tauri-ui/index.html
@@ -2,27 +2,137 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>Music Generator</title>
+    <title>Blossom Music Generator</title>
     <style>
       body {
         margin: 0;
-        height: 100vh;
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
-        background-color: #000;
+        padding: 1rem;
+        background: #111;
         color: #fff;
         font-family: sans-serif;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
       }
-      .icon {
-        font-size: 64px;
-        margin-bottom: 1rem;
+      .row {
+        display: flex;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+      }
+      select, input, button {
+        padding: 0.4rem;
+      }
+      #logs {
+        background: #222;
+        padding: 0.5rem;
+        flex: 1;
+        overflow-y: auto;
+      }
+      progress {
+        width: 100%;
       }
     </style>
   </head>
   <body>
-    <div class="icon">🎵</div>
-    <div>Music Generator</div>
+    <div class="row">
+      <label>Preset <select id="preset"></select></label>
+      <label>Style <select id="style"><option value="">(default)</option></select></label>
+      <label>Seed <input type="number" id="seed" value="42" /></label>
+      <label>Minutes <input type="number" step="0.1" id="minutes" /></label>
+    </div>
+    <div class="row">
+      <button id="start-btn">Start</button>
+      <button id="cancel-btn" style="display:none;">Cancel</button>
+      <button id="download-btn" style="display:none;">Download bundle</button>
+    </div>
+    <progress id="progress" value="0" max="100"></progress>
+    <div id="eta"></div>
+    <pre id="logs"></pre>
+    <script>
+      const { invoke } = window.__TAURI__;
+      const presetSel = document.getElementById('preset');
+      const styleSel = document.getElementById('style');
+      const seedInput = document.getElementById('seed');
+      const minInput = document.getElementById('minutes');
+      const startBtn = document.getElementById('start-btn');
+      const cancelBtn = document.getElementById('cancel-btn');
+      const downloadBtn = document.getElementById('download-btn');
+      const prog = document.getElementById('progress');
+      const eta = document.getElementById('eta');
+      const logs = document.getElementById('logs');
+      let bundlePath = null;
+
+      async function loadOptions() {
+        try {
+          const presets = await invoke('list_presets');
+          presets.forEach(p => {
+            const opt = document.createElement('option');
+            opt.value = p; opt.textContent = p;
+            presetSel.appendChild(opt);
+          });
+          if (presets.length) presetSel.value = presets[0];
+          const styles = await invoke('list_styles');
+          styles.forEach(s => {
+            const opt = document.createElement('option');
+            opt.value = s; opt.textContent = s;
+            styleSel.appendChild(opt);
+          });
+        } catch (e) {
+          logs.textContent += e + '\n';
+        }
+      }
+
+      window.__TAURI__.event.listen('log', e => {
+        logs.textContent += e.payload + '\n';
+        logs.scrollTop = logs.scrollHeight;
+      });
+      window.__TAURI__.event.listen('progress', e => {
+        prog.value = e.payload;
+      });
+      window.__TAURI__.event.listen('eta', e => {
+        eta.textContent = 'ETA: ' + e.payload;
+      });
+      window.__TAURI__.event.listen('result', e => {
+        bundlePath = e.payload;
+        downloadBtn.style.display = 'inline-block';
+        cancelBtn.style.display = 'none';
+        startBtn.disabled = false;
+      });
+      window.__TAURI__.event.listen('error', e => {
+        logs.textContent += 'Error: ' + e.payload + '\n';
+        cancelBtn.style.display = 'none';
+        startBtn.disabled = false;
+      });
+
+      startBtn.addEventListener('click', async () => {
+        logs.textContent = '';
+        downloadBtn.style.display = 'none';
+        prog.value = 0;
+        eta.textContent = '';
+        startBtn.disabled = true;
+        cancelBtn.style.display = 'inline-block';
+        bundlePath = null;
+        await invoke('start_render', {
+          preset: presetSel.value,
+          style: styleSel.value,
+          seed: parseInt(seedInput.value),
+          minutes: minInput.value ? parseFloat(minInput.value) : null
+        });
+      });
+
+      cancelBtn.addEventListener('click', async () => {
+        await invoke('cancel_render');
+        cancelBtn.style.display = 'none';
+        startBtn.disabled = false;
+      });
+
+      downloadBtn.addEventListener('click', () => {
+        if (bundlePath) {
+          window.__TAURI__.shell.open(bundlePath);
+        }
+      });
+
+      loadOptions();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- replace placeholder index with single-page render interface
- expose Tauri commands for presets, styles, and async rendering with progress and cancel
- add required regex and tempfile dependencies

## Testing
- `cargo check` *(fails: The system library `gobject-2.0` required by crate `gobject-sys` was not found)*
- `pytest -q` *(fails: Form data requires "python-multipart" to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c3152153e4832596a1b8f4e630bb66