### PR TITLE
Allow custom mix and arrange configs

### DIFF
--- a/tauri-ui/generate.html
+++ b/tauri-ui/generate.html
@@ -52,8 +52,8 @@
 
     <details id="advanced">
       <summary>Advanced</summary>
-      <label>Mix config <input type="file" id="mix_config" /></label>
-      <label>Arrange config <input type="file" id="arrange_config" /></label>
+      <label>Mix config <input type="file" id="mix_config" accept=".json,application/json" /></label>
+      <label>Arrange config <input type="file" id="arrange_config" accept=".json,application/json" /></label>
       <label><input type="checkbox" id="phrase" /> Phrase backend</label>
       <label>Preview bars <input type="number" id="preview" /></label>
     </details>
@@ -199,10 +199,31 @@
           }
           args.push('--preview', String(prev));
         }
+        const tempDir = await window.__TAURI__.path.tempDir();
         const mixFile = mixConfigInput.files[0];
-        if (mixFile) args.push('--mix-config', mixFile.path);
+        if (mixFile) {
+          const mixCfgPath = await window.__TAURI__.path.join(
+            tempDir,
+            `mix-config-${Date.now()}.json`
+          );
+          await window.__TAURI__.fs.writeFile({
+            path: mixCfgPath,
+            contents: await mixFile.text()
+          });
+          args.push('--mix-config', mixCfgPath);
+        }
         const arrFile = arrangeConfigInput.files[0];
-        if (arrFile) args.push('--arrange-config', arrFile.path);
+        if (arrFile) {
+          const arrCfgPath = await window.__TAURI__.path.join(
+            tempDir,
+            `arrange-config-${Date.now()}.json`
+          );
+          await window.__TAURI__.fs.writeFile({
+            path: arrCfgPath,
+            contents: await arrFile.text()
+          });
+          args.push('--arrange-config', arrCfgPath);
+        }
         const name = nameInput.value.trim() || 'output';
         const mixPath = outputDir ? `${outputDir}/${name}.wav` : `${name}.wav`;
         const stemsPath = outputDir ? `${outputDir}/${name}_stems` : `${name}_stems`;


### PR DESCRIPTION
## Summary
- accept optional mix and arrange configuration JSON files in the generator UI
- persist selected config files to temporary paths and pass `--mix-config`/`--arrange-config` to the backend job

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest` *(fails: RuntimeError: Form data requires "python-multipart" to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c39a89ddc083259fb41cef87833dc4