### PR TITLE
Add note parser

### DIFF
--- a/notes/__init__.py
+++ b/notes/__init__.py
@@ -1,0 +1,4 @@
+"""Note parsing utilities."""
+from .parser import ParsedNote, NoteParseError, parse_note
+
+__all__ = ["ParsedNote", "parse_note", "NoteParseError"]

--- a/notes/parser.py
+++ b/notes/parser.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+"""Utilities for parsing Obsidian style Markdown notes.
+
+This module exposes :func:`parse_note` which loads the frontmatter and
+content of a note, returning a :class:`ParsedNote` dataclass containing
+plain text, aliases, tags and custom fields defined inside ``npc`` code
+blocks.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List
+import re
+
+import frontmatter
+import yaml
+
+
+class NoteParseError(Exception):
+    """Raised when a note cannot be parsed."""
+
+
+@dataclass
+class ParsedNote:
+    """Result of :func:`parse_note`.
+
+    Attributes
+    ----------
+    text:
+        Note body with frontmatter and ``npc`` blocks removed.
+    aliases:
+        Aliases from the frontmatter. Always a list.
+    tags:
+        Tags from the frontmatter. Always a list.
+    fields:
+        Custom fields collected from ``npc`` blocks.
+    """
+
+    text: str
+    aliases: List[str]
+    tags: List[str]
+    fields: Dict[str, Any]
+
+
+# Regex to capture fenced npc blocks
+_NPC_BLOCK_RE = re.compile(r"```npc\s*\n(.*?)```", re.DOTALL | re.IGNORECASE)
+
+
+def _parse_frontmatter(path: Path) -> frontmatter.Post:
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            return frontmatter.load(fh)
+    except UnicodeDecodeError as exc:  # non UTF-8 file
+        raise NoteParseError(f"{path} is not UTF-8 encoded") from exc
+    except yaml.YAMLError as exc:  # malformed YAML frontmatter
+        raise NoteParseError(f"Malformed frontmatter in {path}") from exc
+
+
+def parse_note(path: Path) -> ParsedNote:
+    """Parse ``path`` into a :class:`ParsedNote`.
+
+    Parameters
+    ----------
+    path:
+        Location of the Markdown note to parse.
+    """
+
+    post = _parse_frontmatter(path)
+    text = post.content or ""
+    metadata = post.metadata or {}
+
+    aliases = metadata.get("aliases", [])
+    if isinstance(aliases, str):
+        aliases = [aliases]
+    elif not isinstance(aliases, list):
+        aliases = []
+
+    tags = metadata.get("tags", [])
+    if isinstance(tags, str):
+        tags = [t for t in re.split(r"[ ,]+", tags) if t]
+    elif not isinstance(tags, list):
+        tags = []
+
+    fields: Dict[str, Any] = {}
+    for block in _NPC_BLOCK_RE.findall(text):
+        try:
+            data = yaml.safe_load(block) or {}
+        except yaml.YAMLError as exc:
+            raise NoteParseError(f"Malformed npc block in {path}") from exc
+        if isinstance(data, dict):
+            fields.update(data)
+    # Remove npc blocks from body text
+    clean_text = _NPC_BLOCK_RE.sub("", text).strip()
+
+    return ParsedNote(text=clean_text, aliases=aliases, tags=tags, fields=fields)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ httpx
 uvicorn
 
 jinja2
+python-frontmatter

--- a/tests/test_parse_note.py
+++ b/tests/test_parse_note.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+import pytest
+
+from notes.parser import NoteParseError, parse_note
+
+
+def test_parse_note(tmp_path: Path) -> None:
+    note = tmp_path / "note.md"
+    note.write_text(
+        "---\naliases: [Bob, Bobby]\ntags: [npc, human]\n---\nHello\n```npc\nname: Bob\nrole: merchant\n```\nWorld",
+        encoding="utf-8",
+    )
+    parsed = parse_note(note)
+    assert parsed.text == "Hello\nWorld"
+    assert parsed.aliases == ["Bob", "Bobby"]
+    assert parsed.tags == ["npc", "human"]
+    assert parsed.fields == {"name": "Bob", "role": "merchant"}
+
+
+def test_bad_frontmatter(tmp_path: Path) -> None:
+    note = tmp_path / "bad.md"
+    note.write_text("---\naliases: [\n---\ntext", encoding="utf-8")
+    with pytest.raises(NoteParseError):
+        parse_note(note)
+
+
+def test_non_utf8(tmp_path: Path) -> None:
+    note = tmp_path / "latin1.md"
+    note.write_bytes(b"---\naliases: Bob\n---\n\xff")
+    with pytest.raises(NoteParseError):
+        parse_note(note)
+
+
+def test_bad_npc_block(tmp_path: Path) -> None:
+    note = tmp_path / "npc.md"
+    note.write_text("---\n---\n```npc\n: - bad\n```", encoding="utf-8")
+    with pytest.raises(NoteParseError):
+        parse_note(note)


### PR DESCRIPTION
## Summary
- parse Obsidian-style notes with frontmatter and npc blocks
- expose `parse_note` returning text, aliases, tags and custom fields
- add tests for note parsing and dependency on python-frontmatter

## Testing
- `pytest tests/test_parse_note.py` *(fails: No module named 'frontmatter')*

------
https://chatgpt.com/codex/tasks/task_e_68c4513cf9ec8325b09409163f25a18a