### PR TITLE
Add training UI and script

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -73,6 +73,7 @@
       <h2>Train Model</h2>
     </a>
   </div>
+  <script src="/ui/train.js"></script>
   <script>
     const carousel = document.querySelector('.carousel');
     carousel.addEventListener('keydown', (e) => {

--- a/ui/train.html
+++ b/ui/train.html
@@ -5,19 +5,36 @@
   <title>Train Model</title>
   <style>
     body {
+      font-family: sans-serif;
+      margin: 1em;
       background: #000;
       color: #fff;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      height: 100vh;
-      margin: 0;
-      font-family: sans-serif;
     }
+    label { display:block; margin-bottom:0.5em; }
+    #log {
+      background:#111;
+      color:#0f0;
+      padding:0.5em;
+      height:200px;
+      overflow-y:scroll;
+    }
+    #controls { margin-top:1em; }
   </style>
 </head>
 <body>
-  <h1>Under Construction</h1>
+  <div id="inputs">
+    <label>MIDI files <input type="file" id="midis" multiple accept=".mid,.midi" /></label>
+    <label>Limit <input type="number" id="limit" /></label>
+  </div>
+  <div id="controls">
+    <button id="start" type="button">Start</button>
+    <button id="cancel" type="button" disabled>Cancel</button>
+    <progress id="progress" value="0" max="100"></progress>
+    <span id="stage"></span>
+  </div>
+  <pre id="log"></pre>
+
   <script src="/ui/topbar.js"></script>
+  <script src="/ui/train.js"></script>
 </body>
 </html>

--- a/ui/train.js
+++ b/ui/train.js
@@ -1,0 +1,62 @@
+(function(){
+  function $(id){ return document.getElementById(id); }
+
+  const midiInput = $('midis');
+  const limitInput = $('limit');
+  const startBtn = $('start');
+  const cancelBtn = $('cancel');
+  const prog = $('progress');
+  const stage = $('stage');
+  const log = $('log');
+
+  let jobId = null;
+
+  if(!startBtn) return; // script loaded on unrelated pages
+
+  startBtn.addEventListener('click', async () => {
+    const fd = new FormData();
+    const files = midiInput.files;
+    for(let i=0;i<files.length;i++){
+      fd.append('midis', files[i]);
+    }
+    if(limitInput.value) fd.append('limit', limitInput.value);
+    const resp = await fetch('/train', {method:'POST', body: fd});
+    const data = await resp.json();
+    jobId = data.job_id;
+    startBtn.disabled = true;
+    cancelBtn.disabled = false;
+    log.textContent = '';
+    prog.value = 0;
+    stage.textContent = '';
+    poll();
+  });
+
+  cancelBtn.addEventListener('click', async () => {
+    if(jobId){
+      await fetch(`/jobs/${jobId}/cancel`, {method:'POST'});
+    }
+  });
+
+  async function poll(){
+    if(!jobId) return;
+    try{
+      const resp = await fetch(`/jobs/${jobId}`);
+      if(!resp.ok) throw new Error('status');
+      const data = await resp.json();
+      if(typeof data.progress === 'number') prog.value = data.progress;
+      if(data.log){
+        log.textContent = data.log.join('\n');
+        log.scrollTop = log.scrollHeight;
+      }
+      stage.textContent = data.stage || '';
+      if(data.status === 'running'){
+        setTimeout(poll, 1000);
+      }else{
+        startBtn.disabled = false;
+        cancelBtn.disabled = true;
+      }
+    }catch(e){
+      console.error(e);
+    }
+  }
+})();


### PR DESCRIPTION
## Summary
- implement training page with MIDI uploads, limit field, progress bar and log
- add train.js to submit jobs, poll status and cancel
- load train.js on index page for availability across UI

## Testing
- `pytest tests/test_webui_health.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4542df7d08325a9d33f51eb441d7a