### PR TITLE
Add training UI with file upload and progress polling

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -73,6 +73,7 @@
       <h2>Train Model</h2>
     </a>
   </div>
+  <script src="/ui/train.js"></script>
   <script>
     const carousel = document.querySelector('.carousel');
     carousel.addEventListener('keydown', (e) => {

--- a/ui/train.html
+++ b/ui/train.html
@@ -4,19 +4,23 @@
   <meta charset="utf-8" />
   <title>Train Model</title>
   <style>
-    body {
-      background: #000;
-      color: #fff;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      height: 100vh;
-      margin: 0;
-      font-family: sans-serif;
-    }
+    body { font-family: sans-serif; margin: 1em; background: #000; color: #fff; }
+    label { display: block; margin-bottom: 0.5em; }
+    #log { background: #111; color: #0f0; padding: 0.5em; height: 200px; overflow-y: scroll; }
   </style>
 </head>
 <body>
-  <h1>Under Construction</h1>
+  <div id="inputs">
+    <label>MIDI files <input type="file" id="midi_files" multiple accept=".mid" /></label>
+    <label>Use first N files <input type="number" id="limit" /></label>
+  </div>
+  <div id="controls">
+    <button id="start" type="button">Start</button>
+    <button id="cancel" type="button" disabled>Cancel</button>
+    <progress id="progress" value="0" max="100"></progress>
+    <span id="stage"></span>
+  </div>
+  <pre id="log"></pre>
+  <script src="/ui/train.js"></script>
 </body>
 </html>

--- a/ui/train.js
+++ b/ui/train.js
@@ -1,0 +1,39 @@
+(function(){
+  function $(id){ return document.getElementById(id); }
+  const startBtn = $('start');
+  if (!startBtn) return;
+  let jobId = null;
+  startBtn.onclick = async () => {
+    const fd = new FormData();
+    const files = $('midi_files').files;
+    const limit = parseInt($('limit').value, 10);
+    const n = isNaN(limit) ? files.length : Math.min(limit, files.length);
+    for (let i = 0; i < n; i++) fd.append('midis', files[i]);
+    const resp = await fetch('/train', {method:'POST', body: fd});
+    const data = await resp.json();
+    jobId = data.job_id;
+    startBtn.disabled = true;
+    $('cancel').disabled = false;
+    $('log').textContent = '';
+    poll();
+  };
+  $('cancel').onclick = async () => {
+    if (!jobId) return;
+    await fetch(`/jobs/${jobId}/cancel`, {method:'POST'});
+  };
+  async function poll(){
+    if (!jobId) return;
+    const resp = await fetch(`/jobs/${jobId}`);
+    if (!resp.ok) return;
+    const data = await resp.json();
+    $('progress').value = data.progress || 0;
+    $('stage').textContent = data.stage || '';
+    $('log').textContent = data.log.join('');
+    if (data.status === 'running'){
+      setTimeout(poll, 1000);
+    } else {
+      $('cancel').disabled = true;
+      $('start').disabled = false;
+    }
+  }
+})();


### PR DESCRIPTION
## Summary
- Implement training page with MIDI uploads, limit control, and progress/log display
- Add train.js script to submit training jobs and poll server
- Load train.js from the index page so script is available across UI

## Testing
- `pytest tests/test_webui_health.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c45130fa7083258f20f67cf454b156