### PR TITLE
Add placeholder Dungeons & Dragons page

### DIFF
--- a/ui/dnd.html
+++ b/ui/dnd.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Dungeons & Dragons</title>
+  <style>
+    body {
+      margin: 0;
+      font-family: sans-serif;
+      background: #111;
+      color: #fff;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+    }
+    a { color: #4ea3ff; margin-top: 1em; }
+  </style>
+</head>
+<body>
+  <h1>Under Construction</h1>
+  <a href="index.html">Back to Home</a>
+</body>
+</html>

--- a/ui/index.html
+++ b/ui/index.html
@@ -3,9 +3,22 @@
 <head>
   <meta charset="utf-8" />
   <title>Blossom Music Generator</title>
+  <style>
+    body {
+      background: #111;
+      color: #fff;
+      font-family: sans-serif;
+      margin: 1em;
+    }
+    #carousel { margin-top: 1em; }
+    #carousel a { color: #4ea3ff; margin-right: 1em; }
+  </style>
 </head>
 <body>
   <h1>Blossom Music Generation</h1>
+  <div id="carousel">
+    <a href="dnd.html">Dungeons & Dragons</a>
+  </div>
   <a href="/generate">Start Generating</a>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `ui/dnd.html` placeholder with dark background and "Under Construction" notice
- link the Dungeons & Dragons page from the home page carousel

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest tests/test_webui_health.py -q` *(fails: python-multipart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c44a10fb14832593d21829f0beb5b0