### PR TITLE
feat(ui): add theme support

### DIFF
--- a/ui/dnd.html
+++ b/ui/dnd.html
@@ -1,12 +1,13 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 <head>
   <meta charset="utf-8" />
   <title>Dungeons & Dragons</title>
+  <link rel="stylesheet" href="/ui/theme.css">
   <style>
     body {
-      background: #000;
-      color: #fff;
+      background: var(--bg);
+      color: var(--fg);
       display: flex;
       justify-content: center;
       align-items: center;

--- a/ui/generate.html
+++ b/ui/generate.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 <head>
   <meta charset="utf-8" />
   <title>Blossom Render</title>
+  <link rel="stylesheet" href="/ui/theme.css">
   <style>
-    body { font-family: sans-serif; margin: 1em; }
+    body { font-family: sans-serif; margin: 1em; background: var(--bg); color: var(--fg); }
     label { display: block; margin-bottom: 0.5em; }
     #controls { margin-top: 1em; }
-    #log { background: #111; color: #0f0; padding: 0.5em; height: 200px; overflow-y: scroll; }
+    #log { background: var(--log-bg); color: var(--log-fg); padding: 0.5em; height: 200px; overflow-y: scroll; }
     #results { margin-top: 1em; }
     #recent { margin-top: 1em; }
   </style>

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,12 +1,13 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 <head>
   <meta charset="utf-8" />
   <title>Blossom Music Generator</title>
+  <link rel="stylesheet" href="/ui/theme.css">
   <style>
     body {
-      background: #000;
-      color: #fff;
+      background: var(--bg);
+      color: var(--fg);
       margin: 0;
       font-family: sans-serif;
     }
@@ -20,24 +21,24 @@
     }
 
     .carousel:focus {
-      outline: 2px solid #fff;
+      outline: 2px solid var(--fg);
     }
 
     .panel {
       flex: 0 0 80%;
       max-width: 300px;
-      background: #111;
+      background: var(--panel-bg);
       border-radius: 8px;
       padding: 2rem 1rem;
       text-align: center;
       text-decoration: none;
-      color: #fff;
+      color: var(--fg);
       scroll-snap-align: start;
     }
 
     .panel:hover,
     .panel:focus {
-      background: #222;
+      background: var(--panel-hover-bg);
     }
 
     .panel-icon {
@@ -77,6 +78,7 @@
       <h2>Models</h2>
     </a>
   </div>
+  <script src="/ui/topbar.js"></script>
   <script src="/ui/train.js"></script>
   <script>
     const carousel = document.querySelector('.carousel');

--- a/ui/models.html
+++ b/ui/models.html
@@ -1,18 +1,19 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 <head>
   <meta charset="utf-8" />
   <title>Available Models</title>
+  <link rel="stylesheet" href="/ui/theme.css">
   <style>
     body {
-      background: #000;
-      color: #fff;
+      background: var(--bg);
+      color: var(--fg);
       margin: 0;
       font-family: sans-serif;
       padding: 1rem;
     }
     a {
-      color: #4af;
+      color: var(--link);
     }
     ul {
       list-style: none;
@@ -26,6 +27,7 @@
 <body>
   <h1>Available Models</h1>
   <ul id="models"></ul>
+  <script src="/ui/topbar.js"></script>
   <script src="/ui/models.js"></script>
 </body>
 </html>

--- a/ui/settings.html
+++ b/ui/settings.html
@@ -1,14 +1,13 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 <head>
   <meta charset="utf-8" />
   <title>Settings</title>
+  <link rel="stylesheet" href="/ui/theme.css">
   <style>
-    body { font-family: sans-serif; margin: 1em; }
+    body { font-family: sans-serif; margin: 1em; background: var(--bg); color: var(--fg); }
     section { margin-bottom: 2rem; }
     label { display: block; margin-bottom: 0.5em; }
-    body.light { background: #fff; color: #000; }
-    body.dark { background: #000; color: #fff; }
   </style>
 </head>
 <body>

--- a/ui/settings.js
+++ b/ui/settings.js
@@ -1,36 +1,28 @@
 (function() {
   function $(id) { return document.getElementById(id); }
 
-  function applyTheme(theme) {
-    document.body.classList.remove('light', 'dark');
-    document.body.classList.add(theme);
-  }
-
   function load() {
     const outdir = localStorage.getItem('default_outdir') || '';
     const theme = localStorage.getItem('theme') || 'dark';
     const outInput = $('default_outdir');
     const themeSel = $('theme');
     if (outInput) outInput.value = outdir;
-    if (themeSel) themeSel.value = theme;
-    applyTheme(theme);
+    if (themeSel) {
+      themeSel.value = theme;
+      themeSel.addEventListener('change', () => window.setTheme(themeSel.value));
+    }
   }
 
   function save() {
     const outInput = $('default_outdir');
     const themeSel = $('theme');
     if (outInput) localStorage.setItem('default_outdir', outInput.value);
-    if (themeSel) {
-      localStorage.setItem('theme', themeSel.value);
-      applyTheme(themeSel.value);
-    }
+    if (themeSel) window.setTheme(themeSel.value);
   }
 
   document.addEventListener('DOMContentLoaded', () => {
     load();
     const saveBtn = $('save');
     if (saveBtn) saveBtn.addEventListener('click', save);
-    const themeSel = $('theme');
-    if (themeSel) themeSel.addEventListener('change', () => applyTheme(themeSel.value));
   });
 })();

--- a/ui/theme.css
+++ b/ui/theme.css
@@ -1,0 +1,23 @@
+[data-theme="dark"] {
+  --bg: #000;
+  --fg: #fff;
+  --panel-bg: #111;
+  --panel-hover-bg: #222;
+  --button-bg: #444;
+  --button-hover-bg: #555;
+  --link: #4af;
+  --log-bg: #111;
+  --log-fg: #0f0;
+}
+
+[data-theme="light"] {
+  --bg: #fff;
+  --fg: #000;
+  --panel-bg: #f0f0f0;
+  --panel-hover-bg: #ddd;
+  --button-bg: #ddd;
+  --button-hover-bg: #ccc;
+  --link: #06c;
+  --log-bg: #f0f0f0;
+  --log-fg: #070;
+}

--- a/ui/topbar.js
+++ b/ui/topbar.js
@@ -1,4 +1,12 @@
 (function() {
+  window.setTheme = function(theme) {
+    localStorage.setItem('theme', theme);
+    document.documentElement.setAttribute('data-theme', theme);
+  };
+
+  const currentTheme = localStorage.getItem('theme') || 'dark';
+  document.documentElement.setAttribute('data-theme', currentTheme);
+
   const style = document.createElement('style');
   style.textContent = `
     #top-bar {
@@ -6,8 +14,8 @@
       top: 0;
       left: 0;
       right: 0;
-      background: #111;
-      color: #fff;
+      background: var(--panel-bg);
+      color: var(--fg);
       padding: 0.5rem;
       display: flex;
       align-items: center;
@@ -15,14 +23,14 @@
     }
     body { padding-top: 2.5rem; }
     #top-bar button {
-      background: #444;
-      color: #fff;
+      background: var(--button-bg);
+      color: var(--fg);
       border: none;
       padding: 0.25rem 0.5rem;
       cursor: pointer;
     }
     #top-bar button:hover {
-      background: #555;
+      background: var(--button-hover-bg);
     }
   `;
   document.head.appendChild(style);

--- a/ui/train.html
+++ b/ui/train.html
@@ -1,19 +1,20 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 <head>
   <meta charset="utf-8" />
   <title>Train Model</title>
+  <link rel="stylesheet" href="/ui/theme.css">
   <style>
     body {
       font-family: sans-serif;
       margin: 1em;
-      background: #000;
-      color: #fff;
+      background: var(--bg);
+      color: var(--fg);
     }
     label { display:block; margin-bottom:0.5em; }
     #log {
-      background:#111;
-      color:#0f0;
+      background: var(--log-bg);
+      color: var(--log-fg);
       padding:0.5em;
       height:200px;
       overflow-y:scroll;


### PR DESCRIPTION
## Summary
- add theme stylesheet with color variables for dark and light modes
- replace hard-coded colors in UI and top bar with CSS variables
- persist theme selection and load preferred theme across pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest` *(fails: tests/test_eq_filters.py::test_peaking_eq_matches_reference; tests/test_low_shelf_matches_reference; tests/test_high_shelf_matches_reference)*

------
https://chatgpt.com/codex/tasks/task_e_68c460b115688325b0c8a46d5bf38d35