### PR TITLE
Add TTS caching and warm-start support

### DIFF
--- a/mouth/backends/piper.py
+++ b/mouth/backends/piper.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import io
 import subprocess
-from typing import Optional
+from typing import Iterable, Optional
 
 import numpy as np
 import soundfile as sf
@@ -37,3 +37,17 @@ class PiperBackend(TTSBackend):
 
         audio, _ = sf.read(io.BytesIO(proc.stdout), dtype="float32")
         return audio
+
+    # ------------------------------------------------------------------
+    def warm_start(self, voices: Optional[Iterable[str]] = None) -> None:
+        """Pre-load one or more voice models."""
+
+        targets = list(voices) if voices is not None else [self.model_path]
+        for model in targets:
+            cmd = [self.executable, "--model", str(model)]
+            if self.config_path:
+                cmd.extend(["--config", str(self.config_path)])
+            try:  # pragma: no cover - warm start is best-effort
+                subprocess.run(cmd, input=b"warm start", stdout=subprocess.PIPE, check=True)
+            except Exception:
+                continue

--- a/mouth/tts.py
+++ b/mouth/tts.py
@@ -3,11 +3,66 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+import hashlib
+import json
+import time
+from pathlib import Path
 from typing import Optional, Union
 
 import numpy as np
+import soundfile as sf
 
 from .registry import VoiceProfile, VoiceRegistry
+
+
+CACHE_DIR = Path("cache/tts")
+
+
+def _cache_key(voice: VoiceProfile, text: str) -> str:
+    data = json.dumps(
+        {
+            "voice_id": voice.voice_id,
+            "speed": voice.speed,
+            "emotion": voice.emotion,
+            "text": text,
+        },
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(data).hexdigest()
+
+
+def cache_lookup(key: str, ttl: Optional[float] = None) -> Optional[np.ndarray]:
+    """Return cached PCM if present and not expired."""
+
+    path = CACHE_DIR / f"{key}.npy"
+    if not path.exists():
+        return None
+    if ttl is not None and ttl >= 0:
+        age = time.time() - path.stat().st_mtime
+        if age > ttl:
+            try:
+                path.unlink()
+                (path.with_suffix(".opus")).unlink(missing_ok=True)  # type: ignore[arg-type]
+            except OSError:
+                pass
+            return None
+    return np.load(path)
+
+
+def cache_store(
+    key: str,
+    audio: np.ndarray,
+    *,
+    rate: int = 22050,
+) -> None:
+    """Store ``audio`` in the cache under ``key``."""
+
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    np.save(CACHE_DIR / f"{key}.npy", audio)
+    try:  # pragma: no cover - optional dependency or codec support
+        sf.write(CACHE_DIR / f"{key}.opus", audio, rate, format="OGG", subtype="OPUS")
+    except Exception:
+        pass
 
 
 class TTSBackend(ABC):
@@ -25,6 +80,11 @@ class TTSBackend(ABC):
             PCM audio as a 1-D ``numpy.float32`` array.
         """
 
+    # ------------------------------------------------------------------
+    def warm_start(self, *args, **kwargs) -> None:  # pragma: no cover - default no-op
+        """Pre-load backend resources to reduce first-use latency."""
+        return None
+
 
 class TTSEngine:
     """High level wrapper for text-to-speech synthesis."""
@@ -39,8 +99,26 @@ class TTSEngine:
 
         self.registry = registry or VoiceRegistry()
 
-    def synthesize(self, text: str, voice: Union[str, VoiceProfile, None] = None) -> np.ndarray:
-        """Synthesize audio using the selected backend."""
+    # ------------------------------------------------------------------
+    def synthesize(
+        self, text: str, voice: Union[str, VoiceProfile, None] = None, *, ttl: Optional[float] = None
+    ) -> np.ndarray:
+        """Synthesize audio using the selected backend with caching."""
 
         profile = voice if isinstance(voice, VoiceProfile) else self.registry.get_profile(voice)
-        return self.backend.synthesize(text, profile)
+        key = _cache_key(profile, text)
+        cached = cache_lookup(key, ttl)
+        if cached is not None:
+            return cached
+        audio = self.backend.synthesize(text, profile)
+        cache_store(key, audio)
+        return audio
+
+    # ------------------------------------------------------------------
+    def warm_start(self) -> None:
+        """Eagerly load backend resources."""
+
+        if hasattr(self.backend, "warm_start"):
+            self.backend.warm_start(
+                [p.voice_id for p in getattr(self.registry, "_profiles", {}).values()]
+            )

--- a/tests/test_tts_cache.py
+++ b/tests/test_tts_cache.py
@@ -1,0 +1,55 @@
+"""Tests for TTS caching and warm start helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from mouth import tts
+from mouth.registry import VoiceProfile, VoiceRegistry
+
+
+class DummyBackend(tts.TTSBackend):
+    def __init__(self, **kwargs):
+        self.calls: list[str] = []
+        self.warmed: list[str] = []
+
+    def synthesize(self, text: str, voice: VoiceProfile) -> np.ndarray:  # pragma: no cover - used in tests
+        self.calls.append(text)
+        return np.array([1.0], dtype=np.float32)
+
+    def warm_start(self, voices) -> None:  # pragma: no cover - used in tests
+        if voices is not None:
+            self.warmed.extend(list(voices))
+
+
+def test_cache_roundtrip(monkeypatch, tmp_path):
+    monkeypatch.setattr(tts, "PiperBackend", DummyBackend)
+    monkeypatch.setattr(tts, "CACHE_DIR", tmp_path / "cache" / "tts")
+    engine = tts.TTSEngine()
+    profile = VoiceProfile("demo")
+
+    audio1 = engine.synthesize("hello", profile)
+    assert np.array_equal(audio1, np.array([1.0], dtype=np.float32))
+    assert engine.backend.calls == ["hello"]
+
+    # second call should hit cache
+    audio2 = engine.synthesize("hello", profile)
+    assert np.array_equal(audio1, audio2)
+    assert engine.backend.calls == ["hello"]
+
+    # TTL expiry forces re-synthesis
+    engine.synthesize("hello", profile, ttl=0)
+    assert engine.backend.calls == ["hello", "hello"]
+
+
+def test_warm_start(monkeypatch):
+    monkeypatch.setattr(tts, "PiperBackend", DummyBackend)
+    reg = VoiceRegistry()
+    reg.set_profile("a", VoiceProfile("a"))
+    reg.set_profile("b", VoiceProfile("b"))
+    engine = tts.TTSEngine(registry=reg)
+    engine.warm_start()
+    assert set(engine.backend.warmed) == {"narrator", "a", "b"}
+


### PR DESCRIPTION
## Summary
- cache synthesized speech under `cache/tts/` with helpers to look up and store entries
- allow `TTSEngine` and `PiperBackend` to warm start and preload models
- add tests for TTS cache and warm-start behaviour

## Testing
- `pytest tests/test_tts_cache.py tests/test_discord_player.py tests/test_voice_registry.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5133043188325809f8dd4f2fb384e