### PR TITLE
Add landing screen for music generator

### DIFF
--- a/webui/templates/generate.html
+++ b/webui/templates/generate.html
@@ -9,9 +9,22 @@
     #controls { margin-top: 1em; }
     #log { background: #111; color: #0f0; padding: 0.5em; height: 200px; overflow-y: scroll; }
     #results { margin-top: 1em; }
+    #home {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      height: 100vh;
+      cursor: pointer;
+    }
   </style>
 </head>
 <body>
+  <div id="home">
+    <img src="{{ url_for('static', path='music.svg') }}" alt="Music icon" width="100" height="100" />
+    <div>Music Generation</div>
+  </div>
+  <div id="generator" style="display:none">
   <div id="inputs">
     <label>Preset
       <select id="preset">
@@ -52,7 +65,14 @@
     <ul id="links"></ul>
     <pre id="metrics"></pre>
   </div>
+  </div>
 
   <script src="/static/app.js"></script>
+  <script>
+    document.getElementById('home').addEventListener('click', () => {
+      document.getElementById('home').style.display = 'none';
+      document.getElementById('generator').style.display = 'block';
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `home` view with music icon and description
- hide generator controls behind `#generator` and show on icon click
- center landing icon and text with basic styling

## Testing
- ⚠️ `pytest tests/test_webui_health.py` *(missing dependency: python-multipart)*

------
https://chatgpt.com/codex/tasks/task_e_68c33745700c8325b0a1daf5dddca945