### PR TITLE
docs: add mouth TTS section and discord example

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,3 +339,55 @@ asyncio.run(
 Replace `TOKEN` with your bot token and the integer with the target voice
 channel ID. ``part_callback`` receives both partial and final transcript
 segments; ``rate_limit`` throttles how often partial updates are emitted.
+
+## Mouth
+
+The `mouth` package adds text-to-speech capabilities powered by
+[Piper](https://github.com/rhasspy/piper). It can stream synthesized
+speech to Discord voice channels or generate narration for other
+systems.
+
+### Piper installation
+
+Install the `piper-tts` command-line tool and download at least one
+voice model:
+
+```bash
+pip install piper-tts soundfile
+piper --download en_US-amy-medium
+```
+
+Pass the model path to :class:`~mouth.tts.TTSEngine` or to the helper
+functions shown below.
+
+### Narrator and NPC voices
+
+Voice profiles are stored in ``data/voices.json`` and loaded via
+``VoiceRegistry``.  A ``narrator`` profile is always present and is
+used when no ``voice`` name is supplied.  Assign Piper models to the
+default narrator and to non-player characters (NPCs) by updating the
+registry:
+
+```python
+from mouth import VoiceRegistry, VoiceProfile
+
+registry = VoiceRegistry()
+registry.set_profile("narrator", VoiceProfile("/path/to/narrator.onnx"))
+registry.set_profile("goblin", VoiceProfile("/path/to/goblin.onnx"))
+registry.save()
+```
+
+Later, pass ``voice="goblin"`` to select the NPC voice.
+
+### Cache and warm start
+
+Voice profiles are cached on disk; subsequent runs reuse the registry
+and avoid reconfiguration.  Piper loads the voice model on first use, so
+keeping a ``TTSEngine`` instance alive or calling ``engine.synthesize("")``
+during startup warms the cache and eliminates initial latency.
+
+### Discord example
+
+See ``docs/examples/discord_piper_tts.py`` for an end-to-end snippet that
+joins a voice channel and speaks a line of dialog.
+

--- a/docs/examples/discord_piper_tts.py
+++ b/docs/examples/discord_piper_tts.py
@@ -1,0 +1,24 @@
+"""Speak a line in a Discord voice channel using Piper TTS.
+
+Replace ``BOT_TOKEN``, the channel ID and the model paths with real values.
+"""
+import asyncio
+
+from mouth.discord_player import run_bot
+from mouth import VoiceRegistry, VoiceProfile
+
+registry = VoiceRegistry()
+registry.set_profile("narrator", VoiceProfile("/path/to/narrator.onnx"))
+registry.set_profile("npc", VoiceProfile("/path/to/npc.onnx"))
+registry.save()
+
+asyncio.run(
+    run_bot(
+        "BOT_TOKEN",
+        123456789012345678,
+        text="Welcome to the guild hall!",
+        voice="npc",  # omit to use the narrator
+        registry=registry,
+        model_path="/path/to/narrator.onnx",
+    )
+)


### PR DESCRIPTION
## Summary
- document Piper TTS usage and voice registry in a new Mouth section
- add Discord example demonstrating Piper-based speech playback

## Testing
- `pytest tests/test_voice_registry.py tests/test_discord_player.py`

------
https://chatgpt.com/codex/tasks/task_e_68c51336f6f08325a575926c30755201