### PR TITLE
Add model selection for phrase models

### DIFF
--- a/ui/app.js
+++ b/ui/app.js
@@ -9,14 +9,23 @@ const isTauri = typeof window !== 'undefined' && window.__TAURI__;
 async function browserMain(){
   async function loadOptions(){
     try {
-      const [presets, styles] = await Promise.all([
+      const [presets, styles, models] = await Promise.all([
         fetch('/presets').then(r=>r.json()),
         fetch('/styles').then(r=>r.json()),
+        fetch('/models').then(r=>r.json()),
       ]);
       const presetSel = $('preset');
       presets.forEach(p=>{ const opt=document.createElement('option'); opt.value=p; opt.textContent=p; presetSel.appendChild(opt); });
       const styleSel = $('style');
       styles.forEach(s=>{ const opt=document.createElement('option'); opt.value=s; opt.textContent=s; styleSel.appendChild(opt); });
+      const drumsSel = $('drums_model');
+      const bassSel = $('bass_model');
+      const keysSel = $('keys_model');
+      models.forEach(m=>{
+        if (m.startsWith('drums')){ const opt=document.createElement('option'); opt.value=m; opt.textContent=m; drumsSel.appendChild(opt); }
+        if (m.startsWith('bass')){ const opt=document.createElement('option'); opt.value=m; opt.textContent=m; bassSel.appendChild(opt); }
+        if (m.startsWith('keys')){ const opt=document.createElement('option'); opt.value=m; opt.textContent=m; keysSel.appendChild(opt); }
+      });
     } catch(err) {
       console.error('failed to load options', err);
     }
@@ -59,6 +68,9 @@ async function browserMain(){
     $('seed').value = job.seed ?? 42;
     $('name').value = job.name || 'output';
     $('phrase').checked = !!job.phrase;
+    $('drums_model').value = job.drums_model || '';
+    $('bass_model').value = job.bass_model || '';
+    $('keys_model').value = job.keys_model || '';
     $('preview').value = job.preview ?? '';
     outputDir = job.outdir || '';
     $('outdir').value = outputDir;
@@ -121,6 +133,9 @@ async function browserMain(){
     const melody = $('melody_midi').files[0];
     if (melody) fd.append('melody_midi', melody);
     if ($('phrase').checked) fd.append('phrase', 'true');
+    if ($('drums_model').value) fd.append('drums_model', $('drums_model').value);
+    if ($('bass_model').value) fd.append('bass_model', $('bass_model').value);
+    if ($('keys_model').value) fd.append('keys_model', $('keys_model').value);
     if ($('arrange').value) fd.append('arrange', $('arrange').value);
     if ($('outro').value) fd.append('outro', $('outro').value);
     if ($('preview').value) fd.append('preview', $('preview').value);

--- a/ui/generate.html
+++ b/ui/generate.html
@@ -34,6 +34,9 @@
     <label>Mix config <input type="file" id="mix_config" /></label>
     <label>Arrange config <input type="file" id="arrange_config" /></label>
     <label><input type="checkbox" id="phrase" /> Phrase backend</label>
+    <label>Drums model <select id="drums_model"><option value="">(default)</option></select></label>
+    <label>Bass model <select id="bass_model"><option value="">(default)</option></select></label>
+    <label>Keys model <select id="keys_model"><option value="">(default)</option></select></label>
     <label>Preview bars <input type="number" id="preview" /></label>
     <label><input type="checkbox" id="bundle_stems" /> Bundle stems</label>
     <label><input type="checkbox" id="eval_only" /> Eval only</label>

--- a/webui/app.py
+++ b/webui/app.py
@@ -156,6 +156,9 @@ def _watch(job_id: str) -> None:
         "phrase": job.get("phrase"),
         "preview": job.get("preview"),
         "outdir": job.get("outdir"),
+        "drums_model": job.get("drums_model"),
+        "bass_model": job.get("bass_model"),
+        "keys_model": job.get("keys_model"),
         "status": status,
         "hash": rhash,
         "mix_config": job.get("mix_config"),
@@ -310,6 +313,9 @@ async def render(
     phrase: bool = Form(False),
     preview: int | None = Form(None),
     outdir: str | None = Form(None),
+    drums_model: str | None = Form(None),
+    bass_model: str | None = Form(None),
+    keys_model: str | None = Form(None),
 ) -> dict:
     tmpdir = Path(tempfile.mkdtemp())
     mix_path = tmpdir / "mix.wav"
@@ -338,6 +344,12 @@ async def render(
         cmd += ["--use-phrase-model", "yes"]
     if preview is not None:
         cmd += ["--preview", str(preview)]
+    if drums_model:
+        cmd += ["--drums-model", str(MODELS_DIR / drums_model)]
+    if bass_model:
+        cmd += ["--bass-model", str(MODELS_DIR / bass_model)]
+    if keys_model:
+        cmd += ["--keys-model", str(MODELS_DIR / keys_model)]
     if mix_config is not None:
         mix_bytes = await mix_config.read()
         mix_path = tmpdir / "mix_config.json"
@@ -381,6 +393,9 @@ async def render(
         "sections": sections,
         "phrase": phrase,
         "preview": preview,
+        "drums_model": drums_model,
+        "bass_model": bass_model,
+        "keys_model": keys_model,
         "mix_config": jobs_mix,
         "arrange_config": jobs_arr,
     }


### PR DESCRIPTION
## Summary
- add drums/bass/keys model selectors in render UI
- wire selected models through web backend and CLI
- allow overriding phrase models when rendering

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest` *(fails: peaking_eq_matches_reference, low_shelf_matches_reference, high_shelf_matches_reference)*

------
https://chatgpt.com/codex/tasks/task_e_68c4567e734483258a042eca6ca12e37