### PR TITLE
Add top bar with back navigation on non-home pages

### DIFF
--- a/ui/dnd.html
+++ b/ui/dnd.html
@@ -18,5 +18,6 @@
 </head>
 <body>
   <h1>Under Construction</h1>
+  <script src="/ui/topbar.js"></script>
 </body>
 </html>

--- a/ui/generate.html
+++ b/ui/generate.html
@@ -68,6 +68,7 @@
     <ul id="recent_list"></ul>
   </div>
 
+  <script src="/ui/topbar.js"></script>
   <script src="/ui/app.js"></script>
 </body>
 </html>

--- a/ui/settings.html
+++ b/ui/settings.html
@@ -18,5 +18,6 @@
 </head>
 <body>
   <h1>Under Construction</h1>
+  <script src="/ui/topbar.js"></script>
 </body>
 </html>

--- a/ui/topbar.js
+++ b/ui/topbar.js
@@ -1,0 +1,37 @@
+(function() {
+  const style = document.createElement('style');
+  style.textContent = `
+    #top-bar {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      background: #111;
+      color: #fff;
+      padding: 0.5rem;
+      display: flex;
+      align-items: center;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.5);
+    }
+    body { padding-top: 2.5rem; }
+    #top-bar button {
+      background: #444;
+      color: #fff;
+      border: none;
+      padding: 0.25rem 0.5rem;
+      cursor: pointer;
+    }
+    #top-bar button:hover {
+      background: #555;
+    }
+  `;
+  document.head.appendChild(style);
+
+  const bar = document.createElement('div');
+  bar.id = 'top-bar';
+  const back = document.createElement('button');
+  back.textContent = 'Back';
+  back.addEventListener('click', () => history.back());
+  bar.appendChild(back);
+  document.body.prepend(bar);
+})();

--- a/ui/train.html
+++ b/ui/train.html
@@ -18,5 +18,6 @@
 </head>
 <body>
   <h1>Under Construction</h1>
+  <script src="/ui/topbar.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add reusable top bar script with back button that returns to previous page
- include top bar on all non-home UI pages

## Testing
- `pytest tests/test_webui_health.py` *(fails: RuntimeError: Form data requires "python-multipart" to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c451094ad0832590be5e18beb9813b