### PR TITLE
Add Dungeons & Dragons placeholder page

### DIFF
--- a/ui/dnd.html
+++ b/ui/dnd.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Dungeons & Dragons</title>
+  <style>
+    body {
+      background: #000;
+      color: #fff;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+      margin: 0;
+      font-family: sans-serif;
+    }
+  </style>
+</head>
+<body>
+  <h1>Under Construction</h1>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add dark themed `ui/dnd.html` with "Under Construction" message
- home carousel already points to new Dungeons & Dragons page

## Testing
- `pytest` *(fails: python-multipart missing and couldn't install)*

------
https://chatgpt.com/codex/tasks/task_e_68c44b926e748325bd3d879537a19e08