### PR TITLE
fix(ui): apply saved theme before scripts load

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <title>Blossom Music Generator</title>
+  <script>
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme) {
+      document.documentElement.dataset.theme = savedTheme;
+    }
+  </script>
   <link rel="stylesheet" href="/ui/theme.css">
   <style>
     body {
@@ -90,6 +96,7 @@
       <h2>ONNX Crafter</h2>
     </a>
   </div>
+  <script src="/ui/topbar.js"></script>
   <script src="/ui/train.js"></script>
   <script>
     const carousel = document.querySelector('.carousel');


### PR DESCRIPTION
## Summary
- Apply stored theme from localStorage before loading CSS to prevent flicker
- Load topbar script ahead of other scripts on landing page

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68c4ec59d13c8325bd322ad6a78f231d