### PR TITLE
Add ONNX generation page with progress and cancel support

### DIFF
--- a/ui/onnx.html
+++ b/ui/onnx.html
@@ -6,12 +6,35 @@
   <link rel="stylesheet" href="/ui/theme.css">
   <style>
     body { font-family: sans-serif; margin: 1em; background: var(--bg); color: var(--fg); }
+    label { display: block; margin-bottom: 0.5em; }
+    #log { background: var(--log-bg); color: var(--log-fg); padding: 0.5em; height: 200px; overflow-y: auto; }
   </style>
 </head>
 <body>
   <h1>ONNX Crafter</h1>
-  <p>Under Construction</p>
+  <div id="inputs">
+    <label>Model path <input type="text" id="model" /></label>
+    <label>Song spec (JSON or space-separated chords)
+      <textarea id="song_spec" rows="3"></textarea>
+    </label>
+    <label>Melody MIDI <input type="file" id="midi" /></label>
+    <label>Steps <input type="number" id="steps" value="32" /></label>
+    <label>Top-k <input type="number" id="top_k" /></label>
+    <label>Top-p <input type="number" step="0.01" id="top_p" /></label>
+    <label>Temperature <input type="number" step="0.01" id="temperature" value="1.0" /></label>
+  </div>
+  <div id="controls">
+    <button id="start" type="button">Start</button>
+    <button id="cancel" type="button" disabled>Cancel</button>
+    <progress id="progress" value="0" max="100"></progress>
+  </div>
+  <pre id="log"></pre>
+  <div id="results" hidden>
+    <h3>Result</h3>
+    <a id="midi_link" href="#"></a>
+    <pre id="telemetry"></pre>
+  </div>
   <script src="/ui/topbar.js"></script>
+  <script src="/ui/onnx.js"></script>
 </body>
 </html>
-

--- a/ui/onnx.js
+++ b/ui/onnx.js
@@ -1,0 +1,115 @@
+const isTauri = typeof window !== 'undefined' && window.__TAURI__;
+
+async function tauriOnnxMain(){
+  const { invoke, event, fs, path, shell } = window.__TAURI__;
+  const modelInput = document.getElementById('model');
+  const songSpecInput = document.getElementById('song_spec');
+  const midiInput = document.getElementById('midi');
+  const stepsInput = document.getElementById('steps');
+  const topKInput = document.getElementById('top_k');
+  const topPInput = document.getElementById('top_p');
+  const tempInput = document.getElementById('temperature');
+  const startBtn = document.getElementById('start');
+  const cancelBtn = document.getElementById('cancel');
+  const prog = document.getElementById('progress');
+  const log = document.getElementById('log');
+  const results = document.getElementById('results');
+  const midiLink = document.getElementById('midi_link');
+  const telemetryPre = document.getElementById('telemetry');
+  let jobId = null;
+  let unlisten = null;
+
+  startBtn.addEventListener('click', async () => {
+    const cfg = {
+      model: modelInput.value,
+      steps: parseInt(stepsInput.value) || 0,
+      sampling: {}
+    };
+    if (topKInput.value) cfg.sampling.top_k = parseInt(topKInput.value);
+    if (topPInput.value) cfg.sampling.top_p = parseFloat(topPInput.value);
+    if (tempInput.value) cfg.sampling.temperature = parseFloat(tempInput.value);
+    if (songSpecInput.value.trim()) {
+      try {
+        cfg.song_spec = JSON.parse(songSpecInput.value);
+      } catch {
+        cfg.song_spec = songSpecInput.value.trim().split(/\s+/);
+      }
+    }
+    const midiFile = midiInput.files[0];
+    if (midiFile) {
+      const tempDir = await path.tempDir();
+      const midiPath = await path.join(tempDir, `melody-${Date.now()}.mid`);
+      await fs.writeFile({ path: midiPath, contents: new Uint8Array(await midiFile.arrayBuffer()) });
+      cfg.midi = midiPath;
+    }
+
+    const args = [JSON.stringify(cfg)];
+    try {
+      jobId = await invoke('onnx_generate', { args });
+    } catch (e) {
+      console.error(e);
+      return;
+    }
+    startBtn.disabled = true;
+    cancelBtn.disabled = false;
+    prog.value = 0;
+    log.textContent = '';
+    results.hidden = true;
+    if (unlisten) unlisten();
+    unlisten = await event.listen(`onnx::progress::${jobId}`, e => {
+      const data = e.payload;
+      const msg = data.message || '';
+      if (msg) {
+        log.textContent += msg + '\n';
+        log.scrollTop = log.scrollHeight;
+        const m = msg.match(/generated\s+(\d+)\/(\d+)/);
+        if (m) {
+          const pct = (parseInt(m[1]) / parseInt(m[2])) * 100;
+          prog.value = pct;
+        }
+        if (msg.trim().startsWith('{')) {
+          try {
+            const parsed = JSON.parse(msg);
+            if (parsed.midi) {
+              midiLink.textContent = parsed.midi;
+              midiLink.onclick = () => shell.open(parsed.midi);
+              telemetryPre.textContent = JSON.stringify(parsed.telemetry, null, 2);
+              results.hidden = false;
+            }
+          } catch {
+            // ignore
+          }
+        }
+      }
+      if (typeof data.percent === 'number') {
+        prog.value = data.percent;
+      }
+    });
+    poll();
+  });
+
+  cancelBtn.addEventListener('click', async () => {
+    if (jobId !== null) {
+      await invoke('cancel_render', { jobId });
+    }
+  });
+
+  async function poll(){
+    if (jobId === null) return;
+    try {
+      const data = await invoke('job_status', { jobId });
+      if (data.status === 'running') {
+        setTimeout(poll, 1000);
+      } else {
+        cancelBtn.disabled = true;
+        startBtn.disabled = false;
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  }
+}
+
+if (isTauri) {
+  tauriOnnxMain();
+}


### PR DESCRIPTION
## Summary
- add dedicated ONNX Crafter page with model/song spec inputs and progress display
- implement Tauri script to invoke `onnx_generate`, stream progress, and cancel jobs

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68c47587ef3883258841b85fa90b63ca