### PR TITLE
Ensure ONNX model exists before generation

### DIFF
--- a/ui/onnx.js
+++ b/ui/onnx.js
@@ -93,7 +93,25 @@ async function tauriOnnxMain(){
   });
 
     startBtn.addEventListener('click', async () => {
-      const modelPath = path.join("models", modelSelect.value.split(/[\\/]/).pop());
+      const modelName = modelSelect.value.split(/[\\/]/).pop();
+      const modelPath = path.join("models", `${modelName}.onnx`);
+      let installed;
+      try {
+        installed = await invoke('list_models');
+      } catch (e) {
+        const msg = `Error listing models: ${e}`;
+        log.textContent = msg;
+        log.scrollTop = log.scrollHeight;
+        if (typeof alert === 'function') alert(msg);
+        return;
+      }
+      if (!installed.includes(modelName)) {
+        const msg = `Model not found: ${modelName}`;
+        log.textContent = msg;
+        log.scrollTop = log.scrollHeight;
+        if (typeof alert === 'function') alert(msg);
+        return;
+      }
       const cfg = {
         model: modelPath,
         steps: parseInt(stepsInput.value) || 0,


### PR DESCRIPTION
## Summary
- Append `.onnx` extension to selected model path
- Verify model presence with `list_models` before running ONNX generation

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest tests/test_utils.py` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68c521e9595c83259a3095e052363d6e