### PR TITLE
feat: include metadata in transcript logger

### DIFF
--- a/ears/pipeline.py
+++ b/ears/pipeline.py
@@ -92,7 +92,12 @@ async def run_bot(
                     last_emit = now
             if part.is_final:
                 logger.append(
-                    str(channel_id), speaker or "unknown", part.text, timestamp=part.start
+                    str(channel_id),
+                    speaker or "unknown",
+                    part.text,
+                    timestamp=part.start,
+                    language=part.language,
+                    confidence=part.confidence,
                 )
 
     vad = VoiceActivityDetector(segment_callback=handle_segment, diarizer=diarizer)

--- a/ears/transcript_logger.py
+++ b/ears/transcript_logger.py
@@ -41,12 +41,33 @@ class TranscriptLogger:
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
-    def append(self, channel: str, speaker: str, text: str, *, timestamp: Optional[float] = None) -> None:
+    def append(
+        self,
+        channel: str,
+        speaker: str,
+        text: str,
+        *,
+        timestamp: Optional[float] = None,
+        language: Optional[str] = None,
+        confidence: Optional[float] = None,
+    ) -> None:
         """Append a transcript entry for ``channel``.
 
         Each entry is written atomically to avoid interleaving between
         concurrent writers. The log line is encoded as JSON and flushed using
         the ``O_APPEND`` flag so writes are always appended.
+
+        Parameters
+        ----------
+        channel, speaker, text:
+            Core metadata describing the transcript entry.
+        timestamp:
+            Optional explicit timestamp in seconds since the epoch. When not
+            provided, the current time is used.
+        language:
+            Optional BCP‑47 language code detected for ``text``.
+        confidence:
+            Optional overall confidence score for the transcription.
         """
 
         entry = {
@@ -54,6 +75,10 @@ class TranscriptLogger:
             "speaker": speaker,
             "text": text,
         }
+        if language is not None:
+            entry["language"] = language
+        if confidence is not None:
+            entry["confidence"] = confidence
         data = json.dumps(entry, ensure_ascii=False) + "\n"
         path = self._base_path(channel)
         with self._lock(channel):

--- a/tests/test_pipeline_callback.py
+++ b/tests/test_pipeline_callback.py
@@ -48,10 +48,12 @@ class DummyChannel:
 
 
 class DummyPart:
-    def __init__(self, text, is_final, start=0.0):
+    def __init__(self, text, is_final, start=0.0, language="en", confidence=0.5):
         self.text = text
         self.is_final = is_final
         self.start = start
+        self.language = language
+        self.confidence = confidence
 
 
 class DummyWhisper:
@@ -69,8 +71,18 @@ class DummyLogger:
     def __init__(self, root):
         self.records = []
 
-    def append(self, channel, speaker, text, timestamp=None):
-        self.records.append((channel, speaker, text, timestamp))
+    def append(
+        self,
+        channel,
+        speaker,
+        text,
+        timestamp=None,
+        language=None,
+        confidence=None,
+    ):
+        self.records.append(
+            (channel, speaker, text, timestamp, language, confidence)
+        )
 
 
 class DummyVAD:

--- a/tests/test_transcript_logger.py
+++ b/tests/test_transcript_logger.py
@@ -17,13 +17,15 @@ def read_jsonl(path: Path):
 
 def test_append_and_summary(tmp_path):
     logger = TranscriptLogger(tmp_path)
-    logger.append("chan", "alice", "hello")
-    logger.append("chan", "bob", "hi")
+    logger.append("chan", "alice", "hello", language="en", confidence=0.9)
+    logger.append("chan", "bob", "hi", language="en", confidence=0.8)
 
     path = tmp_path / "chan.jsonl"
     entries = read_jsonl(path)
     assert entries[0]["text"] == "hello"
+    assert entries[0]["language"] == "en"
     assert entries[1]["speaker"] == "bob"
+    assert entries[1]["confidence"] == 0.8
 
     summary = logger.summary("chan")
     assert "alice: hello" in summary


### PR DESCRIPTION
## Summary
- log optional language and confidence fields in TranscriptLogger
- propagate WhisperService language/confidence metadata through pipeline
- update tests for new transcript schema

## Testing
- `pytest tests/test_transcript_logger.py tests/test_pipeline_callback.py`

------
https://chatgpt.com/codex/tasks/task_e_68c4f718c4c88325a821620b9ab7767f