### PR TITLE
Add top bar only to secondary pages

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -90,7 +90,6 @@
       <h2>ONNX Crafter</h2>
     </a>
   </div>
-  <script src="/ui/topbar.js"></script>
   <script src="/ui/train.js"></script>
   <script>
     const carousel = document.querySelector('.carousel');


### PR DESCRIPTION
## Summary
- Ensure the home page remains clean by removing the top bar script
- Keep top bar with Back navigation for all other pages via `topbar.js`

## Testing
- `pytest tests/test_webui_about.py tests/test_webui_health.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install fastapi` *(fails: Could not find a version that satisfies the requirement fastapi; proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d498e25c83258c1ef835bbb11796