### PR TITLE
fix: include step and total in download progress events

### DIFF
--- a/src-tauri/src/musiclang.rs
+++ b/src-tauri/src/musiclang.rs
@@ -82,8 +82,10 @@ pub fn download_model(
         let event = ProgressEvent {
             stage: Some("download".into()),
             percent: Some(100),
-            message: format!("Model {} already exists, skipping download", name),
+            message: Some(format!("Model {} already exists, skipping download", name)),
             eta: None,
+            step: None,
+            total: None,
         };
         let _ = app.emit_all(&format!("download::progress::{}", name), event);
         return list_from_dir(Path::new("models"));
@@ -113,8 +115,10 @@ pub fn download_model(
         let event = ProgressEvent {
             stage: Some("download".into()),
             percent,
-            message: format!("Downloading {}", name),
+            message: Some(format!("Downloading {}", name)),
             eta: None,
+            step: None,
+            total: None,
         };
         let _ = app.emit_all(&format!("download::progress::{}", name), event);
     }


### PR DESCRIPTION
## Summary
- wrap `ProgressEvent` messages in `Some(...)` and include `step`/`total` fields when emitting download progress

## Testing
- `cargo test` *(fails: failed to download from https://index.crates.io)*
- `cargo test --offline` *(fails: no matching package named `regex` found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5132862a08325b02607a0daa306cb