### PR TITLE
Log cancellation and emit cancel events

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -306,7 +306,7 @@ fn onnx_generate(
 }
 
 #[tauri::command]
-fn cancel_render(registry: State<JobRegistry>, job_id: u64) -> Result<(), String> {
+fn cancel_render(app: AppHandle, registry: State<JobRegistry>, job_id: u64) -> Result<(), String> {
     let mut jobs = registry.jobs.lock().map_err(|e| e.to_string())?;
     match jobs.get_mut(&job_id) {
         Some(job) => {
@@ -318,6 +318,7 @@ fn cancel_render(registry: State<JobRegistry>, job_id: u64) -> Result<(), String
                 let status = child.wait().map_err(|e| e.to_string())?;
                 job.status = Some(status.success());
                 job.child = None;
+                let _ = app.emit_all(&format!("onnx::cancelled::{}", job_id), ());
                 Ok(())
             } else {
                 Err("Job already completed".into())


### PR DESCRIPTION
## Summary
- Reset progress bar and log "Job cancelled" after render cancellation in the ONNX UI
- Emit `onnx::cancelled` events from the backend when a job is killed

## Testing
- `cargo test` *(failed: failed to download from crates.io)*
- `npm test` *(failed: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c5244e18448325bba8536af24bf10c