### PR TITLE
refactor: remove theme controls from top bar

### DIFF
--- a/ui/topbar.js
+++ b/ui/topbar.js
@@ -4,8 +4,7 @@
     document.documentElement.setAttribute('data-theme', theme);
   };
 
-  let currentTheme = localStorage.getItem('theme') || 'dark';
-  document.documentElement.setAttribute('data-theme', currentTheme);
+  window.setTheme(localStorage.getItem('theme') || 'dark');
 
   const style = document.createElement('style');
   style.textContent = `
@@ -53,16 +52,5 @@
   });
   bar.appendChild(about);
 
-  const themeBtn = document.createElement('button');
-  function updateThemeBtn() {
-    themeBtn.textContent = currentTheme === 'dark' ? 'Light Mode' : 'Dark Mode';
-  }
-  themeBtn.addEventListener('click', () => {
-    currentTheme = currentTheme === 'dark' ? 'light' : 'dark';
-    window.setTheme(currentTheme);
-    updateThemeBtn();
-  });
-  updateThemeBtn();
-  bar.appendChild(themeBtn);
   document.body.prepend(bar);
 })();


### PR DESCRIPTION
## Summary
- remove theme toggle button from UI top bar
- retain navigation items only (Back, About)

## Testing
- `npm test` (fails: Missing script "test")
- `pytest tests/test_eq_filters.py` (fails: ModuleNotFoundError: No module named 'numpy')

------
https://chatgpt.com/codex/tasks/task_e_68c524672f2483258b248c76f30263b9