### PR TITLE
Use PathBuf for model path construction

### DIFF
--- a/src-tauri/src/musiclang.rs
+++ b/src-tauri/src/musiclang.rs
@@ -74,9 +74,9 @@ pub fn download_model(
     name: &str,
     force: Option<bool>,
 ) -> Result<Vec<String>, String> {
-    fs::create_dir_all("models").map_err(|e| e.to_string())?;
     let file_name = name.split('/').last().unwrap_or(name);
-    let path = PathBuf::from(format!("models/{}.onnx", file_name));
+    let path = PathBuf::from("models").join(file_name).with_extension("onnx");
+    fs::create_dir_all(path.parent().unwrap()).map_err(|e| e.to_string())?;
 
     if path.exists() && !force.unwrap_or(false) {
         let event = ProgressEvent {
@@ -86,7 +86,7 @@ pub fn download_model(
             eta: None,
         };
         let _ = app.emit_all(&format!("download::progress::{}", name), event);
-        return list_from_dir(Path::new("models"));
+        return list_from_dir(path.parent().unwrap());
     }
 
     let url = format!("https://huggingface.co/{}/resolve/main/model.onnx", name);
@@ -119,5 +119,5 @@ pub fn download_model(
         let _ = app.emit_all(&format!("download::progress::{}", name), event);
     }
 
-    list_from_dir(Path::new("models"))
+    list_from_dir(path.parent().unwrap())
 }


### PR DESCRIPTION
## Summary
- build model file path using `PathBuf` and `with_extension`
- reuse the `PathBuf` for creating the model directory, file creation, and listing

## Testing
- `cargo test` *(fails: failed to download crates index because CONNECT tunnel 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c51318d904832585d1e0591136732c