### PR TITLE
Use path.join for ONNX model paths

### DIFF
--- a/ui/onnx.js
+++ b/ui/onnx.js
@@ -1,4 +1,5 @@
 const isTauri = typeof window !== 'undefined' && window.__TAURI__;
+const path = isTauri ? require("path") : null;
 
 async function tauriOnnxMain(){
   const { invoke, event, shell } = window.__TAURI__;
@@ -86,8 +87,9 @@ async function tauriOnnxMain(){
   });
 
     startBtn.addEventListener('click', async () => {
+      const modelPath = path.join("models", modelSelect.value.split(/[\\/]/).pop());
       const cfg = {
-        model: `models/${modelSelect.value.split(/[\\/]/).pop()}`,
+        model: modelPath,
         steps: parseInt(stepsInput.value) || 0,
         sampling: {}
       };


### PR DESCRIPTION
## Summary
- import Node's `path` module in ONNX UI
- build model path with `path.join` and forward it unchanged to backend

## Testing
- `node --check ui/onnx.js && echo 'syntax ok'`


------
https://chatgpt.com/codex/tasks/task_e_68c51877965c8325b53ff702d63fba5a