### PR TITLE
Add render metrics summary to outputs

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use regex::Regex;
-use serde_json::json;
+use serde_json::{json, Value};
 use tauri::{State, Window};
 use tauri::api::dialog::blocking::FileDialogBuilder;
 
@@ -163,7 +163,14 @@ fn start_render(
                             bundle_dir.to_str().unwrap(),
                         ])
                         .output();
-                    let _ = win.emit("result", zip_path.to_string_lossy().to_string());
+                    let metrics = fs::read_to_string(bundle_dir.join("metrics.json"))
+                        .ok()
+                        .and_then(|s| serde_json::from_str::<Value>(&s).ok());
+                    let payload = json!({
+                        "bundle": zip_path.to_string_lossy().to_string(),
+                        "metrics": metrics
+                    });
+                    let _ = win.emit("result", payload);
                 }
             } else {
                 let _ = win.emit("error", "render failed");

--- a/tauri-ui/index.html
+++ b/tauri-ui/index.html
@@ -54,6 +54,10 @@
     </div>
     <div id="eta"></div>
     <pre id="logs"></pre>
+    <div id="results" style="display:none;">
+      <h3>Results</h3>
+      <ul id="summary"></ul>
+    </div>
     <script>
       const { invoke } = window.__TAURI__;
       const presetSel = document.getElementById('preset');
@@ -101,7 +105,26 @@
         eta.textContent = eeta ? 'ETA: ' + eeta : '';
       });
       window.__TAURI__.event.listen('result', e => {
-        bundlePath = e.payload;
+        bundlePath = e.payload.bundle;
+        const summary = document.getElementById('summary');
+        summary.innerHTML = '';
+        const m = e.payload.metrics || {};
+        if (m.hash) {
+          const li = document.createElement('li');
+          li.textContent = `Hash: ${m.hash}`;
+          summary.appendChild(li);
+        }
+        if (typeof m.duration === 'number') {
+          const li = document.createElement('li');
+          li.textContent = `Duration: ${m.duration.toFixed(2)}s`;
+          summary.appendChild(li);
+        }
+        if (m.section_counts) {
+          const li = document.createElement('li');
+          li.textContent = 'Sections: ' + Object.entries(m.section_counts).map(([k,v])=>`${k}: ${v}`).join(', ');
+          summary.appendChild(li);
+        }
+        document.getElementById('results').style.display = 'block';
         downloadBtn.style.display = 'inline-block';
         cancelBtn.style.display = 'none';
         startBtn.disabled = false;

--- a/tests/test_bundle_cli.py
+++ b/tests/test_bundle_cli.py
@@ -91,6 +91,9 @@ def test_bundle_creation(tmp_path):
         metrics = json.load(fh)
     assert "chord_tone_coverage" in metrics
     assert "audio_stats" in metrics
+    assert "hash" in metrics
+    assert "duration" in metrics
+    assert "section_counts" in metrics
 
     mix_bytes = (bundle_dir / "mix.wav").read_bytes()
     idx = mix_bytes.find(b"ICMT")

--- a/tests/test_eval_only.py
+++ b/tests/test_eval_only.py
@@ -68,6 +68,9 @@ def test_eval_only(tmp_path):
         data = json.load(fh)
     assert "chord_tone_coverage" in data
     assert "audio_stats" in data
+    assert "hash" in data
+    assert "duration" in data
+    assert "section_counts" in data
 
     mix_bytes_after = mix_path.read_bytes()
     assert mix_bytes_after == mix_bytes

--- a/webui/static/app.js
+++ b/webui/static/app.js
@@ -76,7 +76,25 @@ async function poll(){
         li.appendChild(a);
         links.appendChild(li);
       }
-      $('metrics').textContent = JSON.stringify(data.metrics || {}, null, 2);
+      const summary = $('summary');
+      summary.innerHTML = '';
+      const m = data.metrics || {};
+      if (m.hash) {
+        const li = document.createElement('li');
+        li.textContent = `Hash: ${m.hash}`;
+        summary.appendChild(li);
+      }
+      if (typeof m.duration === 'number') {
+        const li = document.createElement('li');
+        li.textContent = `Duration: ${m.duration.toFixed(2)}s`;
+        summary.appendChild(li);
+      }
+      if (m.section_counts) {
+        const li = document.createElement('li');
+        li.textContent = 'Sections: ' + Object.entries(m.section_counts).map(([k,v])=>`${k}: ${v}`).join(', ');
+        summary.appendChild(li);
+      }
+      $('metrics').textContent = JSON.stringify(m, null, 2);
     }
   }
 }

--- a/webui/templates/generate.html
+++ b/webui/templates/generate.html
@@ -69,6 +69,7 @@
   <div id="results" hidden>
     <h3>Results</h3>
     <ul id="links"></ul>
+    <ul id="summary"></ul>
     <pre id="metrics"></pre>
   </div>
   </div>


### PR DESCRIPTION
## Summary
- include render hash, duration, and section counts in metrics output
- show summary metrics in web UI results and Tauri frontend
- expose metrics via Tauri backend and expand tests

## Testing
- `pytest` *(fails: Form data requires "python-multipart" to be installed)*
- `cargo check` *(fails: package `blossom_tauri` depends on `tauri-build` with feature `dialog` but `tauri-build` does not have that feature)*

------
https://chatgpt.com/codex/tasks/task_e_68c34882e4fc832583b02f7984e7c30f