### PR TITLE
Handle odd-length PCM in resampling

### DIFF
--- a/tests/test_resampling.py
+++ b/tests/test_resampling.py
@@ -14,3 +14,17 @@ def test_resample_48k_to_16k_length():
     resampled = _resample(pcm, sr_in, sr_out)
     out = np.frombuffer(resampled, dtype=np.int16)
     assert out.shape[0] == int(sr_out * duration)
+
+
+def test_resample_odd_length_does_not_raise():
+    sr_in = 48000
+    sr_out = 16000
+    duration = 1.0
+    t = np.linspace(0, duration, int(sr_in * duration), endpoint=False)
+    sine = np.sin(2 * np.pi * 440 * t)
+    stereo = np.stack([sine, sine], axis=1)
+    pcm = (stereo * 32767).astype(np.int16).tobytes()
+    pcm += b"\x00"  # introduce a single extra byte
+    resampled = _resample(pcm, sr_in, sr_out)
+    out = np.frombuffer(resampled, dtype=np.int16)
+    assert out.shape[0] == int(sr_out * duration)


### PR DESCRIPTION
## Summary
- truncate incomplete PCM frames before resampling and log dropped bytes
- test odd-length PCM data to ensure resampling succeeds

## Testing
- `pytest tests/test_resampling.py -q` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68c4ff53311c8325bfa1d27cc708b981