### PR TITLE
Add Manager trait import for Tauri builder

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -14,6 +14,7 @@ use std::{
 
 use regex::Regex;
 use tauri::{AppHandle, State};
+use tauri::Manager;
 
 #[derive(serde::Serialize)]
 struct ProgressEvent {


### PR DESCRIPTION
## Summary
- import `tauri::Manager` in Rust main so `emit_all` and `shell_scope` compile

## Testing
- `cargo build` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*
- `cargo test` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c43bd5ea9483258191abd58012544b