### PR TITLE
Use configurable RNG for sampling

### DIFF
--- a/core/phrase_model.py
+++ b/core/phrase_model.py
@@ -202,6 +202,7 @@ def generate_phrase(
         raise RuntimeError(f"no model available for {inst}")
 
     prompt = list(prompt or [])
+    rng = np.random.default_rng(seed)
 
     def _sample_loop():  # pragma: no cover - relies on optional deps
         history = list(prompt)
@@ -238,6 +239,7 @@ def generate_phrase(
                 temperature=temperature,
                 repetition_penalty=repetition_penalty,
                 history=history,
+                rng=rng,
             )
             history.append(next_tok)
         return history[len(prompt):]

--- a/core/sampling.py
+++ b/core/sampling.py
@@ -85,10 +85,11 @@ def sample(
     temperature: float = 1.0,
     repetition_penalty: float = 1.0,
     history: Sequence[int] = (),
+    rng: np.random.Generator = np.random.default_rng(),
 ) -> int:
     """Sample an index from ``logits`` using the configured strategies."""
 
     logits = apply_temperature(logits, temperature)
     logits = apply_repetition_penalty(logits, history, repetition_penalty)
     probs = filter_top_k_top_p(logits, top_k, top_p)
-    return int(np.random.choice(len(probs), p=probs))
+    return int(rng.choice(len(probs), p=probs))

--- a/tests/test_sampling_rng.py
+++ b/tests/test_sampling_rng.py
@@ -1,0 +1,9 @@
+import numpy as np
+from core.sampling import sample
+
+
+def test_sample_rng_seed_reproducibility():
+    logits = np.array([1.0, 3.0], dtype=np.float32)
+    rng1 = np.random.default_rng(42)
+    rng2 = np.random.default_rng(42)
+    assert sample(logits, rng=rng1) == sample(logits, rng=rng2)

--- a/training/phrase_models/train_phrase_models.py
+++ b/training/phrase_models/train_phrase_models.py
@@ -15,6 +15,7 @@ The exported TorchScript/ONNX artefacts are still compatible with
 from pathlib import Path
 from typing import Sequence, Union
 
+import numpy as np
 import torch
 import torch.nn as nn
 
@@ -150,7 +151,7 @@ def main() -> None:
         .cpu()
         .numpy()
     )
-    _ = sample(logits, top_k=4, top_p=0.9)
+    _ = sample(logits, top_k=4, top_p=0.9, rng=np.random.default_rng(0))
 
     # Bass phrase: chord conditioned
     bass_in, bass_hidden, bass_out = 12, 32, 12  # additional dims for chords


### PR DESCRIPTION
## Summary
- allow callers to supply an RNG to `core.sampling.sample`
- seed a local `Generator` for phrase model sampling
- add regression test for seeded sampling

## Testing
- `pytest tests/test_sampling_rng.py tests/test_phrase_model_sampling.py::test_sampler_seed_reproducibility tests/test_style_variations.py::test_phrase_style_tokens_change_output -q`

------
https://chatgpt.com/codex/tasks/task_e_68c31db5db28832591f917f6d7646543