### PR TITLE
feat: add musiclang model listing command

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -9,6 +9,7 @@ regex = "1"
 tempfile = "3"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
+reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 
 [build-dependencies]
 tauri-build = { version = "1", features = [] }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -13,8 +13,9 @@ use std::{
 };
 
 use regex::Regex;
-use tauri::{AppHandle, State};
 use tauri::Manager;
+use tauri::{AppHandle, State};
+mod musiclang;
 
 #[derive(serde::Serialize, Clone)]
 struct ProgressEvent {
@@ -104,15 +105,11 @@ fn start_job(
             let eta_re = Regex::new(r"ETA[:\s]+([0-9:]+)").unwrap();
             let reader = BufReader::new(stdout);
             for line in reader.lines().flatten() {
-                let stage = stage_re
-                    .captures(&line)
-                    .map(|c| c[1].to_string());
+                let stage = stage_re.captures(&line).map(|c| c[1].to_string());
                 let percent = percent_re
                     .captures(&line)
                     .and_then(|c| c[1].parse::<u8>().ok());
-                let eta = eta_re
-                    .captures(&line)
-                    .map(|c| c[1].to_string());
+                let eta = eta_re.captures(&line).map(|c| c[1].to_string());
                 let event = ProgressEvent {
                     stage,
                     percent,
@@ -156,15 +153,11 @@ fn onnx_generate(
             let eta_re = Regex::new(r"ETA[:\s]+([0-9:]+)").unwrap();
             let reader = BufReader::new(stdout);
             for line in reader.lines().flatten() {
-                let stage = stage_re
-                    .captures(&line)
-                    .map(|c| c[1].to_string());
+                let stage = stage_re.captures(&line).map(|c| c[1].to_string());
                 let percent = percent_re
                     .captures(&line)
                     .and_then(|c| c[1].parse::<u8>().ok());
-                let eta = eta_re
-                    .captures(&line)
-                    .map(|c| c[1].to_string());
+                let eta = eta_re.captures(&line).map(|c| c[1].to_string());
                 let event = ProgressEvent {
                     stage,
                     percent,
@@ -266,7 +259,8 @@ fn main() {
             onnx_generate,
             cancel_render,
             job_status,
-            open_path
+            open_path,
+            musiclang::list_musiclang_models
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/musiclang.rs
+++ b/src-tauri/src/musiclang.rs
@@ -1,0 +1,24 @@
+use reqwest::blocking;
+use serde_json::Value;
+
+const INDEX_URL: &str = "https://huggingface.co/api/models?search=musiclang";
+
+#[tauri::command]
+pub fn list_musiclang_models() -> Result<Vec<String>, String> {
+    let response = blocking::get(INDEX_URL).map_err(|e| e.to_string())?;
+    let json: Value = response.json().map_err(|e| e.to_string())?;
+    let mut models = Vec::new();
+    if let Some(arr) = json.as_array() {
+        for item in arr {
+            if let Some(name) = item
+                .get("name")
+                .and_then(|v| v.as_str())
+                .or_else(|| item.get("modelId").and_then(|v| v.as_str()))
+                .or_else(|| item.as_str())
+            {
+                models.push(name.to_string());
+            }
+        }
+    }
+    Ok(models)
+}


### PR DESCRIPTION
## Summary
- add reqwest dependency
- create `list_musiclang_models` to pull model names from remote index
- expose new command through Tauri `invoke_handler`

## Testing
- `cargo test` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68c483f3a6dc8325ad3ce09aa80e0fc3