### PR TITLE
Apply dark theme across UI and add theme switch

### DIFF
--- a/ui/onnx.html
+++ b/ui/onnx.html
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 <head>
   <meta charset="utf-8" />
   <title>ONNX Crafter</title>
+  <link rel="stylesheet" href="/ui/theme.css">
   <style>
-    body { font-family: sans-serif; margin: 1em; }
+    body { font-family: sans-serif; margin: 1em; background: var(--bg); color: var(--fg); }
   </style>
 </head>
 <body>

--- a/ui/settings.html
+++ b/ui/settings.html
@@ -25,6 +25,7 @@
       <option value="light">Light</option>
       <option value="dark">Dark</option>
     </select>
+    <button id="set_dark" type="button">Use Dark Theme</button>
   </section>
   <button id="save" type="button">Save</button>
   <script src="/ui/settings.js"></script>

--- a/ui/settings.js
+++ b/ui/settings.js
@@ -24,5 +24,11 @@
     load();
     const saveBtn = $('save');
     if (saveBtn) saveBtn.addEventListener('click', save);
+    const darkBtn = $('set_dark');
+    if (darkBtn) darkBtn.addEventListener('click', () => {
+      window.setTheme('dark');
+      const themeSel = $('theme');
+      if (themeSel) themeSel.value = 'dark';
+    });
   });
 })();


### PR DESCRIPTION
## Summary
- Ensure ONNX page uses the shared dark theme and styles
- Add button in settings to switch to dark theme and wire up handler
- Confirm topbar initializes theme from local storage with dark fallback

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest` *(fails: 30 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c46ad558c0832580d15afebd98f1fa