### PR TITLE
Handle optional SFZ sampler and soundfile dependencies

### DIFF
--- a/core/render.py
+++ b/core/render.py
@@ -15,13 +15,17 @@ import math
 import numpy as np
 
 from .stems import Stem, _steps_per_beat
-from .sfz_sampler import SFZSampler
+try:  # pragma: no cover - optional dependency
+    from .sfz_sampler import SFZSampler
+except ImportError:  # pragma: no cover - handled at runtime
+    SFZSampler = None  # type: ignore
 from .utils import note_to_sample_indices
 from . import synth
 
 try:  # pragma: no cover - optional dependency
     import soundfile as sf  # type: ignore
 except Exception:  # pragma: no cover - handled at runtime
+    # ``soundfile`` is optional; simple synthesis fallbacks are used when missing
     sf = None  # type: ignore
 
 
@@ -212,7 +216,7 @@ def _render_instrument(
     if not notes:
         return np.zeros(0, dtype=np.float32)
 
-    if sfz is not None:
+    if sfz is not None and SFZSampler is not None:
         try:
             sampler = SFZSampler(sfz)
             return sampler.render(notes, sample_rate=sr)


### PR DESCRIPTION
## Summary
- Guard import of `SFZSampler` so module loads when dependency is missing
- Skip SFZ rendering when sampler isn't available
- Clarify that `soundfile` is optional and fallbacks will be used if absent

## Testing
- `pytest tests/test_render_keys.py tests/test_render_piano.py tests/test_render_pads.py tests/test_drum_round_robin.py tests/test_render_sfz_instruments.py -q`
- `pytest -q` *(fails: RuntimeError: Form data requires "python-multipart" to be installed)*
- `pip install python-multipart` *(fails: Could not find a version that satisfies the requirement python-multipart)*

------
https://chatgpt.com/codex/tasks/task_e_68c31d3ddfb08325b2d55b268cb78b5f