### PR TITLE
chore: remove unused Stems dataclass

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -5,7 +5,6 @@ from .pattern_synth import build_patterns_for_song
 from .stems import (
     Note,
     Stem,
-    Stems,
     bars_to_beats,
     beats_to_secs,
     enforce_register,
@@ -20,7 +19,7 @@ __all__ = [
     "SongSpec", "Section",
     "generate_satb", "parse_chord_symbol",
     "build_patterns_for_song", "build_stems_for_song", "arrange_song", "apply_dynamics",
-    "Note", "Stem", "Stems",
+    "Note", "Stem",
     "bars_to_beats", "beats_to_secs",
     "enforce_register", "dedupe_collisions",
     "evaluate_render",

--- a/core/stems.py
+++ b/core/stems.py
@@ -32,17 +32,6 @@ class Stem:
     chan: int
 
 
-@dataclass
-class Stems:
-    """Placeholder for collections of notes; same fields as :class:`Note`."""
-
-    start: float
-    dur: float
-    pitch: int
-    vel: int
-    chan: int
-
-
 def bars_to_beats(meter: str) -> int:
     """Return the number of beats contained in one bar of ``meter``.
 


### PR DESCRIPTION
## Summary
- remove placeholder `Stems` dataclass
- drop `Stems` from core exports

## Testing
- `pytest -q` *(fails: RuntimeError: Form data requires "python-multipart" to be installed)*
- `pytest tests/test_stems_properties.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c31db930e8832592311ce38206e3f8