### PR TITLE
Remove extra import terminator

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,7 +12,6 @@ use std::{
     },
     time::Duration,
 };
-};
 
 use regex::Regex;
 use tauri::Manager;


### PR DESCRIPTION
## Summary
- Clean up top-level `use std` block by removing redundant closing `};`

## Testing
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: failed to download from crates.io due to 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c49e86c1548325bceb8d831bf41210