### PR TITLE
feat: add persistent bundle links

### DIFF
--- a/webui/static/app.js
+++ b/webui/static/app.js
@@ -16,10 +16,19 @@ async function loadRecent(){
     let text = `${job.preset} (seed ${job.seed}) - ${job.status}`;
     if (job.hash) text += ` [${job.hash}]`;
     span.textContent = text;
+    li.appendChild(span);
+
+    if (job.bundle) {
+      const link = document.createElement('a');
+      link.textContent = 'bundle.zip';
+      link.href = `/bundles/${job.id}`;
+      link.style.marginLeft = '8px';
+      li.appendChild(link);
+    }
+
     const btn = document.createElement('button');
     btn.textContent = 'Duplicate';
     btn.onclick = () => fillForm(job);
-    li.appendChild(span);
     li.appendChild(btn);
     list.appendChild(li);
   }


### PR DESCRIPTION
## Summary
- add persistent bundle storage and serve route
- expose bundle download link in recent renders

## Testing
- `pytest tests/test_webui_health.py -q` *(fails: Form data requires python-multipart to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c42f35366483258c672920764e92c2