### PR TITLE
Add job status reporting and persistence

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -8,6 +8,7 @@ tauri = { version = "1", features = ["dialog"] }
 regex = "1"
 tempfile = "3"
 serde_json = "1"
+serde = { version = "1", features = ["derive"] }
 
 [build-dependencies]
 tauri-build = { version = "1" }


### PR DESCRIPTION
## Summary
- add `JobStatus` enum for tracking running/completed/not-found jobs
- store completed job exit status and query with new `job_status` command
- expose new command and add serde dependency

## Testing
- `cargo test` *(fails: download of config.json failed, response 403)*
- `pytest` *(fails: RuntimeError: Form data requires "python-multipart" to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c35832ed248325ac30635510400c7f