### PR TITLE
clarify ModelSession usage in ONNX crafter service

### DIFF
--- a/core/onnx_crafter_service.py
+++ b/core/onnx_crafter_service.py
@@ -241,6 +241,8 @@ def main(argv: Sequence[str] | None = None) -> None:
         python -m core.onnx_crafter_service '{"model": "models", "steps": 32}'
     """
 
+    # Instantiate a fresh session for each invocation so that generation
+    # state and telemetry remain isolated per job.
     session = ModelSession()
     signal.signal(signal.SIGINT, session.cancel)
     signal.signal(signal.SIGTERM, session.cancel)


### PR DESCRIPTION
## Summary
- document ModelSession instantiation in `core.onnx_crafter_service.main`

## Testing
- `pytest tests/test_onnx_crafter_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4f712ed448325ad557663e932916b