### PR TITLE
Enable shell open API feature for Tauri

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tauri = { version = "1", features = ["dialog", "shell-open"] }
+tauri = { version = "1", features = ["dialog", "shell-open", "shell-open-api"] }
 regex = "1"
 tempfile = "3"
 serde_json = "1"


### PR DESCRIPTION
## Summary
- enable shell-open-api feature in Tauri dependency

## Testing
- `cargo build` *(fails: failed to download crate due to 403 from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_68c442fc80188325ad5d34a60c174c8c