### PR TITLE
Handle render subprocess with cancelation

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 tauri = { version = "1" }
 regex = "1"
 tempfile = "3"
+serde_json = "1"
 
 [build-dependencies]
 tauri-build = { version = "1" }


### PR DESCRIPTION
## Summary
- keep main_render.py child handle and bundle path in backend
- stream stdout/stderr lines with progress percent and ETA
- allow canceling renders and clean up temporary output

## Testing
- `cargo check` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c3187e5e0483259fd60a97f94e4f2d