### PR TITLE
feat: add obsidian vault configuration

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,1 @@
+"""Configuration utilities for Blossom."""

--- a/config/obsidian.py
+++ b/config/obsidian.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+"""Utilities for selecting an Obsidian vault.
+
+This module exposes :func:`select_vault` which stores the path to an
+Obsidian vault in a small settings file.  The stored path is treated as
+read-only once written.  Subsequent attempts to change the path will
+raise a :class:`RuntimeError`.
+"""
+
+from pathlib import Path
+
+__all__ = ["select_vault", "get_vault", "VAULT_FILE"]
+
+# Location where the selected vault path will be persisted.
+VAULT_FILE = Path(__file__).with_name("obsidian_vault.txt")
+
+# Internal cached vault path.  This should be treated as read-only.
+_VAULT_PATH: Path | None = None
+
+
+def get_vault() -> Path | None:
+    """Return the currently selected vault path, if any."""
+
+    global _VAULT_PATH
+    if _VAULT_PATH is not None:
+        return _VAULT_PATH
+    if VAULT_FILE.exists():
+        _VAULT_PATH = Path(VAULT_FILE.read_text().strip())
+    return _VAULT_PATH
+
+
+def select_vault(root: Path) -> Path:
+    """Persist the Obsidian vault path in a read-only settings file.
+
+    Parameters
+    ----------
+    root:
+        Directory containing the Obsidian vault.
+
+    Returns
+    -------
+    Path
+        The resolved vault path.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``root`` does not exist.
+    RuntimeError
+        If a vault has already been selected.
+    """
+
+    resolved = root.expanduser().resolve()
+    if not resolved.exists():
+        raise FileNotFoundError(f"Vault path {resolved} does not exist")
+
+    existing = get_vault()
+    if existing is not None:
+        raise RuntimeError(f"Vault already selected: {existing}")
+
+    VAULT_FILE.write_text(str(resolved))
+    try:
+        # Make the settings file read-only so that it cannot be modified
+        # by the running service.
+        VAULT_FILE.chmod(0o444)
+    except Exception:
+        # If changing permissions fails we still continue – the runtime
+        # checks above will prevent further writes.
+        pass
+
+    global _VAULT_PATH
+    _VAULT_PATH = resolved
+    return resolved

--- a/tests/test_obsidian_vault.py
+++ b/tests/test_obsidian_vault.py
@@ -1,0 +1,50 @@
+import os, sys, types
+
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+multipart_mod = types.ModuleType("multipart")
+multipart_submod = types.ModuleType("multipart.multipart")
+multipart_mod.__version__ = "0"
+
+def parse_options_header(value: str) -> tuple[str, dict[str, str]]:
+    return value, {}
+
+multipart_submod.parse_options_header = parse_options_header
+sys.modules.setdefault("multipart", multipart_mod)
+sys.modules.setdefault("multipart.multipart", multipart_submod)
+
+from webui.app import app  # noqa: E402
+from config import obsidian  # noqa: E402
+
+
+def _reset_vault() -> None:
+    # Helper to clear any persisted vault path between tests
+    if obsidian.VAULT_FILE.exists():
+        obsidian.VAULT_FILE.unlink()
+    # Reset in-memory cache
+    if "_VAULT_PATH" in obsidian.__dict__:
+        obsidian.__dict__["_VAULT_PATH"] = None
+
+
+
+def test_set_vault(tmp_path):
+    _reset_vault()
+    client = TestClient(app)
+    resp = client.post("/obsidian/vault", json={"path": str(tmp_path)})
+    assert resp.status_code == 200
+    assert resp.json() == {"vault": str(tmp_path.resolve())}
+
+    # Second attempt should fail
+    resp = client.post("/obsidian/vault", json={"path": str(tmp_path)})
+    assert resp.status_code == 400
+
+
+
+def test_set_vault_missing(tmp_path):
+    _reset_vault()
+    client = TestClient(app)
+    missing = tmp_path / "does-not-exist"
+    resp = client.post("/obsidian/vault", json={"path": str(missing)})
+    assert resp.status_code == 404

--- a/tests/test_webui_health.py
+++ b/tests/test_webui_health.py
@@ -1,7 +1,18 @@
-import os, sys
+import os, sys, types
 from fastapi.testclient import TestClient
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+multipart_mod = types.ModuleType("multipart")
+multipart_submod = types.ModuleType("multipart.multipart")
+multipart_mod.__version__ = "0"
+
+def parse_options_header(value: str) -> tuple[str, dict[str, str]]:
+    return value, {}
+
+multipart_submod.parse_options_header = parse_options_header
+sys.modules.setdefault("multipart", multipart_mod)
+sys.modules.setdefault("multipart.multipart", multipart_submod)
 
 from webui.app import app
 

--- a/webui/app.py
+++ b/webui/app.py
@@ -19,6 +19,9 @@ from fastapi import (
 )
 from fastapi.responses import HTMLResponse, FileResponse
 from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
+
+from config.obsidian import select_vault
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MAIN_RENDER = REPO_ROOT / "main_render.py"
@@ -185,6 +188,27 @@ async def list_presets() -> list[str]:
 @app.get("/styles")
 async def list_styles() -> list[str]:
     return _options("styles")
+
+
+class VaultRequest(BaseModel):
+    path: str
+
+
+@app.post("/obsidian/vault")
+async def set_obsidian_vault(req: VaultRequest) -> dict[str, str]:
+    """Set the Obsidian vault used by the service.
+
+    The provided path must exist and may only be set once.  Subsequent
+    attempts to change the vault will raise an error.
+    """
+
+    try:
+        vault = select_vault(Path(req.path))
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="vault path does not exist")
+    except RuntimeError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"vault": str(vault)}
 
 
 @app.post("/render")


### PR DESCRIPTION
## Summary
- add config.obsidian module to persist a read-only Obsidian vault path
- expose POST /obsidian/vault endpoint for runtime vault selection
- test vault selection behavior and stub multipart dependency for tests

## Testing
- `python -m pytest tests/test_obsidian_vault.py::test_set_vault -q`
- `python -m pytest tests/test_obsidian_vault.py::test_set_vault_missing -q`
- `python -m pytest tests/test_eq_filters.py::test_peaking_eq_matches_reference -q` *(fails: AssertionError)*


------
https://chatgpt.com/codex/tasks/task_e_68c44f9ea0b88325bfdcd1b10d5a4080