### PR TITLE
feat: add Obsidian vault API endpoints

### DIFF
--- a/tests/test_obsidian_api.py
+++ b/tests/test_obsidian_api.py
@@ -1,0 +1,133 @@
+import os
+import sys
+import types
+
+from fastapi.testclient import TestClient
+
+# Patch ``multipart`` as done in other tests to satisfy FastAPI dependency
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+multipart_mod = types.ModuleType("multipart")
+multipart_submod = types.ModuleType("multipart.multipart")
+multipart_mod.__version__ = "0"
+
+def parse_options_header(value: str) -> tuple[str, dict[str, str]]:
+    return value, {}
+
+multipart_submod.parse_options_header = parse_options_header
+sys.modules.setdefault("multipart", multipart_mod)
+sys.modules.setdefault("multipart.multipart", multipart_submod)
+
+from webui.app import app  # noqa: E402
+from config import obsidian  # noqa: E402
+from notes.parser import parse_note  # noqa: E402
+from notes.chunker import chunk_note, store_chunks  # noqa: E402
+
+
+def _reset_vault() -> None:
+    if obsidian.VAULT_FILE.exists():
+        obsidian.VAULT_FILE.unlink()
+    if "_VAULT_PATH" in obsidian.__dict__:
+        obsidian.__dict__["_VAULT_PATH"] = None
+
+
+def _setup_vault(tmp_path):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+
+    (vault / "npc_a.md").write_text(
+        """---
+aliases: [Alice]
+tags: [npc, friend]
+---
+# Bio
+Alice is a friendly NPC.
+# Story
+Alice has a pet dragon.
+""",
+        encoding="utf-8",
+    )
+
+    (vault / "npc_b.md").write_text(
+        """---
+aliases: Bob
+tags: npc
+---
+# Bio
+Bob is an NPC.
+# Story
+Bob lost his sword.
+""",
+        encoding="utf-8",
+    )
+
+    (vault / "lore.md").write_text(
+        """---
+tags: lore
+---
+# History
+The ancient sword was forged in fire.
+""",
+        encoding="utf-8",
+    )
+
+    # Build chunk database
+    chunks = []
+    for path in vault.glob("*.md"):
+        parsed = parse_note(path)
+        rel = path.relative_to(vault).as_posix()
+        chunks.extend(chunk_note(parsed, rel))
+    store_chunks(chunks, vault / "chunks.db")
+
+    _reset_vault()
+    obsidian.select_vault(vault)
+    return vault
+
+
+def test_get_note(tmp_path):
+    _setup_vault(tmp_path)
+    client = TestClient(app)
+
+    resp = client.get("/obsidian/note", params={"path": "npc_a.md"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["aliases"] == ["Alice"]
+    assert "friendly NPC" in data["content"]
+
+    resp = client.get("/obsidian/note", params={"path": "missing.md"})
+    assert resp.status_code == 404
+
+
+def test_search(tmp_path):
+    _setup_vault(tmp_path)
+    client = TestClient(app)
+
+    resp = client.get("/obsidian/search", params={"q": "sword"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] >= 2
+    paths = {r["path"] for r in data["results"]}
+    assert "npc_b.md" in paths
+    assert "lore.md" in paths
+
+    resp = client.get(
+        "/obsidian/search", params={"q": "sword", "limit": 1, "offset": 1}
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["results"]) == 1
+
+
+def test_npcs(tmp_path):
+    _setup_vault(tmp_path)
+    client = TestClient(app)
+
+    resp = client.get("/obsidian/npcs")
+    assert resp.status_code == 200
+    data = resp.json()
+    paths = {r["path"] for r in data["results"]}
+    assert {"npc_a.md", "npc_b.md"} <= paths
+
+    resp = client.get("/obsidian/npcs", params={"limit": 1})
+    assert resp.status_code == 200
+    assert len(resp.json()["results"]) == 1

--- a/webui/__init__.py
+++ b/webui/__init__.py
@@ -1,0 +1,4 @@
+"""Web UI package initialization."""
+
+# Import side-effect to register additional API routes
+from . import obsidian_api  # noqa: F401

--- a/webui/obsidian_api.py
+++ b/webui/obsidian_api.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+"""FastAPI endpoints for interacting with Obsidian vault notes."""
+
+from pathlib import Path
+import sqlite3
+from typing import List
+
+from fastapi import HTTPException, Query
+
+from .app import app
+from config.obsidian import get_vault
+from notes.parser import parse_note, NoteParseError
+
+
+def _get_vault() -> Path:
+    """Return the configured Obsidian vault path or raise an error."""
+
+    vault = get_vault()
+    if vault is None:
+        raise HTTPException(status_code=400, detail="vault not set")
+    return vault
+
+
+@app.get("/obsidian/note")
+def get_note(path: str = Query(..., description="Vault relative path")) -> dict:
+    """Return raw note content and metadata for ``path``.
+
+    Parameters
+    ----------
+    path:
+        Path to the note relative to the configured vault.
+    """
+
+    vault = _get_vault()
+    note_path = (vault / path).resolve()
+    try:
+        note_path.relative_to(vault.resolve())
+    except ValueError:  # outside vault
+        raise HTTPException(status_code=400, detail="invalid path")
+    if not note_path.exists() or not note_path.is_file():
+        raise HTTPException(status_code=404, detail="note not found")
+
+    try:
+        parsed = parse_note(note_path)
+    except NoteParseError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    content = note_path.read_text(encoding="utf-8")
+    return {
+        "path": path,
+        "content": content,
+        "aliases": parsed.aliases,
+        "tags": parsed.tags,
+        "fields": parsed.fields,
+    }
+
+
+@app.get("/obsidian/search")
+def search_notes(
+    q: str = Query(..., description="Search query"),
+    tags: str | None = Query(None, description="Comma separated list of tags"),
+    limit: int = Query(10, ge=1, le=50),
+    offset: int = Query(0, ge=0),
+) -> dict:
+    """Return ranked chunk summaries matching ``q``.
+
+    A simple substring search is used which honours an optional list of
+    ``tags``. Results are paginated via ``limit`` and ``offset``.
+    """
+
+    vault = _get_vault()
+    db_path = vault / "chunks.db"
+    if not db_path.exists():
+        raise HTTPException(status_code=404, detail="chunk database not found")
+
+    tag_list: List[str] = [t for t in (tags.split(",") if tags else []) if t]
+
+    conn = sqlite3.connect(db_path)
+    try:
+        if tag_list:
+            placeholders = ",".join("?" * len(tag_list))
+            sql = (
+                "SELECT c.path, c.heading, c.content FROM chunks c "
+                "JOIN tags t ON c.id = t.chunk_id "
+                f"WHERE t.tag IN ({placeholders})"
+            )
+            rows = conn.execute(sql, tag_list).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT path, heading, content FROM chunks"
+            ).fetchall()
+    finally:
+        conn.close()
+
+    q_lower = q.lower()
+    matches = []
+    for path_, heading, content in rows:
+        idx = content.lower().find(q_lower)
+        if idx != -1:
+            summary = content[:200]
+            matches.append(
+                {
+                    "path": path_,
+                    "heading": heading,
+                    "summary": summary,
+                    "score": idx,
+                }
+            )
+
+    matches.sort(key=lambda x: x["score"])  # smaller index => better match
+    total = len(matches)
+    items = matches[offset : offset + limit]
+    return {"total": total, "results": items}
+
+
+@app.get("/obsidian/npcs")
+def list_npcs(
+    limit: int = Query(50, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+) -> dict:
+    """Return notes tagged ``#npc`` with their aliases."""
+
+    vault = _get_vault()
+    npcs = []
+    for path in sorted(vault.rglob("*.md")):
+        try:
+            parsed = parse_note(path)
+        except NoteParseError:
+            continue
+        if any(tag.lower() == "npc" for tag in parsed.tags):
+            rel = path.relative_to(vault).as_posix()
+            npcs.append({"path": rel, "aliases": parsed.aliases})
+
+    total = len(npcs)
+    items = npcs[offset : offset + limit]
+    return {"total": total, "results": items}


### PR DESCRIPTION
## Summary
- expose `/obsidian/note` for raw note content and metadata
- add `/obsidian/search` with tag filters, ranking, and pagination
- provide `/obsidian/npcs` to list NPC-tagged notes and aliases
- cover new endpoints with unit tests and sample vault data

## Testing
- `pytest tests/test_obsidian_vault.py tests/test_obsidian_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4637b536c8325bcdf85884198c691