### PR TITLE
feat: add output directory picker

### DIFF
--- a/webui/static/app.js
+++ b/webui/static/app.js
@@ -1,6 +1,19 @@
 let jobId = null;
+let outputDir = '';
 
 function $(id){ return document.getElementById(id); }
+
+$('choose_outdir').onclick = () => {
+  $('outdir_picker').click();
+};
+
+$('outdir_picker').onchange = () => {
+  const file = $('outdir_picker').files[0];
+  if (file) {
+    outputDir = file.path || file.webkitRelativePath.split('/')[0];
+    $('outdir').value = outputDir;
+  }
+};
 
 $('dice').onclick = () => {
   $('seed').value = Math.floor(Math.random()*1e9);
@@ -20,6 +33,7 @@ $('start').onclick = async () => {
   if (arr) fd.append('arrange_config', arr);
   if ($('phrase').checked) fd.append('phrase', 'true');
   if ($('preview').value) fd.append('preview', $('preview').value);
+  if (outputDir) fd.append('outdir', outputDir);
 
   const resp = await fetch('/render', {method:'POST', body: fd});
   const data = await resp.json();

--- a/webui/templates/generate.html
+++ b/webui/templates/generate.html
@@ -41,6 +41,11 @@
     <label>Sections <input type="number" id="sections" /></label>
     <label>Seed <input type="number" id="seed" value="42" /> <button id="dice" type="button">🎲</button></label>
     <label>Output name <input type="text" id="name" value="output" /></label>
+    <label>Output folder
+      <input type="text" id="outdir" readonly />
+      <input type="file" id="outdir_picker" webkitdirectory directory hidden />
+      <button id="choose_outdir" type="button">📁</button>
+    </label>
   </div>
 
   <details id="advanced">


### PR DESCRIPTION
## Summary
- add output folder picker to web UI and pass selection through app server
- prompt for output directory using Tauri's `FileDialogBuilder`

## Testing
- `pytest tests/test_webui_health.py -q` *(fails: Form data requires "python-multipart" to be installed)*
- `pytest tests/test_utils.py -q`
- `cargo check` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c34206b1c48325aa6651fd94d9d59d