### PR TITLE
feat: add pyannote diarization hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ To enable optional speaker diarization via
 pip install .[diarization]
 ```
 
+The first invocation downloads the pretrained ``pyannote/speaker-diarization``
+model. A CUDA-enabled GPU is strongly recommended for real-time use; CPU
+inference is possible but significantly slower.
+
+Example usage with the Discord transcription bot:
+
+```python
+import asyncio
+from ears import run_bot, pyannote_diarize
+
+asyncio.run(run_bot("TOKEN", 123456789012345678, diarizer=pyannote_diarize))
+```
+
 ## Generate N minutes of music
 
 1. Create a song specification JSON (see `core/song_spec.py` for fields).

--- a/docs/examples/discord_diarization.py
+++ b/docs/examples/discord_diarization.py
@@ -1,0 +1,12 @@
+"""Minimal configuration enabling speaker diarization with the Discord bot."""
+import asyncio
+
+from ears import run_bot, pyannote_diarize
+
+asyncio.run(
+    run_bot(
+        "BOT_TOKEN",
+        123456789012345678,
+        diarizer=pyannote_diarize,
+    )
+)

--- a/ears/pipeline.py
+++ b/ears/pipeline.py
@@ -64,7 +64,8 @@ async def run_bot(
     transcript_root:
         Directory to store JSONL transcript logs.
     diarizer:
-        Optional speaker diarization hook.
+        Optional :class:`~ears.vad.DiarizationHook` such as
+        :func:`~ears.diarization.pyannote_diarize`.
     part_callback:
         Async callback invoked for every :class:`TranscriptionSegment` produced
         by Whisper. Both partial and final segments are forwarded.


### PR DESCRIPTION
## Summary
- expose a DiarizationHook backed by pyannote.audio
- wire diarizer option through run_bot
- document model/GPU requirements and provide example config

## Testing
- `pytest tests/test_vad_diarization.py tests/test_pipeline_callback.py`

------
https://chatgpt.com/codex/tasks/task_e_68c4fa9480148325bea62f8ac4b42902