### PR TITLE
Add density bucket tests

### DIFF
--- a/tests/test_density_bucket.py
+++ b/tests/test_density_bucket.py
@@ -1,0 +1,21 @@
+import os, sys, pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.utils import density_bucket_from_float
+
+
+def test_density_bucket_sparse():
+    assert density_bucket_from_float(0.2) == "sparse"
+
+
+def test_density_bucket_med():
+    assert density_bucket_from_float(0.5) == "med"
+
+
+def test_density_bucket_busy():
+    assert density_bucket_from_float(0.9) == "busy"
+
+
+def test_density_bucket_malformed_input_defaults_to_med():
+    assert density_bucket_from_float("not-a-number") == "med"


### PR DESCRIPTION
## Summary
- add tests for `density_bucket_from_float`

## Testing
- `pytest tests/test_density_bucket.py`
- `pytest` *(fails: RuntimeError: Form data requires "python-multipart" to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c31db3108083259c47f843008653d5