### PR TITLE
feat: improve musiclang model management

### DIFF
--- a/src-tauri/src/musiclang.rs
+++ b/src-tauri/src/musiclang.rs
@@ -15,19 +15,15 @@ const INDEX_URL: &str = "https://huggingface.co/api/models?search=musiclang";
 pub fn list_musiclang_models() -> Result<Vec<String>, String> {
     let response = blocking::get(INDEX_URL).map_err(|e| e.to_string())?;
     let json: Value = response.json().map_err(|e| e.to_string())?;
-    let mut models = Vec::new();
-    if let Some(arr) = json.as_array() {
-        for item in arr {
-            if let Some(name) = item
-                .get("name")
-                .and_then(|v| v.as_str())
-                .or_else(|| item.get("modelId").and_then(|v| v.as_str()))
-                .or_else(|| item.as_str())
-            {
-                models.push(name.to_string());
-            }
-        }
-    }
+    let models = json
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|item| item.get("modelId").and_then(|v| v.as_str()))
+                .map(|id| id.to_string())
+                .collect::<Vec<String>>()
+        })
+        .unwrap_or_default();
     Ok(models)
 }
 
@@ -39,7 +35,9 @@ pub fn download_model(app: AppHandle, name: &str) -> Result<String, String> {
 
     fs::create_dir_all("models").map_err(|e| e.to_string())?;
     let mut path = PathBuf::from("models");
-    path.push(format!("{}.onnx", name));
+    path.push(name);
+    fs::create_dir_all(&path).map_err(|e| e.to_string())?;
+    path.push("model.onnx");
     let mut file = File::create(&path).map_err(|e| e.to_string())?;
     let mut downloaded = 0u64;
     let mut buffer = [0u8; 8192];


### PR DESCRIPTION
## Summary
- refine list_musiclang_models to return model IDs from HuggingFace
- download models into per-model folders with progress events

## Testing
- `cargo test` *(fails: failed to download from `https://index.crates.io/config.json` [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*

------
https://chatgpt.com/codex/tasks/task_e_68c48a46c1888325a5e5cef06a23f474