### PR TITLE
refactor: centralize model directory constant

### DIFF
--- a/core/onnx_crafter_service.py
+++ b/core/onnx_crafter_service.py
@@ -24,6 +24,7 @@ import tempfile
 import numpy as np
 
 from . import midi_load, event_vocab
+from .paths import MODEL_DIR
 from .stems import Stem, beats_to_secs
 from .midi_export import stems_to_midi
 from .song_spec import SongSpec
@@ -73,8 +74,7 @@ class ModelSession:
 
         path = Path(model_dir)
         if not path.exists():
-            base = Path(__file__).resolve().parents[1] / "models"
-            path = base / path
+            path = MODEL_DIR / path
 
         if path.is_dir():
             candidates = list(path.glob("*.onnx"))

--- a/core/paths.py
+++ b/core/paths.py
@@ -1,0 +1,11 @@
+"""Centralized filesystem paths used throughout the project."""
+
+from pathlib import Path
+
+# Path to the directory holding all model files. Ensure the directory exists
+# so callers can rely on its presence without performing their own checks.
+MODEL_DIR = Path(__file__).resolve().parents[1] / "models"
+MODEL_DIR.mkdir(parents=True, exist_ok=True)
+
+__all__ = ["MODEL_DIR"]
+

--- a/core/phrase_model.py
+++ b/core/phrase_model.py
@@ -15,7 +15,6 @@ an exception is raised so callers can fall back to the deterministic
 algorithms.
 """
 
-from pathlib import Path
 from typing import Iterable, List, Optional, Sequence, Tuple
 import threading
 import random
@@ -23,6 +22,7 @@ import logging
 
 import numpy as np
 
+from .paths import MODEL_DIR
 from .sampling import sample
 from .style import StyleToken
 
@@ -39,8 +39,6 @@ try:  # pragma: no cover - optional import
 except Exception:  # pragma: no cover - handled gracefully
     ort = None
 
-
-MODEL_DIR = Path(__file__).resolve().parent.parent / "models"
 
 # Cache for loaded models to avoid repeated disk access. Access to the cache
 # is guarded by a lock because models may also be loaded from a background


### PR DESCRIPTION
## Summary
- add shared `MODEL_DIR` constant in `core.paths`
- use `MODEL_DIR` in `phrase_model` and `onnx_crafter_service`

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68c50cb1767c8325b2e48e94214aa17b