### PR TITLE
Add models listing page and API

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -72,6 +72,10 @@
       <span class="panel-icon">🎚️</span>
       <h2>Train Model</h2>
     </a>
+    <a class="panel" href="/models">
+      <span class="panel-icon">📦</span>
+      <h2>Models</h2>
+    </a>
   </div>
   <script src="/ui/train.js"></script>
   <script>

--- a/ui/models.html
+++ b/ui/models.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Available Models</title>
+  <style>
+    body {
+      background: #000;
+      color: #fff;
+      margin: 0;
+      font-family: sans-serif;
+      padding: 1rem;
+    }
+    a {
+      color: #4af;
+    }
+    ul {
+      list-style: none;
+      padding: 0;
+    }
+    li {
+      margin: 0.5rem 0;
+    }
+  </style>
+</head>
+<body>
+  <h1>Available Models</h1>
+  <ul id="models"></ul>
+  <script src="/ui/models.js"></script>
+</body>
+</html>

--- a/ui/models.js
+++ b/ui/models.js
@@ -1,0 +1,19 @@
+(function(){
+  const list = document.getElementById('models');
+  if(!list) return;
+  fetch('/models', {headers: {'Accept': 'application/json'}})
+    .then(r => r.json())
+    .then(models => {
+      models.forEach(m => {
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        a.href = m.url;
+        a.textContent = m.name;
+        li.appendChild(a);
+        list.appendChild(li);
+      });
+    })
+    .catch(err => {
+      console.error(err);
+    });
+})();


### PR DESCRIPTION
## Summary
- Add `/models` page listing downloadable models
- Link models page from home carousel
- Serve model listings and downloads via FastAPI

## Testing
- `pytest tests/test_webui_health.py::test_health_check -q`
- `pytest` *(fails: command hung, unable to complete)*

------
https://chatgpt.com/codex/tasks/task_e_68c456781ae48325a620b0573707bfe1