### PR TITLE
feat(ui): add theme toggle and persist theme

### DIFF
--- a/ui/dnd.html
+++ b/ui/dnd.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <title>Dungeons & Dragons</title>
+  <script>
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme) {
+      document.documentElement.dataset.theme = savedTheme;
+    }
+  </script>
   <link rel="stylesheet" href="/ui/theme.css">
   <style>
     body {

--- a/ui/generate.html
+++ b/ui/generate.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <title>Blossom Render</title>
+  <script>
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme) {
+      document.documentElement.dataset.theme = savedTheme;
+    }
+  </script>
   <link rel="stylesheet" href="/ui/theme.css">
   <style>
     body { font-family: sans-serif; margin: 1em; background: var(--bg); color: var(--fg); }

--- a/ui/models.html
+++ b/ui/models.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <title>Available Models</title>
+  <script>
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme) {
+      document.documentElement.dataset.theme = savedTheme;
+    }
+  </script>
   <link rel="stylesheet" href="/ui/theme.css">
   <style>
     body {

--- a/ui/onnx.html
+++ b/ui/onnx.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <title>ONNX Crafter</title>
+  <script>
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme) {
+      document.documentElement.dataset.theme = savedTheme;
+    }
+  </script>
   <link rel="stylesheet" href="/ui/theme.css">
   <style>
     body { font-family: sans-serif; margin: 1em; background: var(--bg); color: var(--fg); }

--- a/ui/settings.html
+++ b/ui/settings.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <title>Settings</title>
+  <script>
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme) {
+      document.documentElement.dataset.theme = savedTheme;
+    }
+  </script>
   <link rel="stylesheet" href="/ui/theme.css">
   <style>
     body { font-family: sans-serif; margin: 1em; background: var(--bg); color: var(--fg); }
@@ -28,7 +34,7 @@
     <button id="set_dark" type="button">Use Dark Theme</button>
   </section>
   <button id="save" type="button">Save</button>
-  <script src="/ui/settings.js"></script>
   <script src="./topbar.js"></script>
+  <script src="/ui/settings.js"></script>
 </body>
 </html>

--- a/ui/topbar.js
+++ b/ui/topbar.js
@@ -4,7 +4,7 @@
     document.documentElement.setAttribute('data-theme', theme);
   };
 
-  const currentTheme = localStorage.getItem('theme') || 'dark';
+  let currentTheme = localStorage.getItem('theme') || 'dark';
   document.documentElement.setAttribute('data-theme', currentTheme);
 
   const style = document.createElement('style');
@@ -52,5 +52,17 @@
     }
   });
   bar.appendChild(about);
+
+  const themeBtn = document.createElement('button');
+  function updateThemeBtn() {
+    themeBtn.textContent = currentTheme === 'dark' ? 'Light Mode' : 'Dark Mode';
+  }
+  themeBtn.addEventListener('click', () => {
+    currentTheme = currentTheme === 'dark' ? 'light' : 'dark';
+    window.setTheme(currentTheme);
+    updateThemeBtn();
+  });
+  updateThemeBtn();
+  bar.appendChild(themeBtn);
   document.body.prepend(bar);
 })();

--- a/ui/train.html
+++ b/ui/train.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <title>Train Model</title>
+  <script>
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme) {
+      document.documentElement.dataset.theme = savedTheme;
+    }
+  </script>
   <link rel="stylesheet" href="/ui/theme.css">
   <style>
     body {


### PR DESCRIPTION
## Summary
- add topbar theme toggle and update button text
- apply saved theme on load across UI pages
- ensure topbar loads before other scripts

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest tests/test_utils.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68c51eb5f4f083258f8c2e1afcc42e9f