### PR TITLE
Ensure NPM dependencies are installed before running Tauri UI

### DIFF
--- a/start.py
+++ b/start.py
@@ -87,8 +87,15 @@ def main() -> None:
         )
         sys.exit(1)
 
+    npm_dir = Path.cwd()
     try:
-        subprocess.run([npm_path, "run", "tauri", "dev"], check=True)
+        subprocess.run([npm_path, "install"], cwd=npm_dir, check=True)
+    except subprocess.CalledProcessError:
+        print("Failed to install NPM dependencies", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        subprocess.run([npm_path, "run", "tauri", "dev"], cwd=npm_dir, check=True)
     except subprocess.CalledProcessError:
         print("Failed to launch Tauri UI", file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
## Summary
- add step to install NPM dependencies before launching the Tauri UI

## Testing
- `python -m py_compile start.py`
- `pytest tests/test_webui_health.py::test_health -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68c4a826ae688325a8f39e39a315b0b8