### PR TITLE
Add ARIA labels to generator buttons

### DIFF
--- a/webui/templates/generate.html
+++ b/webui/templates/generate.html
@@ -40,12 +40,12 @@
     </label>
     <label>Minutes <input type="number" step="0.1" id="minutes" /></label>
     <label>Sections <input type="number" id="sections" /></label>
-    <label>Seed <input type="number" id="seed" value="42" /> <button id="dice" type="button">🎲</button></label>
+    <label>Seed <input type="number" id="seed" value="42" /> <button id="dice" type="button" aria-label="Randomize seed">🎲</button></label>
     <label>Output name <input type="text" id="name" value="output" /></label>
     <label>Output folder
       <input type="text" id="outdir" readonly />
       <input type="file" id="outdir_picker" webkitdirectory directory hidden />
-      <button id="choose_outdir" type="button">📁</button>
+      <button id="choose_outdir" type="button" aria-label="Choose output folder">📁</button>
     </label>
   </div>
 


### PR DESCRIPTION
## Summary
- add descriptive `aria-label` attributes to dice and folder buttons in the web UI

## Testing
- `python - <<'PY' ...` (parse HTML to confirm aria labels and tab focus)
- `pytest tests/test_webui_health.py -q` *(fails: Form data requires "python-multipart" to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c42f3ed96c83259edd4552e1f9253c