### PR TITLE
Add transcript logger with session rotation

### DIFF
--- a/ears/__init__.py
+++ b/ears/__init__.py
@@ -1,5 +1,12 @@
 """Audio input utilities."""
 
-from .discord_listener import DiscordListener
+from .transcript_logger import TranscriptLogger
 
-__all__ = ["DiscordListener"]
+try:  # pragma: no cover - optional dependency
+    from .discord_listener import DiscordListener
+except Exception:  # pragma: no cover - discord is optional
+    DiscordListener = None  # type: ignore[assignment]
+
+__all__ = ["TranscriptLogger"]
+if DiscordListener is not None:
+    __all__.append("DiscordListener")

--- a/ears/transcript_logger.py
+++ b/ears/transcript_logger.py
@@ -1,0 +1,123 @@
+"""Utilities for logging speech transcripts.
+
+This module provides :class:`TranscriptLogger` which appends JSON lines to a
+per‑channel log file. Each line contains ``channel_id``, ``speaker``, ``start``,
+``end``, ``text``, ``lang``, and ``confidence`` fields. Files are rotated on each
+new logger instantiation to avoid corruption across sessions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import datetime as _dt
+import glob
+import json
+import os
+from typing import Any, Dict, List
+
+__all__ = ["TranscriptLogger"]
+
+
+@dataclass
+class TranscriptEntry:
+    """Container describing a single transcript segment."""
+
+    channel_id: str
+    speaker: str
+    start: float
+    end: float
+    text: str
+    lang: str | None
+    confidence: float | None
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "channel_id": self.channel_id,
+                "speaker": self.speaker,
+                "start": self.start,
+                "end": self.end,
+                "text": self.text,
+                "lang": self.lang,
+                "confidence": self.confidence,
+            },
+            ensure_ascii=False,
+        )
+
+
+class TranscriptLogger:
+    """Append‑only JSONL logger for speech transcripts."""
+
+    def __init__(self, channel_id: str, *, root: str = "transcripts") -> None:
+        self.channel_id = str(channel_id)
+        self.root = root
+        os.makedirs(self.root, exist_ok=True)
+        self._path = os.path.join(self.root, f"{self.channel_id}.jsonl")
+
+        # Rotate any pre‑existing log to avoid corruption between sessions.
+        if os.path.exists(self._path):
+            timestamp = _dt.datetime.now().strftime("%Y%m%d%H%M%S")
+            rotated = os.path.join(self.root, f"{self.channel_id}.{timestamp}.jsonl")
+            os.replace(self._path, rotated)
+
+    # ------------------------------------------------------------------
+    def log(
+        self,
+        speaker: str,
+        start: float,
+        end: float,
+        text: str,
+        *,
+        lang: str | None = None,
+        confidence: float | None = None,
+    ) -> None:
+        """Append a transcript entry to the JSONL file.
+
+        Parameters
+        ----------
+        speaker, start, end, text, lang, confidence:
+            Metadata describing the transcript segment.
+        """
+
+        entry = TranscriptEntry(
+            channel_id=self.channel_id,
+            speaker=speaker,
+            start=start,
+            end=end,
+            text=text,
+            lang=lang,
+            confidence=confidence,
+        )
+
+        line = entry.to_json() + "\n"
+        data = line.encode("utf-8")
+        fd = os.open(self._path, os.O_APPEND | os.O_CREAT | os.O_WRONLY)
+        try:
+            with os.fdopen(fd, "ab") as f:
+                f.write(data)
+                f.flush()
+                os.fsync(f.fileno())
+        finally:
+            # ``with`` block closes fd; this is just to satisfy type checkers.
+            pass
+
+    # ------------------------------------------------------------------
+    def summary(self) -> List[Dict[str, Any]]:
+        """Return all transcript entries for ``channel_id``.
+
+        This scans both the current session file and any rotated logs.
+        """
+
+        pattern = os.path.join(self.root, f"{self.channel_id}*.jsonl")
+        entries: List[Dict[str, Any]] = []
+        for path in sorted(glob.glob(pattern)):
+            with open(path, "r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        entries.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        continue
+        return entries

--- a/tests/test_transcript_logger.py
+++ b/tests/test_transcript_logger.py
@@ -1,0 +1,33 @@
+import json
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from ears.transcript_logger import TranscriptLogger
+
+
+def test_transcript_logger_write_and_rotate(tmp_path: Path) -> None:
+    logger1 = TranscriptLogger("chan", root=str(tmp_path))
+    logger1.log("alice", 0.0, 1.0, "hello", lang="en", confidence=0.9)
+
+    first_file = tmp_path / "chan.jsonl"
+    assert first_file.exists()
+    with open(first_file, "r", encoding="utf-8") as f:
+        lines = f.read().splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0])["text"] == "hello"
+
+    logger2 = TranscriptLogger("chan", root=str(tmp_path))
+    rotated = list(tmp_path.glob("chan.*.jsonl"))
+    assert rotated and rotated[0].name != "chan.jsonl"
+    assert not (tmp_path / "chan.jsonl").exists()
+
+    logger2.log("bob", 1.0, 2.0, "hi", lang="en", confidence=0.8)
+    new_lines = (tmp_path / "chan.jsonl").read_text(encoding="utf-8").splitlines()
+    assert len(new_lines) == 1
+    assert json.loads(new_lines[0])["text"] == "hi"
+
+    summary = logger2.summary()
+    texts = {entry["text"] for entry in summary}
+    assert texts == {"hello", "hi"}


### PR DESCRIPTION
## Summary
- add `TranscriptLogger` to atomically append transcript entries per channel and rotate files per session
- expose logger in `ears` package with optional `discord_listener` import
- test transcript logging, rotation, and summary retrieval

## Testing
- `pytest tests/test_transcript_logger.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c46ab52f288325923ad36dcbb8af1b