### PR TITLE
Add tests for Piper TTS pipeline and Discord player

### DIFF
--- a/tests/test_discord_player.py
+++ b/tests/test_discord_player.py
@@ -52,3 +52,10 @@ async def test_speak_encodes_and_sends(monkeypatch):
     assert vc.send_audio_packet.call_count == 5
     vc.send_audio_packet.assert_called_with(b"packet", encode=False)
     await player.close()
+
+
+@pytest.mark.asyncio
+async def test_speak_without_connection_raises():
+    player = DiscordPlayer()
+    with pytest.raises(RuntimeError):
+        await player.speak("no channel")

--- a/tests/test_piper_backend.py
+++ b/tests/test_piper_backend.py
@@ -1,0 +1,53 @@
+import io
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+import subprocess
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+try:
+    import numpy as np
+except Exception:  # pragma: no cover - fallback stub
+    import _numpy_stub as np  # type: ignore[import-not-found]
+    sys.modules["numpy"] = np  # make available for imported modules
+import types
+sys.modules.setdefault("soundfile", types.SimpleNamespace(read=lambda *a, **k: ([], 22050)))
+import pytest
+
+from mouth.backends.piper import PiperBackend
+from mouth.registry import VoiceProfile
+
+
+def _dummy_wav(samples: np.ndarray, rate: int = 22050) -> bytes:
+    # Not used when soundfile is stubbed; retained for completeness
+    return b"dummy"
+
+
+def test_synthesize_invokes_piper(monkeypatch):
+    audio = np.array([0.0, 0.5, -0.5])
+    run = MagicMock(return_value=SimpleNamespace(stdout=b"data"))
+    monkeypatch.setattr("mouth.backends.piper.subprocess.run", run)
+    sf_read = MagicMock(return_value=(audio, 22050))
+    monkeypatch.setattr("mouth.backends.piper.sf.read", sf_read)
+    backend = PiperBackend(model_path="base", config_path="cfg", executable="piper-bin")
+    voice = VoiceProfile("alt")
+    out = backend.synthesize("hi", voice)
+    assert list(out) == list(audio)
+    run.assert_called_once_with(
+        ["piper-bin", "--model", "alt", "--config", "cfg"],
+        input=b"hi",
+        stdout=subprocess.PIPE,
+        check=True,
+    )
+
+
+def test_warm_start_invokes_subprocess(monkeypatch):
+    run = MagicMock()
+    monkeypatch.setattr("mouth.backends.piper.subprocess.run", run)
+    backend = PiperBackend(model_path="base", executable="piper")
+    backend.warm_start(["a", "b"])
+    assert run.call_count == 2
+    run.assert_any_call(
+        ["piper", "--model", "a"], input=b"warm start", stdout=subprocess.PIPE, check=True
+    )

--- a/tests/test_piper_pipeline.py
+++ b/tests/test_piper_pipeline.py
@@ -1,0 +1,49 @@
+import io
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+try:
+    import numpy as np
+except Exception:  # pragma: no cover - fallback stub
+    import _numpy_stub as np  # type: ignore[import-not-found]
+    sys.modules["numpy"] = np
+import types
+sys.modules.setdefault("soundfile", types.SimpleNamespace(read=lambda *a, **k: ([], 22050)))
+import pytest
+
+pytest.importorskip("discord")
+
+from mouth.discord_player import DiscordPlayer  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_text_to_discord_pipeline(monkeypatch):
+    audio = np.zeros(4800)
+    run = MagicMock(return_value=SimpleNamespace(stdout=b"data"))
+    monkeypatch.setattr("mouth.backends.piper.subprocess.run", run)
+    sf_read = MagicMock(return_value=(audio, 22050))
+    monkeypatch.setattr("mouth.backends.piper.sf.read", sf_read)
+
+    player = DiscordPlayer()
+    vc = MagicMock()
+    player.voice_client = vc
+
+    class DummyEncoder:
+        frame_size = 960
+        channels = 1
+
+        def encode(self, pcm, frame_size):
+            return b"packet"
+
+    monkeypatch.setattr("discord.opus.Encoder", lambda *a, **k: DummyEncoder())
+    sleep = AsyncMock()
+    monkeypatch.setattr("asyncio.sleep", sleep)
+
+    await player.speak("hello world")
+
+    assert run.called, "Piper backend should be invoked"
+    assert vc.send_audio_packet.called, "Discord voice client should receive audio"
+    await player.close()

--- a/tests/test_voice_registry.py
+++ b/tests/test_voice_registry.py
@@ -4,7 +4,7 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from mouth.registry import VoiceRegistry
+from mouth.registry import VoiceProfile, VoiceRegistry
 
 
 def test_registry_default_narrator(tmp_path):
@@ -22,3 +22,15 @@ def test_registry_unknown_voice(tmp_path):
     registry.save()
     data = json.loads(path.read_text())
     assert "custom" in data
+
+
+def test_registry_roundtrip(tmp_path):
+    path = tmp_path / "voices.json"
+    registry = VoiceRegistry(path)
+    registry.set_profile("alice", VoiceProfile("alice", speed=1.2, emotion="happy"))
+    registry.save()
+
+    loaded = VoiceRegistry(path)
+    profile = loaded.get_profile("alice")
+    assert profile.speed == 1.2
+    assert profile.emotion == "happy"


### PR DESCRIPTION
## Summary
- add unit tests for PiperBackend synthesize and warm start
- cover VoiceRegistry default, persistence, and roundtrip behaviour
- expand DiscordPlayer tests including error case without connection
- add integration test for text → PCM → DiscordPlayer flow

## Testing
- `pytest tests/test_piper_backend.py tests/test_voice_registry.py tests/test_discord_player.py tests/test_piper_pipeline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5188444f8832595b103bb3c63f177