### PR TITLE
feat(ui): expose advanced render options

### DIFF
--- a/ui/app.js
+++ b/ui/app.js
@@ -100,12 +100,29 @@ async function browserMain(){
     if ($('minutes').value) fd.append('minutes', $('minutes').value);
     if ($('sections').value) fd.append('sections', $('sections').value);
     fd.append('seed', $('seed').value);
+    if ($('sampler_seed').value) fd.append('sampler_seed', $('sampler_seed').value);
+    if ($('mix_preset').value) fd.append('mix_preset', $('mix_preset').value);
     fd.append('name', $('name').value);
     const mix = $('mix_config').files[0];
     if (mix) fd.append('mix_config', mix);
     const arr = $('arrange_config').files[0];
     if (arr) fd.append('arrange_config', arr);
+    if ($('bundle_stems').checked) fd.append('bundle_stems', 'true');
+    if ($('eval_only').checked) fd.append('eval_only', 'true');
+    if ($('dry_run').checked) fd.append('dry_run', 'true');
+    const keys = $('keys_sfz').files[0];
+    if (keys) fd.append('keys_sfz', keys);
+    const pads = $('pads_sfz').files[0];
+    if (pads) fd.append('pads_sfz', pads);
+    const bass = $('bass_sfz').files[0];
+    if (bass) fd.append('bass_sfz', bass);
+    const drums = $('drums_sfz').files[0];
+    if (drums) fd.append('drums_sfz', drums);
+    const melody = $('melody_midi').files[0];
+    if (melody) fd.append('melody_midi', melody);
     if ($('phrase').checked) fd.append('phrase', 'true');
+    if ($('arrange').value) fd.append('arrange', $('arrange').value);
+    if ($('outro').value) fd.append('outro', $('outro').value);
     if ($('preview').value) fd.append('preview', $('preview').value);
     if (outputDir) fd.append('outdir', outputDir);
     const resp = await fetch('/render', {method:'POST', body: fd});
@@ -184,14 +201,26 @@ async function tauriMain(){
   const presetSel = $('preset');
   const styleSel = $('style');
   const seedInput = $('seed');
+  const samplerSeedInput = $('sampler_seed');
+  const mixPresetInput = $('mix_preset');
   const minInput = $('minutes');
   const sectionsInput = $('sections');
   const nameInput = $('name');
   const outdirInput = $('outdir');
   const mixConfigInput = $('mix_config');
   const arrangeConfigInput = $('arrange_config');
+  const bundleStemsInput = $('bundle_stems');
+  const evalOnlyInput = $('eval_only');
+  const dryRunInput = $('dry_run');
+  const keysSfzInput = $('keys_sfz');
+  const padsSfzInput = $('pads_sfz');
+  const bassSfzInput = $('bass_sfz');
+  const drumsSfzInput = $('drums_sfz');
+  const melodyMidiInput = $('melody_midi');
   const phraseInput = $('phrase');
   const previewInput = $('preview');
+  const arrangeInput = $('arrange');
+  const outroInput = $('outro');
   const startBtn = $('start');
   const cancelBtn = $('cancel');
   const prog = $('progress');
@@ -227,11 +256,18 @@ async function tauriMain(){
     cancelBtn.disabled = false;
     const seed = parseInt(seedInput.value);
     const args = ['main_render.py', '--preset', presetSel.value, '--seed', String(seed)];
+    if (samplerSeedInput.value) args.push('--sampler-seed', samplerSeedInput.value);
+    if (mixPresetInput.value) args.push('--mix-preset', mixPresetInput.value);
     if (styleSel.value) args.push('--style', styleSel.value);
     if (minInput.value) args.push('--minutes', minInput.value);
     if (sectionsInput.value) args.push('--sections', sectionsInput.value);
     if (phraseInput.checked) args.push('--use-phrase-model', 'yes');
     if (previewInput.value) args.push('--preview', previewInput.value);
+    if (bundleStemsInput.checked) args.push('--bundle-stems');
+    if (evalOnlyInput.checked) args.push('--eval-only');
+    if (dryRunInput.checked) args.push('--dry-run');
+    if (arrangeInput.value) args.push('--arrange', arrangeInput.value);
+    if (outroInput.value) args.push('--outro', outroInput.value);
     const tempDir = await path.tempDir();
     const mixFile = mixConfigInput.files[0];
     if (mixFile) {
@@ -244,6 +280,36 @@ async function tauriMain(){
       const arrCfgPath = await path.join(tempDir, `arrange-config-${Date.now()}.json`);
       await fs.writeFile({ path: arrCfgPath, contents: await arrFile.text() });
       args.push('--arrange-config', arrCfgPath);
+    }
+    const keysFile = keysSfzInput.files[0];
+    if (keysFile) {
+      const keysPath = await path.join(tempDir, `keys-sfz-${Date.now()}.sfz`);
+      await fs.writeFile({ path: keysPath, contents: await keysFile.text() });
+      args.push('--keys-sfz', keysPath);
+    }
+    const padsFile = padsSfzInput.files[0];
+    if (padsFile) {
+      const padsPath = await path.join(tempDir, `pads-sfz-${Date.now()}.sfz`);
+      await fs.writeFile({ path: padsPath, contents: await padsFile.text() });
+      args.push('--pads-sfz', padsPath);
+    }
+    const bassFile = bassSfzInput.files[0];
+    if (bassFile) {
+      const bassPath = await path.join(tempDir, `bass-sfz-${Date.now()}.sfz`);
+      await fs.writeFile({ path: bassPath, contents: await bassFile.text() });
+      args.push('--bass-sfz', bassPath);
+    }
+    const drumsFile = drumsSfzInput.files[0];
+    if (drumsFile) {
+      const drumsPath = await path.join(tempDir, `drums-sfz-${Date.now()}.sfz`);
+      await fs.writeFile({ path: drumsPath, contents: await drumsFile.text() });
+      args.push('--drums-sfz', drumsPath);
+    }
+    const melodyFile = melodyMidiInput.files[0];
+    if (melodyFile) {
+      const melodyPath = await path.join(tempDir, `melody-${Date.now()}.mid`);
+      await fs.writeFile({ path: melodyPath, contents: new Uint8Array(await melodyFile.arrayBuffer()) });
+      args.push('--melody-midi', melodyPath);
     }
     const name = nameInput.value.trim() || 'output';
     const mixPath = outputDir ? `${outputDir}/${name}.wav` : `${name}.wav`;

--- a/ui/generate.html
+++ b/ui/generate.html
@@ -19,6 +19,8 @@
     <label>Minutes <input type="number" step="0.1" id="minutes" /></label>
     <label>Sections <input type="number" id="sections" /></label>
     <label>Seed <input type="number" id="seed" value="42" /> <button id="dice" type="button" aria-label="Randomize seed">🎲</button></label>
+    <label>Sampler seed <input type="number" id="sampler_seed" /></label>
+    <label>Mix preset <input type="text" id="mix_preset" /></label>
     <label>Output name <input type="text" id="name" value="output" /></label>
     <label>Output folder
       <input type="text" id="outdir" readonly />
@@ -33,6 +35,16 @@
     <label>Arrange config <input type="file" id="arrange_config" /></label>
     <label><input type="checkbox" id="phrase" /> Phrase backend</label>
     <label>Preview bars <input type="number" id="preview" /></label>
+    <label><input type="checkbox" id="bundle_stems" /> Bundle stems</label>
+    <label><input type="checkbox" id="eval_only" /> Eval only</label>
+    <label><input type="checkbox" id="dry_run" /> Dry run</label>
+    <label>Keys SFZ <input type="file" id="keys_sfz" /></label>
+    <label>Pads SFZ <input type="file" id="pads_sfz" /></label>
+    <label>Bass SFZ <input type="file" id="bass_sfz" /></label>
+    <label>Drums SFZ <input type="file" id="drums_sfz" /></label>
+    <label>Melody MIDI <input type="file" id="melody_midi" /></label>
+    <label>Arrange <select id="arrange"><option value="">(default)</option><option value="on">on</option><option value="off">off</option></select></label>
+    <label>Outro <select id="outro"><option value="">(default)</option><option value="hit">hit</option><option value="ritard">ritard</option></select></label>
   </details>
 
   <div id="controls">


### PR DESCRIPTION
## Summary
- add sampler seed & mix preset inputs
- support advanced options like SFZ overrides, eval flags, and arrangement controls
- wire new fields into browser and Tauri form submission

## Testing
- `node --check ui/app.js`
- `python3.10 main_render.py --help` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68c44a17729c832595f1094438213abc