### PR TITLE
Skip existing model downloads unless forced

### DIFF
--- a/ui/onnx.js
+++ b/ui/onnx.js
@@ -49,7 +49,7 @@ async function tauriOnnxMain(){
 
   modelSelect.addEventListener('change', refreshModels);
 
-  downloadBtn.addEventListener('click', async () => {
+  downloadBtn.addEventListener('click', async e => {
     const name = modelSelect.value;
     prog.value = 0;
     log.textContent = '';
@@ -65,7 +65,7 @@ async function tauriOnnxMain(){
       }
     });
     try {
-      await invoke('download_model', { name });
+      await invoke('download_model', { name, force: e.shiftKey });
     } catch (e) {
       console.error(e);
     }


### PR DESCRIPTION
## Summary
- Avoid re-downloading ONNX models that already exist on disk
- Add optional `force` flag for `download_model` and hook shift-click to invoke it
- Emit progress events when a download is skipped

## Testing
- `cargo test` *(fails: failed to download from crates.io, 403)*
- `pytest tests/test_utils.py::test_list_from_dir -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e49c5ec88325a238ec3c5d7ebc29