### PR TITLE
Enable shell-open feature for Tauri

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tauri = { version = "1", features = ["dialog"] }
+tauri = { version = "1", features = ["dialog", "shell-open"] }
 regex = "1"
 tempfile = "3"
 serde_json = "1"


### PR DESCRIPTION
## Summary
- enable shell-open feature for Tauri dependency

## Testing
- `cargo build` *(fails: failed to download from `https://index.crates.io/op/en/open` (CONNECT tunnel failed, response 403))*

------
https://chatgpt.com/codex/tasks/task_e_68c43bd1ab1c8325801cbb4b2dd1b93e