### PR TITLE
feat: add model download command

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -18,7 +18,7 @@ use tauri::{AppHandle, State};
 mod musiclang;
 
 #[derive(serde::Serialize, Clone)]
-struct ProgressEvent {
+pub struct ProgressEvent {
     stage: Option<String>,
     percent: Option<u8>,
     message: String,
@@ -260,7 +260,8 @@ fn main() {
             cancel_render,
             job_status,
             open_path,
-            musiclang::list_musiclang_models
+            musiclang::list_musiclang_models,
+            musiclang::download_model
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/musiclang.rs
+++ b/src-tauri/src/musiclang.rs
@@ -1,5 +1,13 @@
 use reqwest::blocking;
 use serde_json::Value;
+use std::{
+    fs::{self, File},
+    io::{Read, Write},
+    path::PathBuf,
+};
+use tauri::{AppHandle, Manager};
+
+use crate::ProgressEvent;
 
 const INDEX_URL: &str = "https://huggingface.co/api/models?search=musiclang";
 
@@ -21,4 +29,36 @@ pub fn list_musiclang_models() -> Result<Vec<String>, String> {
         }
     }
     Ok(models)
+}
+
+#[tauri::command]
+pub fn download_model(app: AppHandle, name: &str) -> Result<String, String> {
+    let url = format!("https://huggingface.co/{}/resolve/main/model.onnx", name);
+    let mut response = blocking::get(&url).map_err(|e| e.to_string())?;
+    let total = response.content_length();
+
+    fs::create_dir_all("models").map_err(|e| e.to_string())?;
+    let mut path = PathBuf::from("models");
+    path.push(format!("{}.onnx", name));
+    let mut file = File::create(&path).map_err(|e| e.to_string())?;
+    let mut downloaded = 0u64;
+    let mut buffer = [0u8; 8192];
+    loop {
+        let n = response.read(&mut buffer).map_err(|e| e.to_string())?;
+        if n == 0 {
+            break;
+        }
+        file.write_all(&buffer[..n]).map_err(|e| e.to_string())?;
+        downloaded += n as u64;
+        let percent = total.map(|t| ((downloaded * 100) / t) as u8);
+        let event = ProgressEvent {
+            stage: Some("download".into()),
+            percent,
+            message: format!("Downloading {}", name),
+            eta: None,
+        };
+        let _ = app.emit_all(&format!("download::progress::{}", name), event);
+    }
+
+    Ok(path.to_string_lossy().to_string())
 }


### PR DESCRIPTION
## Summary
- enable Tauri to download ONNX models by name with progress events
- expose model download function via command handler

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml` *(failed: Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*

------
https://chatgpt.com/codex/tasks/task_e_68c4888239f4832594f13573d79f38a4