### PR TITLE
chore: update tauri build dependency configuration

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -10,4 +10,4 @@ tempfile = "3"
 serde_json = "1"
 
 [build-dependencies]
-tauri-build = { version = "1", features = ["dialog"] }
+tauri-build = { version = "1" }


### PR DESCRIPTION
## Summary
- remove dialog feature from tauri-build build dependency

## Testing
- `npm run tauri dev` *(fails: failed to get `rfd` dependency, CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c353e118f883258babd19c3712fd8f