### PR TITLE
Add settings page with theme selection and about dialog

### DIFF
--- a/ui/dnd.html
+++ b/ui/dnd.html
@@ -3,10 +3,11 @@
 <head>
   <meta charset="utf-8" />
   <title>Dungeons & Dragons</title>
+  <script src="/ui/theme.js"></script>
   <style>
     body {
-      background: #000;
-      color: #fff;
+      background: var(--bg-color);
+      color: var(--text-color);
       display: flex;
       justify-content: center;
       align-items: center;

--- a/ui/generate.html
+++ b/ui/generate.html
@@ -3,11 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <title>Blossom Render</title>
+  <script src="/ui/theme.js"></script>
   <style>
-    body { font-family: sans-serif; margin: 1em; }
+    body { font-family: sans-serif; margin: 1em; background: var(--bg-color); color: var(--text-color); }
     label { display: block; margin-bottom: 0.5em; }
     #controls { margin-top: 1em; }
-    #log { background: #111; color: #0f0; padding: 0.5em; height: 200px; overflow-y: scroll; }
+    #log { background: var(--log-bg); color: var(--log-text); padding: 0.5em; height: 200px; overflow-y: scroll; }
     #results { margin-top: 1em; }
     #recent { margin-top: 1em; }
   </style>

--- a/ui/index.html
+++ b/ui/index.html
@@ -3,10 +3,11 @@
 <head>
   <meta charset="utf-8" />
   <title>Blossom Music Generator</title>
+  <script src="/ui/theme.js"></script>
   <style>
     body {
-      background: #000;
-      color: #fff;
+      background: var(--bg-color);
+      color: var(--text-color);
       margin: 0;
       font-family: sans-serif;
     }
@@ -20,24 +21,24 @@
     }
 
     .carousel:focus {
-      outline: 2px solid #fff;
+      outline: 2px solid var(--text-color);
     }
 
     .panel {
       flex: 0 0 80%;
       max-width: 300px;
-      background: #111;
+      background: var(--panel-bg);
       border-radius: 8px;
       padding: 2rem 1rem;
       text-align: center;
       text-decoration: none;
-      color: #fff;
+      color: var(--text-color);
       scroll-snap-align: start;
     }
 
     .panel:hover,
     .panel:focus {
-      background: #222;
+      background: var(--panel-hover);
     }
 
     .panel-icon {

--- a/ui/settings.html
+++ b/ui/settings.html
@@ -3,21 +3,70 @@
 <head>
   <meta charset="utf-8" />
   <title>Settings</title>
+  <script src="/ui/theme.js"></script>
   <style>
     body {
-      background: #000;
-      color: #fff;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      height: 100vh;
+      background: var(--bg-color);
+      color: var(--text-color);
       margin: 0;
       font-family: sans-serif;
     }
+    .settings-container {
+      display: flex;
+      height: 100vh;
+    }
+    .menu {
+      width: 200px;
+      background: var(--panel-bg);
+      padding: 1rem;
+      box-sizing: border-box;
+    }
+    .menu button {
+      display: block;
+      width: 100%;
+      background: none;
+      border: none;
+      color: var(--text-color);
+      padding: 0.5rem 1rem;
+      text-align: left;
+      cursor: pointer;
+    }
+    .menu button.active,
+    .menu button:hover {
+      background: var(--panel-hover);
+    }
+    .content {
+      flex: 1;
+      padding: 1rem;
+      box-sizing: border-box;
+    }
+    .section { display: none; }
+    .section.active { display: block; }
   </style>
 </head>
 <body>
-  <h1>Under Construction</h1>
+  <div class="settings-container">
+    <aside class="menu">
+      <button class="active" data-section="general">General</button>
+      <button data-section="appearance">Appearance</button>
+    </aside>
+    <section class="content">
+      <div id="general" class="section active">
+        <h2>General</h2>
+        <button id="about-btn" type="button">About</button>
+        <div id="about-info" style="margin-top:1rem;"></div>
+      </div>
+      <div id="appearance" class="section">
+        <h2>Appearance</h2>
+        <label for="theme-select">Theme:</label>
+        <select id="theme-select">
+          <option value="dark">Dark</option>
+          <option value="light">Light</option>
+        </select>
+      </div>
+    </section>
+  </div>
+  <script src="/ui/settings.js"></script>
   <script src="/ui/topbar.js"></script>
 </body>
 </html>

--- a/ui/settings.js
+++ b/ui/settings.js
@@ -1,0 +1,26 @@
+(function() {
+  function showSection(id) {
+    document.querySelectorAll('.section').forEach(s => s.classList.remove('active'));
+    document.querySelectorAll('.menu button').forEach(b => b.classList.remove('active'));
+    document.getElementById(id).classList.add('active');
+    document.querySelector(`.menu button[data-section="${id}"]`).classList.add('active');
+  }
+
+  document.querySelectorAll('.menu button').forEach(btn => {
+    btn.addEventListener('click', () => showSection(btn.dataset.section));
+  });
+
+  document.getElementById('about-btn').addEventListener('click', async () => {
+    const resp = await fetch('/about');
+    if (resp.ok) {
+      const data = await resp.json();
+      document.getElementById('about-info').textContent = `Python ${data.python_version}`;
+    }
+  });
+
+  const themeSelect = document.getElementById('theme-select');
+  themeSelect.value = localStorage.getItem('theme') || 'dark';
+  themeSelect.addEventListener('change', () => {
+    setTheme(themeSelect.value);
+  });
+})();

--- a/ui/theme.js
+++ b/ui/theme.js
@@ -1,0 +1,39 @@
+(function() {
+  const themes = {
+    dark: {
+      '--bg-color': '#000',
+      '--text-color': '#fff',
+      '--panel-bg': '#111',
+      '--panel-hover': '#222',
+      '--topbar-bg': '#111',
+      '--button-bg': '#444',
+      '--button-hover-bg': '#555',
+      '--log-bg': '#111',
+      '--log-text': '#0f0'
+    },
+    light: {
+      '--bg-color': '#fff',
+      '--text-color': '#000',
+      '--panel-bg': '#eee',
+      '--panel-hover': '#ddd',
+      '--topbar-bg': '#f0f0f0',
+      '--button-bg': '#ddd',
+      '--button-hover-bg': '#ccc',
+      '--log-bg': '#eee',
+      '--log-text': '#060'
+    }
+  };
+
+  function applyTheme(name) {
+    const theme = themes[name] || themes.dark;
+    for (const [k, v] of Object.entries(theme)) {
+      document.documentElement.style.setProperty(k, v);
+    }
+    localStorage.setItem('theme', name);
+  }
+
+  const saved = localStorage.getItem('theme') || 'dark';
+  applyTheme(saved);
+
+  window.setTheme = applyTheme;
+})();

--- a/ui/topbar.js
+++ b/ui/topbar.js
@@ -6,8 +6,8 @@
       top: 0;
       left: 0;
       right: 0;
-      background: #111;
-      color: #fff;
+      background: var(--topbar-bg);
+      color: var(--text-color);
       padding: 0.5rem;
       display: flex;
       align-items: center;
@@ -15,14 +15,14 @@
     }
     body { padding-top: 2.5rem; }
     #top-bar button {
-      background: #444;
-      color: #fff;
+      background: var(--button-bg);
+      color: var(--text-color);
       border: none;
       padding: 0.25rem 0.5rem;
       cursor: pointer;
     }
     #top-bar button:hover {
-      background: #555;
+      background: var(--button-hover-bg);
     }
   `;
   document.head.appendChild(style);

--- a/ui/train.html
+++ b/ui/train.html
@@ -3,10 +3,11 @@
 <head>
   <meta charset="utf-8" />
   <title>Train Model</title>
+  <script src="/ui/theme.js"></script>
   <style>
     body {
-      background: #000;
-      color: #fff;
+      background: var(--bg-color);
+      color: var(--text-color);
       display: flex;
       justify-content: center;
       align-items: center;

--- a/webui/app.py
+++ b/webui/app.py
@@ -180,6 +180,12 @@ async def generate() -> HTMLResponse:
     return HTMLResponse((REPO_ROOT / "ui" / "generate.html").read_text())
 
 
+@app.get("/about")
+async def about() -> dict[str, str]:
+    """Return basic program information."""
+    return {"python_version": sys.version}
+
+
 @app.get("/settings", response_class=HTMLResponse)
 async def settings() -> HTMLResponse:
     return HTMLResponse((REPO_ROOT / "ui" / "settings.html").read_text())


### PR DESCRIPTION
## Summary
- Implement settings interface with General and Appearance sections
- Add About action showing Python version from new `/about` endpoint
- Introduce light/dark themes with dark as default across UI

## Testing
- `pytest tests/test_webui_health.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4550c4dc083259b90b7f203a3f5a2