### PR TITLE
Expose render stage and display in UIs

### DIFF
--- a/tauri-ui/index.html
+++ b/tauri-ui/index.html
@@ -29,7 +29,10 @@
         overflow-y: auto;
       }
       progress {
-        width: 100%;
+        flex: 1;
+      }
+      #progbar {
+        align-items: center;
       }
     </style>
   </head>
@@ -45,7 +48,10 @@
       <button id="cancel-btn" style="display:none;">Cancel</button>
       <button id="download-btn" style="display:none;">Download bundle</button>
     </div>
-    <progress id="progress" value="0" max="100"></progress>
+    <div id="progbar" class="row">
+      <progress id="progress" value="0" max="100"></progress>
+      <div id="stage"></div>
+    </div>
     <div id="eta"></div>
     <pre id="logs"></pre>
     <script>
@@ -58,6 +64,7 @@
       const cancelBtn = document.getElementById('cancel-btn');
       const downloadBtn = document.getElementById('download-btn');
       const prog = document.getElementById('progress');
+      const stage = document.getElementById('stage');
       const eta = document.getElementById('eta');
       const logs = document.getElementById('logs');
       let bundlePath = null;
@@ -82,15 +89,16 @@
         }
       }
 
-      window.__TAURI__.event.listen('log', e => {
-        logs.textContent += e.payload + '\n';
-        logs.scrollTop = logs.scrollHeight;
-      });
       window.__TAURI__.event.listen('progress', e => {
-        prog.value = e.payload;
-      });
-      window.__TAURI__.event.listen('eta', e => {
-        eta.textContent = 'ETA: ' + e.payload;
+        const { line, percent, eta: eeta } = e.payload;
+        if (typeof percent === 'number') prog.value = percent;
+        if (line) {
+          logs.textContent += line + '\n';
+          logs.scrollTop = logs.scrollHeight;
+          const m = line.match(/^\s*([\w-]+):/);
+          stage.textContent = m ? m[1] : '';
+        }
+        eta.textContent = eeta ? 'ETA: ' + eeta : '';
       });
       window.__TAURI__.event.listen('result', e => {
         bundlePath = e.payload;

--- a/webui/static/app.js
+++ b/webui/static/app.js
@@ -57,6 +57,7 @@ async function poll(){
   const data = await resp.json();
   $('progress').value = data.progress || 0;
   $('eta').textContent = data.eta ? `ETA: ${data.eta}` : '';
+  $('stage').textContent = data.stage || '';
   $('log').textContent = data.log.join('');
   if (data.status === 'running'){
     setTimeout(poll, 1000);

--- a/webui/templates/generate.html
+++ b/webui/templates/generate.html
@@ -60,6 +60,7 @@
     <button id="start" type="button">Start</button>
     <button id="cancel" type="button" disabled>Cancel</button>
     <progress id="progress" value="0" max="100"></progress>
+    <span id="stage"></span>
     <span id="eta"></span>
   </div>
 


### PR DESCRIPTION
## Summary
- Parse render stage keywords from worker logs and expose `stage` via `/jobs/{job_id}`
- Show the current stage next to the progress bar in the web UI
- Surface stage information in the Tauri frontend, alongside progress and ETA

## Testing
- `pytest` *(fails: Form data requires "python-multipart" to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c347180600832588b6b4d325a50cf3