### PR TITLE
Validate sampling parameter bounds

### DIFF
--- a/core/sampling.py
+++ b/core/sampling.py
@@ -57,6 +57,11 @@ def apply_repetition_penalty(
 def filter_top_k_top_p(logits: np.ndarray, top_k: int, top_p: float) -> np.ndarray:
     """Convert ``logits`` to probabilities after top-k and top-p filtering."""
 
+    if top_k < 0:
+        raise ValueError("top_k must be >= 0")
+    if not 0.0 <= top_p <= 1.0:
+        raise ValueError("top_p must be between 0 and 1")
+
     # Top-k filtering in logit space to avoid numerical issues with very small
     # probabilities.
     if top_k > 0 and top_k < len(logits):

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -1,0 +1,20 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import numpy as np
+import pytest
+
+from core.sampling import filter_top_k_top_p
+
+
+def test_filter_top_k_negative():
+    logits = np.array([1.0, 2.0])
+    with pytest.raises(ValueError):
+        filter_top_k_top_p(logits, top_k=-1, top_p=0.0)
+
+
+@pytest.mark.parametrize("top_p", [-0.1, 1.1])
+def test_filter_top_k_top_p_invalid_range(top_p):
+    logits = np.array([1.0, 2.0])
+    with pytest.raises(ValueError):
+        filter_top_k_top_p(logits, top_k=0, top_p=top_p)


### PR DESCRIPTION
## Summary
- enforce non-negative `top_k` and ensure `top_p` is within [0, 1]
- add unit tests covering invalid `top_k` and `top_p` usage

## Testing
- `pytest tests/test_sampling.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c31db6f0f083258dfdedc2b9c2e6a1