### PR TITLE
Use Tauri command for About dialog

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -16,7 +16,7 @@ use std::{
 use regex::Regex;
 use tauri::Manager;
 use tauri::{AppHandle, State};
-use serde_json::Value;
+use serde_json::{json, Value};
 mod musiclang;
 mod util;
 use crate::util::list_from_dir;
@@ -86,6 +86,21 @@ fn list_models() -> Result<Vec<String>, String> {
     }
     items.sort();
     Ok(items)
+}
+
+#[tauri::command]
+fn app_version() -> Result<Value, String> {
+    let app = env!("CARGO_PKG_VERSION").to_string();
+    let output = Command::new("python")
+        .arg("--version")
+        .output()
+        .map_err(|e| e.to_string())?;
+    let python = if output.stdout.is_empty() {
+        String::from_utf8_lossy(&output.stderr).trim().to_string()
+    } else {
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    };
+    Ok(json!({ "app": app, "python": python }))
 }
 
 #[tauri::command]
@@ -372,6 +387,7 @@ fn main() {
             list_presets,
             list_styles,
             list_models,
+            app_version,
             start_job,
             onnx_generate,
             cancel_render,

--- a/ui/topbar.js
+++ b/ui/topbar.js
@@ -45,9 +45,8 @@
   about.textContent = 'About';
   about.addEventListener('click', async () => {
     try {
-      const res = await fetch('/about');
-      const data = await res.json();
-      alert(`Python version: ${data.python}`);
+      const data = await window.__TAURI__.invoke('app_version');
+      alert(`App version: ${data.app}\nPython version: ${data.python}`);
     } catch (err) {
       alert('Failed to fetch version');
     }


### PR DESCRIPTION
## Summary
- Replace `/about` fetch with a Tauri `app_version` command in the top bar
- Add `app_version` command in Rust returning app and Python versions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cargo test` *(fails: spurious network error: Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*

------
https://chatgpt.com/codex/tasks/task_e_68c4f72aadb48325920b362ba9813282