### PR TITLE
Add settings and train pages

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -64,6 +64,14 @@
       <span class="panel-icon">🐉</span>
       <h2>Dungeons & Dragons</h2>
     </a>
+    <a class="panel" href="settings.html">
+      <span class="panel-icon">⚙️</span>
+      <h2>Settings</h2>
+    </a>
+    <a class="panel" href="train.html">
+      <span class="panel-icon">🎚️</span>
+      <h2>Train Model</h2>
+    </a>
   </div>
   <script>
     const carousel = document.querySelector('.carousel');

--- a/ui/settings.html
+++ b/ui/settings.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Settings</title>
+  <style>
+    body {
+      background: #000;
+      color: #fff;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+      margin: 0;
+      font-family: sans-serif;
+    }
+  </style>
+</head>
+<body>
+  <h1>Under Construction</h1>
+</body>
+</html>

--- a/ui/train.html
+++ b/ui/train.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Train Model</title>
+  <style>
+    body {
+      background: #000;
+      color: #fff;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+      margin: 0;
+      font-family: sans-serif;
+    }
+  </style>
+</head>
+<body>
+  <h1>Under Construction</h1>
+</body>
+</html>

--- a/webui/app.py
+++ b/webui/app.py
@@ -177,6 +177,16 @@ async def generate() -> HTMLResponse:
     return HTMLResponse((REPO_ROOT / "ui" / "generate.html").read_text())
 
 
+@app.get("/settings", response_class=HTMLResponse)
+async def settings() -> HTMLResponse:
+    return HTMLResponse((REPO_ROOT / "ui" / "settings.html").read_text())
+
+
+@app.get("/train", response_class=HTMLResponse)
+async def train() -> HTMLResponse:
+    return HTMLResponse((REPO_ROOT / "ui" / "train.html").read_text())
+
+
 @app.get("/presets")
 async def list_presets() -> list[str]:
     return _options("presets")


### PR DESCRIPTION
## Summary
- Add Settings and Train Model panels to index
- Introduce placeholder settings and training pages
- Serve the new pages with FastAPI routes

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: python-multipart missing)*
- `pip install python-multipart` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c44ebae1a483258a5d6b46fbf84904