### PR TITLE
Strip model path components and simplify ONNX session loading

### DIFF
--- a/core/onnx_crafter_service.py
+++ b/core/onnx_crafter_service.py
@@ -72,13 +72,7 @@ class ModelSession:
         path = Path(model_dir)
         if not path.exists():
             base = Path(__file__).resolve().parents[1] / "models"
-            candidate = base / path
-            if candidate.exists():
-                path = candidate
-            else:
-                candidate = base / f"{path}.onnx"
-                if candidate.exists():
-                    path = candidate
+            path = base / path
 
         if path.is_dir():
             candidates = list(path.glob("*.onnx"))

--- a/ui/onnx.js
+++ b/ui/onnx.js
@@ -79,13 +79,12 @@ async function tauriOnnxMain(){
     await refreshModels();
   });
 
-  startBtn.addEventListener('click', async () => {
-    const modelName = modelSelect.value.split(/[\\/]/).pop();
-    const cfg = {
-      model: modelName,
-      steps: parseInt(stepsInput.value) || 0,
-      sampling: {}
-    };
+    startBtn.addEventListener('click', async () => {
+      const cfg = {
+        model: modelSelect.value.split(/[\\/]/).pop(),
+        steps: parseInt(stepsInput.value) || 0,
+        sampling: {}
+      };
     if (topKInput.value) cfg.sampling.top_k = parseInt(topKInput.value);
     if (topPInput.value) cfg.sampling.top_p = parseFloat(topPInput.value);
     if (tempInput.value) cfg.sampling.temperature = parseFloat(tempInput.value);


### PR DESCRIPTION
## Summary
- Ensure ONNX UI sends only the model folder name in config
- Simplify `ModelSession.load_session` to resolve model folders under `models/`

## Testing
- `pytest tests/test_onnx_crafter_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c4f3f73e048325a6d2eee126a3c875