### PR TITLE
test: ensure ModelSession instances are isolated

### DIFF
--- a/tests/test_onnx_crafter_service.py
+++ b/tests/test_onnx_crafter_service.py
@@ -1,0 +1,22 @@
+import pytest
+from pathlib import Path
+
+pytest.importorskip("onnxruntime")
+pytest.importorskip("numpy")
+
+from core.onnx_crafter_service import ModelSession
+
+MODELS_DIR = Path(__file__).resolve().parents[1] / "models"
+
+
+def test_modelsessions_are_isolated():
+    model = MODELS_DIR / "bass_phrase.onnx"
+    ms1 = ModelSession()
+    ms2 = ModelSession()
+    ms1.load_session(model)
+    ms2.load_session(model)
+    ms1.generate([], 0, {})
+    ms2.generate([], 0, {})
+    assert ms1.sess is not ms2.sess
+    assert ms1.telemetry is not ms2.telemetry
+    assert "device" in ms1.telemetry and "device" in ms2.telemetry


### PR DESCRIPTION
## Summary
- add regression test confirming separate ModelSession instances keep independent sessions and telemetry

## Testing
- `PYTHONPATH=. pytest tests/test_onnx_crafter_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c4b3c1b5b483258bebdade34380fd9