### PR TITLE
Flatten ONNX model storage layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,9 +280,8 @@ curl -s https://huggingface.co/api/models?search=musiclang | jq '.[].modelId'
 Download a model and place it under the local `models/` directory:
 
 ```bash
-mkdir -p models/musiclang-small
 curl -L https://huggingface.co/musiclang/musiclang-small/resolve/main/model.onnx \
-  -o models/musiclang-small/model.onnx
+  -o models/musiclang-small.onnx
 ```
 
 ### CLI usage
@@ -292,7 +291,7 @@ Generation is performed by passing a JSON configuration to
 an input melody with `midi`:
 
 ```bash
-python core/onnx_crafter_service.py '{"model":"models/musiclang-small","song_spec":["C","F","G","C"],"steps":32,"sampling":{"top_k":8,"top_p":0.95,"temperature":1.0},"out":"output.mid"}'
+python core/onnx_crafter_service.py '{"model":"musiclang-small","song_spec":["C","F","G","C"],"steps":32,"sampling":{"top_k":8,"top_p":0.95,"temperature":1.0},"out":"output.mid"}'
 ```
 
 ### GUI usage

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -74,7 +74,18 @@ fn list_styles() -> Result<Vec<String>, String> {
 
 #[tauri::command]
 fn list_models() -> Result<Vec<String>, String> {
-    list_from_dir(Path::new("models"))
+    let mut items = Vec::new();
+    for entry in fs::read_dir("models").map_err(|e| e.to_string())? {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) == Some("onnx") {
+            if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                items.push(stem.to_string());
+            }
+        }
+    }
+    items.sort();
+    Ok(items)
 }
 
 #[tauri::command]

--- a/src-tauri/src/musiclang.rs
+++ b/src-tauri/src/musiclang.rs
@@ -34,10 +34,8 @@ pub fn download_model(app: AppHandle, name: &str) -> Result<Vec<String>, String>
     let total = response.content_length();
 
     fs::create_dir_all("models").map_err(|e| e.to_string())?;
-    let mut path = PathBuf::from("models");
-    path.push(name);
-    fs::create_dir_all(&path).map_err(|e| e.to_string())?;
-    path.push("model.onnx");
+    let file_name = name.split('/').last().unwrap_or(name);
+    let path = PathBuf::from(format!("models/{}.onnx", file_name));
     let mut file = File::create(&path).map_err(|e| e.to_string())?;
     let mut downloaded = 0u64;
     let mut buffer = [0u8; 8192];

--- a/webui/app.py
+++ b/webui/app.py
@@ -276,8 +276,8 @@ async def list_models(request: Request):
         return HTMLResponse(html)
     if not MODELS_DIR.exists():
         return []
-    files = sorted(p for p in MODELS_DIR.glob("*") if p.is_file())
-    return [{"name": p.name, "url": f"/models/{p.name}"} for p in files]
+    files = sorted(p for p in MODELS_DIR.glob("*.onnx") if p.is_file())
+    return [{"name": p.stem, "url": f"/models/{p.name}"} for p in files]
 
 
 @app.get("/models/{filename}")


### PR DESCRIPTION
## Summary
- Save downloaded MusicLang models directly as `models/<name>.onnx`
- Enumerate ONNX models by filename in Rust and web UI
- Document new flat model structure in README

## Testing
- `cargo test` *(failed: failed to download crates, 403)*
- `pytest` *(failed: missing numpy, fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d4f4dcf88325bcc24e712c25154e