### PR TITLE
Emit per-job progress events

### DIFF
--- a/tauri-ui/generate.html
+++ b/tauri-ui/generate.html
@@ -94,18 +94,12 @@
         }
       }
 
-      window.__TAURI__.event.listen('progress', e => {
-        const { line, percent, eta: eeta } = e.payload;
-        if (typeof percent === 'number') prog.value = percent;
-        if (line) {
-          logs.textContent += line + '\n';
-          logs.scrollTop = logs.scrollHeight;
-          const m = line.match(/^\s*([\w-]+):/);
-          stage.textContent = m ? m[1] : '';
-        }
-        eta.textContent = eeta ? 'ETA: ' + eeta : '';
-      });
+      let progressUnlisten = null;
       window.__TAURI__.event.listen('result', e => {
+        if (progressUnlisten) {
+          progressUnlisten();
+          progressUnlisten = null;
+        }
         bundlePath = e.payload.bundle;
         const summary = document.getElementById('summary');
         summary.innerHTML = '';
@@ -132,6 +126,10 @@
       });
       window.__TAURI__.event.listen('error', e => {
         logs.textContent += 'Error: ' + e.payload + '\n';
+        if (progressUnlisten) {
+          progressUnlisten();
+          progressUnlisten = null;
+        }
         cancelBtn.style.display = 'none';
         startBtn.disabled = false;
       });
@@ -149,6 +147,19 @@
           style: styleSel.value,
           seed: parseInt(seedInput.value),
           minutes: minInput.value ? parseFloat(minInput.value) : null
+        });
+        if (progressUnlisten) {
+          progressUnlisten();
+        }
+        progressUnlisten = await window.__TAURI__.event.listen(`progress::${currentJobId}`, e => {
+          const { stage: stg, percent, msg, eta: eeta } = e.payload;
+          if (typeof percent === 'number') prog.value = percent;
+          if (msg) {
+            logs.textContent += msg + '\n';
+            logs.scrollTop = logs.scrollHeight;
+          }
+          stage.textContent = stg || '';
+          eta.textContent = eeta ? 'ETA: ' + eeta : '';
         });
       });
 

--- a/webui/app.py
+++ b/webui/app.py
@@ -92,6 +92,15 @@ def _watch(job_id: str) -> None:
         m = stage_re.match(line)
         if m:
             job["stage"] = m.group(1)
+        payload = {
+            "stage": job.get("stage"),
+            "percent": job.get("progress"),
+            "msg": line.rstrip(),
+        }
+        eta = job.get("eta")
+        if eta is not None:
+            payload["eta"] = eta
+        print(f"progress::{job_id} {json.dumps(payload)}", flush=True)
     proc.wait()
     job["returncode"] = proc.returncode
     job["progress"] = 100


### PR DESCRIPTION
## Summary
- Emit progress updates on `progress::{job_id}` with stage, percent, message, and optional ETA
- Listen for per-job progress events in Tauri UI and update logs, stage, and ETA

## Testing
- `pytest tests/test_webui_health.py::test_health -q` *(fails: Form data requires "python-multipart" to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c35c37e1e883258c054f5306d1536a