### PR TITLE
Filter MusicLang models with ONNX metadata

### DIFF
--- a/ui/onnx.js
+++ b/ui/onnx.js
@@ -33,10 +33,16 @@ async function tauriOnnxMain(){
   async function populateModels(){
     try {
       const models = await invoke('list_musiclang_models');
-      models.forEach(name => {
+      models.forEach(info => {
         const opt = document.createElement('option');
-        opt.value = name;
-        opt.textContent = name;
+        opt.value = info.id;
+        let label = info.id;
+        if (info.description) label += ` - ${info.description}`;
+        if (info.size) {
+          const mb = (info.size / (1024 * 1024)).toFixed(1);
+          label += ` (${mb} MB)`;
+        }
+        opt.textContent = label;
         modelSelect.appendChild(opt);
       });
       await refreshModels();


### PR DESCRIPTION
## Summary
- Add `ModelInfo` struct and enrich `list_musiclang_models` to filter for official MusicLang models with ONNX assets and expose description/size metadata
- Display model descriptions and file sizes in the UI dropdown

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: failed to download dependency; CONNECT tunnel 403)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c4e4a27bd083258e5877d4a46539c3