### PR TITLE
Add model download and selection to ONNX crafter

### DIFF
--- a/ui/onnx.html
+++ b/ui/onnx.html
@@ -13,7 +13,7 @@
 <body>
   <h1>ONNX Crafter</h1>
   <div id="inputs">
-    <label>Model path <input type="text" id="model" /></label>
+    <label>Model <select id="model-select"></select></label>
     <label>Song spec (JSON or space-separated chords)
       <textarea id="song_spec" rows="3"></textarea>
     </label>
@@ -24,7 +24,8 @@
     <label>Temperature <input type="number" step="0.01" id="temperature" value="1.0" /></label>
   </div>
   <div id="controls">
-    <button id="start" type="button">Start</button>
+    <button id="download" type="button">Download</button>
+    <button id="start" type="button" disabled>Start</button>
     <button id="cancel" type="button" disabled>Cancel</button>
     <progress id="progress" value="0" max="100"></progress>
   </div>

--- a/ui/onnx.js
+++ b/ui/onnx.js
@@ -2,7 +2,8 @@ const isTauri = typeof window !== 'undefined' && window.__TAURI__;
 
 async function tauriOnnxMain(){
   const { invoke, event, fs, path, shell } = window.__TAURI__;
-  const modelInput = document.getElementById('model');
+  const modelSelect = document.getElementById('model-select');
+  const downloadBtn = document.getElementById('download');
   const songSpecInput = document.getElementById('song_spec');
   const midiInput = document.getElementById('midi');
   const stepsInput = document.getElementById('steps');
@@ -19,9 +20,61 @@ async function tauriOnnxMain(){
   let jobId = null;
   let unlisten = null;
 
+  async function refreshModels(){
+    try {
+      const installed = await invoke('list_models');
+      startBtn.disabled = !installed.includes(modelSelect.value);
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  async function populateModels(){
+    try {
+      const models = await invoke('list_musiclang_models');
+      models.forEach(name => {
+        const opt = document.createElement('option');
+        opt.value = name;
+        opt.textContent = name;
+        modelSelect.appendChild(opt);
+      });
+      await refreshModels();
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  await populateModels();
+
+  modelSelect.addEventListener('change', refreshModels);
+
+  downloadBtn.addEventListener('click', async () => {
+    const name = modelSelect.value;
+    prog.value = 0;
+    log.textContent = '';
+    const unlistenDownload = await event.listen(`download::progress::${name}`, e => {
+      const data = e.payload;
+      const msg = data.message || '';
+      if (msg) {
+        log.textContent += msg + '\n';
+        log.scrollTop = log.scrollHeight;
+      }
+      if (typeof data.percent === 'number') {
+        prog.value = data.percent;
+      }
+    });
+    try {
+      await invoke('download_model', { name });
+    } catch (e) {
+      console.error(e);
+    }
+    unlistenDownload();
+    await refreshModels();
+  });
+
   startBtn.addEventListener('click', async () => {
     const cfg = {
-      model: modelInput.value,
+      model: modelSelect.value,
       steps: parseInt(stepsInput.value) || 0,
       sampling: {}
     };


### PR DESCRIPTION
## Summary
- replace model path input with model dropdown and download control
- load available MusicLang models on start
- download models with progress and enable generation when available

## Testing
- `pytest` *(fails: 31 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c48b4aae90832586d738d64a3750c7