### PR TITLE
Add pyannote-based speaker diarization utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ For enhanced MIDI import and export support, install the optional
 pip install mido
 ```
 
+To enable optional speaker diarization via
+[pyannote.audio](https://github.com/pyannote/pyannote-audio), install the
+``diarization`` extra:
+
+```bash
+pip install .[diarization]
+```
+
 ## Generate N minutes of music
 
 1. Create a song specification JSON (see `core/song_spec.py` for fields).

--- a/ears/__init__.py
+++ b/ears/__init__.py
@@ -18,10 +18,16 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # ImportError and runtime errors if backend missing
     run_bot = None  # type: ignore[assignment]
 
+try:  # pragma: no cover - optional dependency
+    from .diarization import pyannote_diarize
+except Exception:  # ImportError and runtime errors if backend missing
+    pyannote_diarize = None  # type: ignore[assignment]
+
 __all__ = [
     "DiscordListener",
     "WhisperService",
     "TranscriptionSegment",
     "TranscriptLogger",
     "run_bot",
+    "pyannote_diarize",
 ]

--- a/ears/diarization.py
+++ b/ears/diarization.py
@@ -1,0 +1,70 @@
+"""Optional speaker diarization utilities using pyannote.audio.
+
+This module exposes :func:`pyannote_diarize` which splits a mono PCM
+buffer into per-speaker segments using a pre-trained
+``pyannote.audio`` pipeline.  The function returns an iterable of
+``(speaker_id, segment_bytes)`` tuples where ``segment_bytes`` contains
+16-bit PCM data at 16 kHz corresponding to a single speaker turn.
+
+The heavy ``pyannote.audio`` dependency is imported lazily so that the
+rest of the package can function without it.  A ``RuntimeError`` is
+raised if the library is unavailable when the function is invoked.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Iterable, Tuple
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency
+    import torch
+    from pyannote.audio import Pipeline
+except Exception:  # pragma: no cover - handled at runtime
+    Pipeline = None  # type: ignore
+    torch = None  # type: ignore
+
+
+@lru_cache()
+def _load_pipeline() -> Pipeline:
+    """Load the default pyannote speaker diarization pipeline.
+
+    The resulting object is cached to avoid repeated initialization.
+    """
+
+    if Pipeline is None:
+        raise RuntimeError("pyannote.audio is required for diarization")
+    # ``from_pretrained`` will download the model if necessary.  The
+    # default model performs speaker diarization on short audio clips.
+    return Pipeline.from_pretrained("pyannote/speaker-diarization")
+
+
+def pyannote_diarize(pcm: bytes, sample_rate: int = 16000) -> Iterable[Tuple[str, bytes]]:
+    """Split ``pcm`` into per-speaker segments using ``pyannote.audio``.
+
+    Parameters
+    ----------
+    pcm:
+        Mono 16‑bit PCM audio.
+    sample_rate:
+        Sampling rate of ``pcm``.  Defaults to 16 kHz which matches the
+        expected rate of :class:`~ears.vad.VoiceActivityDetector`.
+    """
+
+    pipeline = _load_pipeline()
+
+    # Convert PCM bytes to the ``pyannote.audio`` expected format.
+    waveform = np.frombuffer(pcm, dtype=np.int16).astype(np.float32) / 32768.0
+    tensor = torch.from_numpy(waveform).unsqueeze(0)
+    audio = {"waveform": tensor, "sample_rate": sample_rate}
+    diarization = pipeline(audio)
+
+    for segment, _, speaker in diarization.itertracks(yield_label=True):
+        start = int(segment.start * sample_rate)
+        end = int(segment.end * sample_rate)
+        portion = waveform[start:end]
+        yield speaker, (portion * 32768.0).astype(np.int16).tobytes()
+
+
+__all__ = ["pyannote_diarize"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ requires-python = ">=3.10,<3.11"
 
 [project.optional-dependencies]
 midi = ["mido"]
+diarization = ["pyannote.audio"]
 
 [build-system]
 requires = ["setuptools>=61"]

--- a/tests/test_vad_diarization.py
+++ b/tests/test_vad_diarization.py
@@ -1,0 +1,43 @@
+import asyncio
+import array
+import math
+import pathlib
+import sys
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+pytest.importorskip("webrtcvad")
+
+from ears.vad import VoiceActivityDetector, _StreamState
+
+
+def _synthetic_segment() -> bytes:
+    """Return 1 s of two alternating "speakers" as PCM."""
+    sr = 16000
+    t = range(sr // 2)
+    spk_a = array.array("h", (int(0.3 * 32767 * math.sin(2 * math.pi * 440 * i / sr)) for i in t))
+    spk_b = array.array("h", (int(0.3 * 32767 * math.sin(2 * math.pi * 880 * i / sr)) for i in t))
+    return spk_a.tobytes() + spk_b.tobytes()
+
+
+def test_diarizer_splits_speakers() -> None:
+    segment = _synthetic_segment()
+    seen = []
+
+    async def cb(seg: bytes, spk: str | None) -> None:
+        seen.append(spk)
+
+    def fake_diarizer(pcm: bytes):
+        mid = len(pcm) // 2
+        return [("A", pcm[:mid]), ("B", pcm[mid:])]
+
+    vad = VoiceActivityDetector(segment_callback=cb, diarizer=fake_diarizer, padding_ms=0)
+
+    state = _StreamState(0)
+    state.triggered = True
+    state.frames.append(segment)
+
+    asyncio.run(vad._emit(state, None))
+
+    assert seen == ["A", "B"]


### PR DESCRIPTION
## Summary
- add pyannote-based `pyannote_diarize` helper for splitting PCM buffers by speaker
- allow Discord transcription pipeline to accept optional `diarizer`
- document optional `[diarization]` extra for installing `pyannote.audio`
- include test covering diarizer integration

## Testing
- `pytest tests/test_vad_diarization.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68c48b41e0f483258e778be2d1607856