### PR TITLE
Persist recent render metadata and duplicate jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 src-tauri/target
 src-tauri/Cargo.lock
+webui/recent_renders.json

--- a/webui/static/app.js
+++ b/webui/static/app.js
@@ -3,6 +3,39 @@ let outputDir = '';
 
 function $(id){ return document.getElementById(id); }
 
+async function loadRecent(){
+  const resp = await fetch('/recent');
+  if (!resp.ok) return;
+  const data = await resp.json();
+  const list = $('recent_list');
+  if (!list) return;
+  list.innerHTML = '';
+  for (const job of data){
+    const li = document.createElement('li');
+    const span = document.createElement('span');
+    span.textContent = `${job.preset} (seed ${job.seed}) - ${job.status}`;
+    const btn = document.createElement('button');
+    btn.textContent = 'Duplicate';
+    btn.onclick = () => fillForm(job);
+    li.appendChild(span);
+    li.appendChild(btn);
+    list.appendChild(li);
+  }
+}
+
+function fillForm(job){
+  $('preset').value = job.preset;
+  $('style').value = job.style || '';
+  $('minutes').value = job.minutes ?? '';
+  $('sections').value = job.sections ?? '';
+  $('seed').value = job.seed ?? 42;
+  $('name').value = job.name || 'output';
+  $('phrase').checked = !!job.phrase;
+  $('preview').value = job.preview ?? '';
+  outputDir = job.outdir || '';
+  $('outdir').value = outputDir;
+}
+
 $('choose_outdir').onclick = () => {
   $('outdir_picker').click();
 };
@@ -78,5 +111,8 @@ async function poll(){
       }
       $('metrics').textContent = JSON.stringify(data.metrics || {}, null, 2);
     }
+    loadRecent();
   }
 }
+
+loadRecent();

--- a/webui/templates/generate.html
+++ b/webui/templates/generate.html
@@ -9,6 +9,7 @@
     #controls { margin-top: 1em; }
     #log { background: #111; color: #0f0; padding: 0.5em; height: 200px; overflow-y: scroll; }
     #results { margin-top: 1em; }
+    #recent { margin-top: 1em; }
     #home {
       display: flex;
       flex-direction: column;
@@ -70,6 +71,10 @@
     <h3>Results</h3>
     <ul id="links"></ul>
     <pre id="metrics"></pre>
+  </div>
+  <div id="recent">
+    <h3>Recent Renders</h3>
+    <ul id="recent_list"></ul>
   </div>
   </div>
 


### PR DESCRIPTION
## Summary
- save completed render metadata to `recent_renders.json`
- expose `/recent` endpoint and show recent jobs with duplicate button in UI

## Testing
- `pytest` *(fails: python-multipart missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c348e0264c832597aef8c369178cd2