### PR TITLE
feat: validate generation inputs

### DIFF
--- a/ui/onnx.js
+++ b/ui/onnx.js
@@ -128,6 +128,13 @@ async function tauriOnnxMain(){
       }
     }
     const midiFile = midiInput.files[0];
+    if (!songSpecInput.value.trim() && !midiFile) {
+      const msg = 'Please provide a song spec or a MIDI file.';
+      log.textContent = msg;
+      log.scrollTop = log.scrollHeight;
+      startBtn.disabled = false;
+      return;
+    }
     if (midiFile) {
       cfg.midi = await convertMidiFileToDataUri(midiFile);
     }


### PR DESCRIPTION
## Summary
- require either song spec text or MIDI file before invoking ONNX generation
- log helpful message and keep Start button enabled if input missing

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c5233925b0832591f14172baefcb6d