### PR TITLE
Improve ONNX generation error handling

### DIFF
--- a/core/onnx_crafter_service.py
+++ b/core/onnx_crafter_service.py
@@ -246,7 +246,12 @@ def main(argv: Sequence[str] | None = None) -> None:
     model = cfg.get("model")
     if model is None:
         raise SystemExit("missing 'model' in config")
-    session.load_session(model)
+    try:
+        session.load_session(model)
+    except FileNotFoundError as exc:
+        import sys
+        print(json.dumps({"error": str(exc)}), file=sys.stderr)
+        raise SystemExit(1)
 
     if "midi" in cfg:
         tokens = encode_midi(cfg["midi"])

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7,8 +7,10 @@ use std::{
     process::{Child, Command, Stdio},
     sync::{
         atomic::{AtomicU64, Ordering},
-        Mutex,
+        Arc, Mutex,
     },
+    time::Duration,
+};
 };
 
 use regex::Regex;
@@ -30,6 +32,7 @@ struct JobInfo {
     child: Option<Child>,
     args: Vec<String>,
     status: Option<bool>,
+    stderr: Arc<Mutex<String>>,
 }
 
 struct JobRegistry {
@@ -82,13 +85,28 @@ fn start_job(
     let mut child = Command::new("python")
         .args(&args)
         .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .spawn()
         .map_err(|e| e.to_string())?;
     let stdout = child.stdout.take();
+    let stderr_pipe = child.stderr.take();
+    let stderr_buf = Arc::new(Mutex::new(String::new()));
+    if let Some(stderr) = stderr_pipe {
+        let stderr_buf_clone = stderr_buf.clone();
+        std::thread::spawn(move || {
+            let reader = BufReader::new(stderr);
+            for line in reader.lines().flatten() {
+                let mut buf = stderr_buf_clone.lock().unwrap();
+                buf.push_str(&line);
+                buf.push('\n');
+            }
+        });
+    }
     let job = JobInfo {
         child: Some(child),
         args,
         status: None,
+        stderr: stderr_buf,
     };
     let id = registry.add(job);
 
@@ -130,24 +148,46 @@ fn onnx_generate(
     let mut child = Command::new("python")
         .args(&full_args)
         .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .spawn()
         .map_err(|e| e.to_string())?;
     let stdout = child.stdout.take();
+    let stderr_pipe = child.stderr.take();
+    let stderr_buf = Arc::new(Mutex::new(String::new()));
+    if let Some(stderr) = stderr_pipe {
+        let stderr_buf_clone = stderr_buf.clone();
+        std::thread::spawn(move || {
+            let reader = BufReader::new(stderr);
+            for line in reader.lines().flatten() {
+                let mut buf = stderr_buf_clone.lock().unwrap();
+                buf.push_str(&line);
+                buf.push('\n');
+            }
+        });
+    }
     let job = JobInfo {
         child: Some(child),
         args: full_args.clone(),
         status: None,
+        stderr: stderr_buf.clone(),
     };
     let id = registry.add(job);
 
+    let (tx, rx) = std::sync::mpsc::channel();
     if let Some(stdout) = stdout {
         let app_handle = app.clone();
+        let tx2 = tx.clone();
         std::thread::spawn(move || {
             let stage_re = Regex::new(r"^\s*([\w-]+):").unwrap();
             let percent_re = Regex::new(r"(\d+)%").unwrap();
             let eta_re = Regex::new(r"ETA[:\s]+([0-9:]+)").unwrap();
             let reader = BufReader::new(stdout);
+            let mut first = true;
             for line in reader.lines().flatten() {
+                if first {
+                    let _ = tx2.send(());
+                    first = false;
+                }
                 let stage = stage_re.captures(&line).map(|c| c[1].to_string());
                 let percent = percent_re
                     .captures(&line)
@@ -162,6 +202,45 @@ fn onnx_generate(
                 let _ = app_handle.emit_all(&format!("onnx::progress::{}", id), event);
             }
         });
+    }
+
+    // Wait for first progress line or early failure
+    loop {
+        match rx.try_recv() {
+            Ok(_) => break,
+            Err(std::sync::mpsc::TryRecvError::Empty) => {
+                let mut jobs = registry.jobs.lock().unwrap();
+                if let Some(job) = jobs.get_mut(&id) {
+                    if let Some(child) = job.child.as_mut() {
+                        match child.try_wait() {
+                            Ok(Some(status)) => {
+                                let success = status.success();
+                                if !success {
+                                    let err = job.stderr.lock().unwrap().clone();
+                                    jobs.remove(&id);
+                                    return Err(if err.is_empty() {
+                                        "onnx generation failed".into()
+                                    } else {
+                                        err
+                                    });
+                                } else {
+                                    job.status = Some(true);
+                                    job.child = None;
+                                    break;
+                                }
+                            }
+                            Ok(None) => {}
+                            Err(e) => {
+                                jobs.remove(&id);
+                                return Err(e.to_string());
+                            }
+                        }
+                    }
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => break,
+        }
     }
 
     Ok(id)
@@ -192,6 +271,7 @@ fn cancel_render(registry: State<JobRegistry>, job_id: u64) -> Result<(), String
 #[derive(serde::Serialize)]
 struct JobState {
     status: String,
+    message: Option<String>,
 }
 
 #[tauri::command]
@@ -202,6 +282,11 @@ fn job_status(registry: State<JobRegistry>, job_id: u64) -> JobState {
             if let Some(success) = job.status {
                 JobState {
                     status: if success { "completed" } else { "error" }.into(),
+                    message: if success {
+                        None
+                    } else {
+                        Some(job.stderr.lock().unwrap().clone())
+                    },
                 }
             } else if let Some(child) = job.child.as_mut() {
                 match child.try_wait() {
@@ -211,27 +296,36 @@ fn job_status(registry: State<JobRegistry>, job_id: u64) -> JobState {
                         job.child = None;
                         JobState {
                             status: if success { "completed" } else { "error" }.into(),
+                            message: if success {
+                                None
+                            } else {
+                                Some(job.stderr.lock().unwrap().clone())
+                            },
                         }
                     }
                     Ok(None) => JobState {
                         status: "running".into(),
+                        message: None,
                     },
                     Err(_) => {
                         job.status = Some(false);
                         job.child = None;
                         JobState {
                             status: "error".into(),
+                            message: Some(job.stderr.lock().unwrap().clone()),
                         }
                     }
                 }
             } else {
                 JobState {
                     status: "running".into(),
+                    message: None,
                 }
             }
         }
         None => JobState {
             status: "not-found".into(),
+            message: None,
         },
     }
 }

--- a/ui/onnx.js
+++ b/ui/onnx.js
@@ -100,7 +100,8 @@ async function tauriOnnxMain(){
     try {
       jobId = await invoke('onnx_generate', { args });
     } catch (e) {
-      console.error(e);
+      log.textContent = `Error: ${e}`;
+      log.scrollTop = log.scrollHeight;
       return;
     }
     startBtn.disabled = true;
@@ -153,6 +154,13 @@ async function tauriOnnxMain(){
       const data = await invoke('job_status', { jobId });
       if (data.status === 'running') {
         setTimeout(poll, 1000);
+      } else if (data.status === 'error') {
+        cancelBtn.disabled = true;
+        startBtn.disabled = false;
+        if (data.message) {
+          log.textContent += `\nError: ${data.message}\n`;
+          log.scrollTop = log.scrollHeight;
+        }
       } else {
         cancelBtn.disabled = true;
         startBtn.disabled = false;


### PR DESCRIPTION
## Summary
- capture stderr and check process status in `onnx_generate`
- propagate ONNX crafter `FileNotFoundError` as JSON error
- surface ONNX generation failures in the UI

## Testing
- ❌ `cargo test -p blossom_music-gen --manifest-path src-tauri/Cargo.toml` (failed: failed to download crates index: CONNECT tunnel failed, response 403)
- ❌ `pytest tests/test_utils.py::test_ensure_file_rejects_directory -q` (failed: ModuleNotFoundError: No module named 'numpy')
- ❌ `pip install numpy` (failed: Tunnel connection failed: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68c493d644d08325800b6d4b92e145af