### PR TITLE
Ensure models directory and path resolution

### DIFF
--- a/core/onnx_crafter_service.py
+++ b/core/onnx_crafter_service.py
@@ -70,11 +70,24 @@ class ModelSession:
         import onnxruntime as ort  # type: ignore
 
         path = Path(model_dir)
+        if not path.exists():
+            base = Path(__file__).resolve().parents[1] / "models"
+            candidate = base / path
+            if candidate.exists():
+                path = candidate
+            else:
+                candidate = base / f"{path}.onnx"
+                if candidate.exists():
+                    path = candidate
+
         if path.is_dir():
             candidates = list(path.glob("*.onnx"))
             if not candidates:
                 raise FileNotFoundError(f"No ONNX model found in {path}")
             path = candidates[0]
+
+        if not path.exists():
+            raise FileNotFoundError(f"No model found at {path}")
 
         providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
         sess = ort.InferenceSession(str(path), providers=providers)

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,6 +2,7 @@
 
 use std::{
     collections::HashMap,
+    fs,
     io::{BufRead, BufReader},
     path::Path,
     process::{Child, Command, Stdio},
@@ -351,6 +352,10 @@ fn open_path(app: AppHandle, path: String) -> Result<(), String> {
 }
 
 fn main() {
+    if let Err(e) = fs::create_dir_all(Path::new("models")) {
+        eprintln!("failed to create models directory: {}", e);
+    }
+
     tauri::Builder::default()
         .manage(JobRegistry::default())
         .invoke_handler(tauri::generate_handler![

--- a/ui/onnx.js
+++ b/ui/onnx.js
@@ -23,7 +23,8 @@ async function tauriOnnxMain(){
   async function refreshModels(){
     try {
       const installed = await invoke('list_models');
-      startBtn.disabled = !installed.includes(modelSelect.value);
+      const selected = modelSelect.value.split(/[\\/]/).pop();
+      startBtn.disabled = !installed.includes(selected);
     } catch (e) {
       console.error(e);
     }
@@ -73,8 +74,9 @@ async function tauriOnnxMain(){
   });
 
   startBtn.addEventListener('click', async () => {
+    const modelName = modelSelect.value.split(/[\\/]/).pop();
     const cfg = {
-      model: modelSelect.value,
+      model: modelName,
       steps: parseInt(stepsInput.value) || 0,
       sampling: {}
     };


### PR DESCRIPTION
## Summary
- Ensure `models/` directory exists at startup
- Resolve model names inside `models/` when loading ONNX sessions
- Send only model name from UI and build full paths on backend

## Testing
- `pytest tests/test_exported_models.py::test_onnx_model_loads -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68c49c4d0d208325882e664bb93c7e6b