### PR TITLE
Add Piper TTS backend

### DIFF
--- a/mouth/__init__.py
+++ b/mouth/__init__.py
@@ -1,0 +1,5 @@
+"""Text-to-speech utilities."""
+
+from .tts import TTSEngine, TTSBackend
+
+__all__ = ["TTSEngine", "TTSBackend"]

--- a/mouth/backends/__init__.py
+++ b/mouth/backends/__init__.py
@@ -1,0 +1,5 @@
+"""Backend implementations for text-to-speech."""
+
+from .piper import PiperBackend
+
+__all__ = ["PiperBackend"]

--- a/mouth/backends/piper.py
+++ b/mouth/backends/piper.py
@@ -1,0 +1,38 @@
+"""Piper text-to-speech backend."""
+
+from __future__ import annotations
+
+import io
+import subprocess
+from typing import Optional
+
+import numpy as np
+import soundfile as sf
+
+from ..tts import TTSBackend
+
+
+class PiperBackend(TTSBackend):
+    """Wrapper around the Piper TTS system."""
+
+    def __init__(self, model_path: str, config_path: Optional[str] = None, executable: str = "piper") -> None:
+        self.model_path = model_path
+        self.config_path = config_path
+        self.executable = executable
+
+    def synthesize(self, text: str, voice_profile: Optional[str] = None) -> np.ndarray:
+        model = voice_profile or self.model_path
+
+        cmd = [self.executable, "--model", str(model)]
+        if self.config_path:
+            cmd.extend(["--config", str(self.config_path)])
+
+        proc = subprocess.run(
+            cmd,
+            input=text.encode("utf-8"),
+            stdout=subprocess.PIPE,
+            check=True,
+        )
+
+        audio, _ = sf.read(io.BytesIO(proc.stdout), dtype="float32")
+        return audio

--- a/mouth/tts.py
+++ b/mouth/tts.py
@@ -1,0 +1,41 @@
+"""Abstractions for text-to-speech backends."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Optional
+
+import numpy as np
+
+
+class TTSBackend(ABC):
+    """Abstract base class for TTS backends."""
+
+    @abstractmethod
+    def synthesize(self, text: str, voice_profile: Optional[str] = None) -> np.ndarray:
+        """Synthesize audio from text.
+
+        Args:
+            text: Text to convert to speech.
+            voice_profile: Optional identifier or path for a voice profile or model.
+
+        Returns:
+            PCM audio as a 1-D ``numpy.float32`` array.
+        """
+
+
+class TTSEngine:
+    """High level wrapper for text-to-speech synthesis."""
+
+    def __init__(self, backend: str = "piper", **backend_kwargs) -> None:
+        if backend == "piper":
+            from .backends.piper import PiperBackend
+
+            self.backend: TTSBackend = PiperBackend(**backend_kwargs)
+        else:  # pragma: no cover - defensive programming
+            raise ValueError(f"Unsupported TTS backend: {backend}")
+
+    def synthesize(self, text: str, voice_profile: Optional[str] = None) -> np.ndarray:
+        """Synthesize audio using the selected backend."""
+
+        return self.backend.synthesize(text, voice_profile)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.10,<3.11"
 [project.optional-dependencies]
 midi = ["mido"]
 diarization = ["pyannote.audio"]
+tts = ["piper-tts"]
 
 [build-system]
 requires = ["setuptools>=61"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,6 @@ python-frontmatter
 faiss-cpu
 sentence-transformers
 watchfiles
+piper-tts
 
 discord.py[voice] @ git+https://github.com/jg-l/discord.py


### PR DESCRIPTION
## Summary
- add generic text-to-speech interfaces under `mouth`
- implement Piper-based backend and high-level engine wrapper
- include Piper dependency in project config

## Testing
- `pip install piper-tts` *(fails: Could not find a version that satisfies the requirement piper-tts)*
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy)*
- `pytest` *(fails: 22 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c50a645d048325bbfbabacbfa5fb1b