### PR TITLE
feat: expose local model list

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,7 +2,6 @@
 
 use std::{
     collections::HashMap,
-    fs,
     io::{BufRead, BufReader},
     path::Path,
     process::{Child, Command, Stdio},
@@ -16,6 +15,8 @@ use regex::Regex;
 use tauri::Manager;
 use tauri::{AppHandle, State};
 mod musiclang;
+mod util;
+use crate::util::list_from_dir;
 
 #[derive(serde::Serialize, Clone)]
 pub struct ProgressEvent {
@@ -57,17 +58,6 @@ impl Default for JobRegistry {
     }
 }
 
-fn list_from_dir(dir: &Path) -> Result<Vec<String>, String> {
-    let mut items = Vec::new();
-    for entry in fs::read_dir(dir).map_err(|e| e.to_string())? {
-        let entry = entry.map_err(|e| e.to_string())?;
-        if let Some(stem) = entry.path().file_stem().and_then(|s| s.to_str()) {
-            items.push(stem.to_string());
-        }
-    }
-    Ok(items)
-}
-
 #[tauri::command]
 fn list_presets() -> Result<Vec<String>, String> {
     list_from_dir(Path::new("assets/presets"))
@@ -76,6 +66,11 @@ fn list_presets() -> Result<Vec<String>, String> {
 #[tauri::command]
 fn list_styles() -> Result<Vec<String>, String> {
     list_from_dir(Path::new("assets/styles"))
+}
+
+#[tauri::command]
+fn list_models() -> Result<Vec<String>, String> {
+    list_from_dir(Path::new("models"))
 }
 
 #[tauri::command]
@@ -255,6 +250,7 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             list_presets,
             list_styles,
+            list_models,
             start_job,
             onnx_generate,
             cancel_render,

--- a/src-tauri/src/musiclang.rs
+++ b/src-tauri/src/musiclang.rs
@@ -3,11 +3,11 @@ use serde_json::Value;
 use std::{
     fs::{self, File},
     io::{Read, Write},
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 use tauri::{AppHandle, Manager};
 
-use crate::ProgressEvent;
+use crate::{util::list_from_dir, ProgressEvent};
 
 const INDEX_URL: &str = "https://huggingface.co/api/models?search=musiclang";
 
@@ -32,7 +32,7 @@ pub fn list_musiclang_models() -> Result<Vec<String>, String> {
 }
 
 #[tauri::command]
-pub fn download_model(app: AppHandle, name: &str) -> Result<String, String> {
+pub fn download_model(app: AppHandle, name: &str) -> Result<Vec<String>, String> {
     let url = format!("https://huggingface.co/{}/resolve/main/model.onnx", name);
     let mut response = blocking::get(&url).map_err(|e| e.to_string())?;
     let total = response.content_length();
@@ -60,5 +60,5 @@ pub fn download_model(app: AppHandle, name: &str) -> Result<String, String> {
         let _ = app.emit_all(&format!("download::progress::{}", name), event);
     }
 
-    Ok(path.to_string_lossy().to_string())
+    list_from_dir(Path::new("models"))
 }

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -1,0 +1,15 @@
+use std::{collections::HashSet, fs, path::Path};
+
+pub fn list_from_dir(dir: &Path) -> Result<Vec<String>, String> {
+    let mut items = HashSet::new();
+    for entry in fs::read_dir(dir).map_err(|e| e.to_string())? {
+        let entry = entry.map_err(|e| e.to_string())?;
+        if let Some(name) = entry.path().file_name().and_then(|s| s.to_str()) {
+            let stem = name.split('.').next().unwrap_or(name);
+            items.insert(stem.to_string());
+        }
+    }
+    let mut items: Vec<String> = items.into_iter().collect();
+    items.sort();
+    Ok(items)
+}


### PR DESCRIPTION
## Summary
- add shared `list_from_dir` helper for returning unique file stems
- expose `list_models` Tauri command
- report local model list when a model download completes

## Testing
- `cargo test` *(fails: download of config.json failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c48949add4832596e5894ec7870045