### PR TITLE
Derive Clone for ProgressEvent

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -16,7 +16,7 @@ use regex::Regex;
 use tauri::{AppHandle, State};
 use tauri::Manager;
 
-#[derive(serde::Serialize)]
+#[derive(serde::Serialize, Clone)]
 struct ProgressEvent {
     stage: Option<String>,
     percent: Option<u8>,


### PR DESCRIPTION
## Summary
- derive `Clone` for `ProgressEvent` to allow cloning progress updates

## Testing
- `cargo build` *(fails: failed to download crates - Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*

------
https://chatgpt.com/codex/tasks/task_e_68c442fafa108325874284c79e936eb7