### PR TITLE
Add transcript logger with session rotation

### DIFF
--- a/ears/__init__.py
+++ b/ears/__init__.py
@@ -1,6 +1,11 @@
 """Audio input utilities."""
 
-from .discord_listener import DiscordListener
+from .transcript_logger import TranscriptLogger
+
+try:  # pragma: no cover - optional dependency
+    from .discord_listener import DiscordListener
+except Exception:  # ImportError and runtime errors if backend missing
+    DiscordListener = None  # type: ignore[assignment]
 
 try:  # pragma: no cover - optional dependency
     from .whisper_service import TranscriptionSegment, WhisperService
@@ -8,4 +13,9 @@ except Exception:  # ImportError and runtime errors if backend missing
     WhisperService = None  # type: ignore[assignment]
     TranscriptionSegment = None  # type: ignore[assignment]
 
-__all__ = ["DiscordListener", "WhisperService", "TranscriptionSegment"]
+__all__ = [
+    "DiscordListener",
+    "WhisperService",
+    "TranscriptionSegment",
+    "TranscriptLogger",
+]

--- a/ears/transcript_logger.py
+++ b/ears/transcript_logger.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+
+class TranscriptLogger:
+    """Append and rotate per-channel transcript logs.
+
+    Parameters
+    ----------
+    root:
+        Directory where transcript files are stored. Files are written in
+        JSONL format with one entry per line.
+    """
+
+    def __init__(self, root: str | Path) -> None:
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+        self._locks: Dict[str, threading.Lock] = {}
+        self._session = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _lock(self, channel: str) -> threading.Lock:
+        lock = self._locks.get(channel)
+        if lock is None:
+            lock = threading.Lock()
+            self._locks[channel] = lock
+        return lock
+
+    def _base_path(self, channel: str) -> Path:
+        return self.root / f"{channel}.jsonl"
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def append(self, channel: str, speaker: str, text: str, *, timestamp: Optional[float] = None) -> None:
+        """Append a transcript entry for ``channel``.
+
+        Each entry is written atomically to avoid interleaving between
+        concurrent writers. The log line is encoded as JSON and flushed using
+        the ``O_APPEND`` flag so writes are always appended.
+        """
+
+        entry = {
+            "ts": timestamp if timestamp is not None else time.time(),
+            "speaker": speaker,
+            "text": text,
+        }
+        data = json.dumps(entry, ensure_ascii=False) + "\n"
+        path = self._base_path(channel)
+        with self._lock(channel):
+            fd = os.open(path, os.O_WRONLY | os.O_APPEND | os.O_CREAT)
+            try:
+                os.write(fd, data.encode("utf-8"))
+            finally:
+                os.close(fd)
+
+    def rotate(self) -> str:
+        """Rotate existing channel logs into a session‑named file.
+
+        Returns the session identifier used for the rotation. New entries will
+        start a fresh session after calling this method.
+        """
+
+        session_id = self._session
+        for file in self.root.glob("*.jsonl"):
+            rotated = file.with_name(f"{file.stem}.{session_id}{file.suffix}")
+            file.replace(rotated)
+        self._session = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+        return session_id
+
+    def _session_path(self, channel: str, session_id: Optional[str]) -> Path:
+        if session_id is None:
+            return self._base_path(channel)
+        return self.root / f"{channel}.{session_id}.jsonl"
+
+    def entries(self, channel: str, session_id: Optional[str] = None) -> Iterable[dict]:
+        """Iterate transcript entries for ``channel`` and ``session_id``."""
+
+        path = self._session_path(channel, session_id)
+        if not path.exists():
+            return []
+        with open(path, encoding="utf-8") as fh:
+            return [json.loads(line) for line in fh if line.strip()]
+
+    def summary(self, channel: str, session_id: Optional[str] = None) -> str:
+        """Return a human‑readable summary for ``channel``."""
+
+        return "\n".join(f"{e['speaker']}: {e['text']}" for e in self.entries(channel, session_id))
+
+
+__all__ = ["TranscriptLogger"]

--- a/tests/test_transcript_logger.py
+++ b/tests/test_transcript_logger.py
@@ -1,0 +1,44 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from ears import TranscriptLogger
+
+
+def read_jsonl(path: Path):
+    if not path.exists():
+        return []
+    with open(path, encoding="utf-8") as fh:
+        return [json.loads(l) for l in fh if l.strip()]
+
+
+def test_append_and_summary(tmp_path):
+    logger = TranscriptLogger(tmp_path)
+    logger.append("chan", "alice", "hello")
+    logger.append("chan", "bob", "hi")
+
+    path = tmp_path / "chan.jsonl"
+    entries = read_jsonl(path)
+    assert entries[0]["text"] == "hello"
+    assert entries[1]["speaker"] == "bob"
+
+    summary = logger.summary("chan")
+    assert "alice: hello" in summary
+    assert "bob: hi" in summary
+
+
+def test_rotation_and_session_summary(tmp_path):
+    logger = TranscriptLogger(tmp_path)
+    logger.append("chan", "alice", "one")
+    first_session = logger.rotate()
+
+    rotated = tmp_path / f"chan.{first_session}.jsonl"
+    assert rotated.exists()
+    assert "one" in logger.summary("chan", first_session)
+
+    logger.append("chan", "bob", "two")
+    assert "two" in logger.summary("chan")
+    assert "one" not in logger.summary("chan")


### PR DESCRIPTION
## Summary
- introduce `TranscriptLogger` for atomic JSONL transcript logging with per-session rotation and summaries
- expose `TranscriptLogger` from `ears` while making `DiscordListener` optional
- cover transcript logging, rotation and summary retrieval in unit tests

## Testing
- `pytest tests/test_transcript_logger.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c46c13bed88325b09215a21cb9ed9c