### PR TITLE
feat: add web UI about endpoint and button

### DIFF
--- a/tests/test_webui_about.py
+++ b/tests/test_webui_about.py
@@ -1,0 +1,26 @@
+import os, sys, types
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+multipart_mod = types.ModuleType("multipart")
+multipart_submod = types.ModuleType("multipart.multipart")
+multipart_mod.__version__ = "0"
+
+
+def parse_options_header(value: str) -> tuple[str, dict[str, str]]:
+    return value, {}
+
+
+multipart_submod.parse_options_header = parse_options_header
+sys.modules.setdefault("multipart", multipart_mod)
+sys.modules.setdefault("multipart.multipart", multipart_submod)
+
+from webui.app import app
+
+
+def test_about_endpoint():
+    client = TestClient(app)
+    resp = client.get("/about")
+    assert resp.status_code == 200
+    assert resp.json() == {"python": sys.version}

--- a/ui/topbar.js
+++ b/ui/topbar.js
@@ -33,5 +33,17 @@
   back.textContent = 'Back';
   back.addEventListener('click', () => history.back());
   bar.appendChild(back);
+  const about = document.createElement('button');
+  about.textContent = 'About';
+  about.addEventListener('click', async () => {
+    try {
+      const res = await fetch('/about');
+      const data = await res.json();
+      alert(`Python version: ${data.python}`);
+    } catch (err) {
+      alert('Failed to fetch version');
+    }
+  });
+  bar.appendChild(about);
   document.body.prepend(bar);
 })();

--- a/webui/app.py
+++ b/webui/app.py
@@ -197,6 +197,11 @@ async def health() -> dict[str, str]:
     return {"status": "ok"}
 
 
+@app.get("/about")
+def about() -> dict[str, str]:
+    return {"python": sys.version}
+
+
 @app.get("/", response_class=HTMLResponse)
 async def home() -> HTMLResponse:
     return HTMLResponse((REPO_ROOT / "ui" / "index.html").read_text())


### PR DESCRIPTION
## Summary
- expose `/about` endpoint returning Python version
- add About button to top bar that fetches `/about`
- test about endpoint

## Testing
- `pytest tests/test_webui_about.py`

------
https://chatgpt.com/codex/tasks/task_e_68c45b2bebd083258884993d11891bba