### PR TITLE
Add basic settings page with theme option

### DIFF
--- a/ui/settings.html
+++ b/ui/settings.html
@@ -4,20 +4,31 @@
   <meta charset="utf-8" />
   <title>Settings</title>
   <style>
-    body {
-      background: #000;
-      color: #fff;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      height: 100vh;
-      margin: 0;
-      font-family: sans-serif;
-    }
+    body { font-family: sans-serif; margin: 1em; }
+    section { margin-bottom: 2rem; }
+    label { display: block; margin-bottom: 0.5em; }
+    body.light { background: #fff; color: #000; }
+    body.dark { background: #000; color: #fff; }
   </style>
 </head>
 <body>
-  <h1>Under Construction</h1>
+  <h1>Settings</h1>
+  <section id="general">
+    <h2>General</h2>
+    <label>Default Output Directory
+      <input type="text" id="default_outdir" placeholder="/path/to/output" />
+    </label>
+  </section>
+  <section id="appearance">
+    <h2>Appearance</h2>
+    <label for="theme">Theme</label>
+    <select id="theme">
+      <option value="light">Light</option>
+      <option value="dark">Dark</option>
+    </select>
+  </section>
+  <button id="save" type="button">Save</button>
+  <script src="/ui/settings.js"></script>
   <script src="/ui/topbar.js"></script>
 </body>
 </html>

--- a/ui/settings.js
+++ b/ui/settings.js
@@ -1,0 +1,36 @@
+(function() {
+  function $(id) { return document.getElementById(id); }
+
+  function applyTheme(theme) {
+    document.body.classList.remove('light', 'dark');
+    document.body.classList.add(theme);
+  }
+
+  function load() {
+    const outdir = localStorage.getItem('default_outdir') || '';
+    const theme = localStorage.getItem('theme') || 'dark';
+    const outInput = $('default_outdir');
+    const themeSel = $('theme');
+    if (outInput) outInput.value = outdir;
+    if (themeSel) themeSel.value = theme;
+    applyTheme(theme);
+  }
+
+  function save() {
+    const outInput = $('default_outdir');
+    const themeSel = $('theme');
+    if (outInput) localStorage.setItem('default_outdir', outInput.value);
+    if (themeSel) {
+      localStorage.setItem('theme', themeSel.value);
+      applyTheme(themeSel.value);
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    load();
+    const saveBtn = $('save');
+    if (saveBtn) saveBtn.addEventListener('click', save);
+    const themeSel = $('theme');
+    if (themeSel) themeSel.addEventListener('change', () => applyTheme(themeSel.value));
+  });
+})();


### PR DESCRIPTION
## Summary
- Replace settings placeholder with General and Appearance sections
- Allow choosing default output directory and Light/Dark theme
- Persist settings in localStorage via new settings.js

## Testing
- `pytest -q` *(fails: test_peaking_eq_matches_reference, test_low_shelf_matches_reference, test_high_shelf_matches_reference)*

------
https://chatgpt.com/codex/tasks/task_e_68c45749e38c83258e955861ea98ebeb