### PR TITLE
Add Tauri build script

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    tauri_build::build();
+}


### PR DESCRIPTION
## Summary
- Add build.rs script in src-tauri to run tauri_build::build()

## Testing
- `cargo tauri dev` *(fails: no such command `tauri`)*
- `python start.py` *(fails: command '/root/.pyenv/shims/python3.10' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c31a8aadfc8325bb5709da320fdc52