### PR TITLE
feat: allow choosing output path for ONNX generation

### DIFF
--- a/core/onnx_crafter_service.py
+++ b/core/onnx_crafter_service.py
@@ -311,10 +311,10 @@ def main(argv: Sequence[str] | None = None) -> None:
 
     tokens = session.generate(tokens, steps, sampling, progress_cb=emit)
 
-    out_path = cfg.get("out", "out.mid")
-    midi_path = session.decode_to_midi(tokens, out_path)
+    out_path = Path(cfg.get("out", "out.mid")).expanduser()
+    session.decode_to_midi(tokens, out_path)
 
-    result = {"midi": midi_path, "telemetry": session.telemetry}
+    result = {"midi": str(out_path), "telemetry": session.telemetry}
     print(json.dumps(result))
 
 

--- a/ui/onnx.js
+++ b/ui/onnx.js
@@ -2,7 +2,7 @@ const isTauri = typeof window !== 'undefined' && window.__TAURI__;
 const path = isTauri ? require("path") : null;
 
 async function tauriOnnxMain(){
-  const { invoke, event, shell } = window.__TAURI__;
+  const { invoke, event, shell, dialog } = window.__TAURI__;
   const modelSelect = document.getElementById('model-select');
   const downloadBtn = document.getElementById('download');
   const songSpecInput = document.getElementById('song_spec');
@@ -145,33 +145,41 @@ async function tauriOnnxMain(){
     await refreshModels();
   });
 
-    startBtn.addEventListener('click', async () => {
-      const parsed = validateInputs();
-      if (!parsed) return;
-      const modelName = modelSelect.value.split(/[\\/]/).pop();
-      const modelPath = path.join("models", `${modelName}.onnx`);
-      let installed;
-      try {
-        installed = await invoke('list_models');
-      } catch (e) {
-        const msg = `Error listing models: ${e}`;
-        log.textContent = msg;
-        log.scrollTop = log.scrollHeight;
-        if (typeof alert === 'function') alert(msg);
-        return;
-      }
-      if (!installed.includes(modelName)) {
-        const msg = `Model not found: ${modelName}`;
-        log.textContent = msg;
-        log.scrollTop = log.scrollHeight;
-        if (typeof alert === 'function') alert(msg);
-        return;
-      }
-      const cfg = {
-        model: modelPath,
-        steps: parsed.steps,
-        sampling: {}
-      };
+  startBtn.addEventListener('click', async () => {
+    const parsed = validateInputs();
+    if (!parsed) return;
+    const modelName = modelSelect.value.split(/[\\/]/).pop();
+    const modelPath = path.join("models", `${modelName}.onnx`);
+    let installed;
+    try {
+      installed = await invoke('list_models');
+    } catch (e) {
+      const msg = `Error listing models: ${e}`;
+      log.textContent = msg;
+      log.scrollTop = log.scrollHeight;
+      if (typeof alert === 'function') alert(msg);
+      return;
+    }
+    if (!installed.includes(modelName)) {
+      const msg = `Model not found: ${modelName}`;
+      log.textContent = msg;
+      log.scrollTop = log.scrollHeight;
+      if (typeof alert === 'function') alert(msg);
+      return;
+    }
+    const cfg = {
+      model: modelPath,
+      steps: parsed.steps,
+      sampling: {}
+    };
+    const outPath = await dialog.save({
+      title: 'Save MIDI as...',
+      defaultPath: 'output.mid'
+    });
+    if (!outPath) {
+      return;
+    }
+    cfg.out = outPath;
     if (parsed.top_k !== undefined) cfg.sampling.top_k = parsed.top_k;
     if (parsed.top_p !== undefined) cfg.sampling.top_p = parsed.top_p;
     if (parsed.temperature !== undefined) cfg.sampling.temperature = parsed.temperature;


### PR DESCRIPTION
## Summary
- add Tauri file-save dialog to choose output location and send via cfg.out
- respect provided output path in onnx_crafter_service and return it in result

## Testing
- `npm test` (fails: Missing script: "test")
- `pytest` (fails: ModuleNotFoundError: No module named 'numpy', etc.)

------
https://chatgpt.com/codex/tasks/task_e_68c52459a1bc832599fa9fb0d2309405