### PR TITLE
Resample Discord audio to 16 kHz mono

### DIFF
--- a/ears/discord_listener.py
+++ b/ears/discord_listener.py
@@ -2,8 +2,9 @@
 
 This module relies on a maintained ``discord.py`` fork that exposes voice
 receive functionality.  It provides a small wrapper around
-:class:`discord.Client` to join voice channels and forward raw 16‑bit PCM frames
-for downstream processing.
+:class:`discord.Client` to join voice channels and forward raw 48 kHz stereo
+16‑bit PCM frames for downstream processing. The transcription pipeline
+resamples these frames to 16 kHz mono.
 """
 
 from __future__ import annotations
@@ -40,7 +41,8 @@ class DiscordListener(discord.Client):
     Parameters
     ----------
     frame_callback:
-        Coroutine executed for every 20 ms frame of 16‑bit PCM data.
+        Coroutine executed for every 20 ms frame of 48 kHz stereo 16‑bit PCM
+        data. Downstream consumers typically convert this to 16 kHz mono.
     on_voice_state_update:
         Optional coroutine dispatched when a user's voice state changes.
     on_speaking:

--- a/ears/pipeline.py
+++ b/ears/pipeline.py
@@ -1,11 +1,16 @@
-"""Discord transcription pipeline."""
+"""Discord transcription pipeline with 48 kHz → 16 kHz resampling."""
 from __future__ import annotations
 
 import math
 from typing import Optional
 
 import numpy as np
-from scipy.signal import resample_poly
+
+try:
+    import resampy
+except Exception:  # pragma: no cover - optional dependency
+    resampy = None
+    from scipy.signal import resample_poly
 
 from .discord_listener import DiscordListener
 from .transcript_logger import TranscriptLogger
@@ -14,18 +19,33 @@ from .whisper_service import WhisperService
 
 
 def _resample(pcm: bytes, source_rate: int, target_rate: int) -> bytes:
-    """Convert stereo PCM from ``source_rate`` to mono ``target_rate``."""
-    if source_rate == target_rate:
-        return pcm
-    audio = np.frombuffer(pcm, dtype=np.int16).reshape(-1, 2).mean(axis=1).astype(np.float32)
-    g = math.gcd(source_rate, target_rate)
-    resampled = resample_poly(audio, target_rate // g, source_rate // g)
-    resampled = np.clip(resampled, -32768, 32767)
-    return resampled.astype(np.int16).tobytes()
+    """Convert 48 kHz stereo PCM to mono ``target_rate`` using ``resampy``.
+
+    The input is expected to contain interleaved 16‑bit little‑endian stereo
+    samples. Channels are averaged to mono before resampling. When
+    ``source_rate`` already matches ``target_rate`` the audio is still converted
+    to mono but no resampling is performed. If ``resampy`` is unavailable,
+    ``scipy.signal.resample_poly`` is used as a fallback.
+    """
+    audio = (
+        np.frombuffer(pcm, dtype=np.int16).reshape(-1, 2).mean(axis=1).astype(np.float32)
+    )
+    if source_rate != target_rate:
+        if resampy is not None:
+            audio = resampy.resample(audio, source_rate, target_rate)
+        else:  # pragma: no cover - exercised when resampy missing
+            g = math.gcd(source_rate, target_rate)
+            audio = resample_poly(audio, target_rate // g, source_rate // g)
+    audio = np.clip(audio, -32768, 32767)
+    return audio.astype(np.int16).tobytes()
 
 
 async def run_bot(token: str, channel_id: int, *, model_path: str = "small", transcript_root: str = "transcripts") -> None:
-    """Join a Discord voice channel and transcribe speech in real time."""
+    """Join a Discord voice channel and transcribe speech in real time.
+
+    Incoming 48 kHz stereo frames are converted to 16 kHz mono before voice
+    activity detection and Whisper transcription.
+    """
     logger = TranscriptLogger(transcript_root)
     whisper = WhisperService(model_path)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 numpy
 scipy
 soundfile
+resampy
 webrtcvad
 faster-whisper
 pytest

--- a/tests/test_resampling.py
+++ b/tests/test_resampling.py
@@ -1,0 +1,16 @@
+import numpy as np
+
+from ears.pipeline import _resample
+
+
+def test_resample_48k_to_16k_length():
+    sr_in = 48000
+    sr_out = 16000
+    duration = 1.0
+    t = np.linspace(0, duration, int(sr_in * duration), endpoint=False)
+    sine = np.sin(2 * np.pi * 440 * t)
+    stereo = np.stack([sine, sine], axis=1)
+    pcm = (stereo * 32767).astype(np.int16).tobytes()
+    resampled = _resample(pcm, sr_in, sr_out)
+    out = np.frombuffer(resampled, dtype=np.int16)
+    assert out.shape[0] == int(sr_out * duration)


### PR DESCRIPTION
## Summary
- resample Discord PCM frames from 48 kHz stereo to 16 kHz mono in the pipeline using `resampy` with a SciPy fallback
- document resampling behavior in `DiscordListener` and pipeline docstrings
- add unit test for resampling length and include `resampy` dependency

## Testing
- `pytest tests/test_resampling.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy)*
- `pip install resampy` *(fails: Could not find a version that satisfies the requirement resampy)*

------
https://chatgpt.com/codex/tasks/task_e_68c489cd40488325a759bc53b90170da