### PR TITLE
Handle cancel_render job termination

### DIFF
--- a/tauri-ui/generate.html
+++ b/tauri-ui/generate.html
@@ -72,6 +72,7 @@
       const eta = document.getElementById('eta');
       const logs = document.getElementById('logs');
       let bundlePath = null;
+      let currentJobId = null;
 
       async function loadOptions() {
         try {
@@ -143,7 +144,7 @@
         startBtn.disabled = true;
         cancelBtn.style.display = 'inline-block';
         bundlePath = null;
-        await invoke('start_render', {
+        currentJobId = await invoke('start_render', {
           preset: presetSel.value,
           style: styleSel.value,
           seed: parseInt(seedInput.value),
@@ -152,7 +153,9 @@
       });
 
       cancelBtn.addEventListener('click', async () => {
-        await invoke('cancel_render');
+        if (currentJobId !== null) {
+          await invoke('cancel_render', { jobId: currentJobId });
+        }
         cancelBtn.style.display = 'none';
         startBtn.disabled = false;
       });


### PR DESCRIPTION
## Summary
- update Tauri cancel_render command to kill jobs by ID and report errors for unknown or finished jobs
- track current job ID in generate.html and pass it to cancel_render

## Testing
- `pytest tests/test_webui_health.py -q` *(fails: RuntimeError: Form data requires "python-multipart" to be installed)*
- `pip install python-multipart` *(fails: Could not find a version that satisfies the requirement python-multipart)*

------
https://chatgpt.com/codex/tasks/task_e_68c359037fc483259b5e04ad271d1343