### PR TITLE
Add service API for note search and retrieval

### DIFF
--- a/scripts/service_api_example.py
+++ b/scripts/service_api_example.py
@@ -1,0 +1,34 @@
+"""Example usage of :mod:`service_api`.
+
+This script demonstrates simple interactions such as performing a search,
+listing NPC notes and fetching the raw Markdown for a note. It assumes that
+an Obsidian vault has been selected via ``config.obsidian.select_vault``.
+"""
+
+from __future__ import annotations
+
+import service_api
+
+
+def main() -> None:
+    # Search for chunks mentioning "dragon"
+    hits = service_api.search("dragon")
+    print("Search results:")
+    for hit in hits:
+        print(f"{hit['path']} -> {hit['score']:.2f}")
+
+    # List NPC notes and show their aliases
+    npcs = service_api.list_npcs()
+    print("\nNPCs:")
+    for npc in npcs:
+        print(f"{npc['path']} aliases={npc['aliases']}")
+
+    if npcs:
+        # Fetch the raw Markdown for the first NPC note
+        path = npcs[0]['path']
+        print(f"\nContent of {path}:")
+        print(service_api.get_note(path))
+
+
+if __name__ == "__main__":
+    main()

--- a/service_api.py
+++ b/service_api.py
@@ -1,0 +1,147 @@
+"""High level helpers for interacting with Obsidian notes.
+
+This module exposes small convenience functions that operate on the
+SQLite/FAISS index maintained for an Obsidian vault. A vault must be
+selected via :func:`config.obsidian.select_vault` before any of the
+functions here can be used.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sqlite3
+from typing import List, Dict, Any
+
+from config.obsidian import get_vault
+from notes.embedding import DEFAULT_INDEX_PATH
+from notes.watchdog import DEFAULT_DB_PATH
+from notes.search import search_chunks
+from notes.parser import parse_note, NoteParseError
+
+
+def _paths() -> tuple[Path, Path, Path]:
+    """Return ``(vault, db_path, index_path)`` for the selected vault.
+
+    Raises
+    ------
+    RuntimeError
+        If a vault has not been selected.
+    """
+
+    vault = get_vault()
+    if vault is None:
+        raise RuntimeError("Obsidian vault has not been selected")
+    vault = vault.resolve()
+    db_path = vault / DEFAULT_DB_PATH
+    index_path = vault / DEFAULT_INDEX_PATH
+    return vault, db_path, index_path
+
+
+def search(query: str, tags: List[str] | None = None) -> List[Dict[str, Any]]:
+    """Return ranked note chunks matching ``query``.
+
+    Parameters
+    ----------
+    query:
+        Natural language search string.
+    tags:
+        Optional list of tag strings. When provided, only chunks having at
+        least one of these tags are considered.
+
+    Returns
+    -------
+    list[dict]
+        Each result dictionary contains ``path``, ``heading``, ``content`` and
+        ``score`` (Euclidean distance where smaller is better).
+    """
+
+    _, db_path, index_path = _paths()
+    results = search_chunks(query, db_path, index_path, tags=tags, top_k=5)
+    if not results:
+        return []
+
+    chunk_ids = [cid for cid, _ in results]
+    placeholders = ",".join("?" * len(chunk_ids))
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute(
+            f"SELECT id, path, heading, content FROM chunks WHERE id IN ({placeholders})",
+            chunk_ids,
+        ).fetchall()
+    finally:
+        conn.close()
+
+    meta = {row[0]: row[1:] for row in rows}
+    output: List[Dict[str, Any]] = []
+    for cid, dist in results:
+        info = meta.get(cid)
+        if info is None:
+            continue
+        path, heading, content = info
+        output.append(
+            {
+                "path": path,
+                "heading": heading,
+                "content": content,
+                "score": dist,
+            }
+        )
+    return output
+
+
+def get_note(path: str) -> str:
+    """Return the raw Markdown for ``path`` within the selected vault.
+
+    Parameters
+    ----------
+    path:
+        Path to the note relative to the root of the Obsidian vault.
+    """
+
+    vault, _, _ = _paths()
+    note_path = (vault / path).resolve()
+    try:
+        note_path.relative_to(vault)
+    except ValueError as exc:
+        raise ValueError("path is outside the vault") from exc
+    if not note_path.exists() or not note_path.is_file():
+        raise FileNotFoundError(f"note not found: {path}")
+    return note_path.read_text(encoding="utf-8")
+
+
+def list_npcs() -> List[Dict[str, Any]]:
+    """Return metadata for all notes tagged ``#npc``.
+
+    The chunk database is queried for any notes containing an ``npc`` tag and
+    each matching note is parsed to extract its metadata.
+    """
+
+    vault, db_path, _ = _paths()
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute(
+            """
+            SELECT DISTINCT c.path FROM chunks c
+            JOIN tags t ON c.id = t.chunk_id
+            WHERE lower(t.tag) = 'npc'
+            """
+        ).fetchall()
+    finally:
+        conn.close()
+
+    results: List[Dict[str, Any]] = []
+    for (rel_path,) in rows:
+        note_file = vault / rel_path
+        try:
+            parsed = parse_note(note_file)
+        except NoteParseError:
+            continue
+        results.append(
+            {
+                "path": rel_path,
+                "aliases": parsed.aliases,
+                "tags": parsed.tags,
+                "fields": parsed.fields,
+            }
+        )
+    return results


### PR DESCRIPTION
## Summary
- add `service_api` module exposing helper functions for Obsidian note access
- search notes via FAISS/SQLite index
- fetch note markdown and list `#npc` notes
- provide example usage script

## Testing
- `pytest` *(fails: 31 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ecb7be4c83258d153407d22f9398