### PR TITLE
Improve ensure_file validation and add directory test

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -18,8 +18,11 @@ def write_json(path: str | Path, obj) -> None:
 
 def ensure_file(path: str | Path, err: str = "File missing"):
     p = Path(path)
-    if not p.exists():
-        raise FileNotFoundError(f"{err}: {p}")
+    if p.is_file():
+        return
+    if p.is_dir():
+        raise FileNotFoundError(f"{err}: expected a file but found directory: {p}")
+    raise FileNotFoundError(f"{err}: {p}")
 
 def density_bucket_from_float(x: float) -> str:
     """Map [0..1] -> 'sparse' | 'med' | 'busy'."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,13 @@
+import os, sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.utils import ensure_file
+
+
+def test_ensure_file_rejects_directory(tmp_path):
+    directory = tmp_path / "subdir"
+    directory.mkdir()
+    with pytest.raises(FileNotFoundError, match="directory"):
+        ensure_file(directory)


### PR DESCRIPTION
## Summary
- Use Path.is_file in ensure_file and raise clearer error when encountering a directory
- Add unit test verifying directories raise FileNotFoundError

## Testing
- `pytest tests/test_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c31d9b55008325879a9ddc0d35d69a