### PR TITLE
Improve ONNX dropdown stability and visibility

### DIFF
--- a/ui/onnx.html
+++ b/ui/onnx.html
@@ -33,7 +33,11 @@
     </p>
   </section>
   <div id="inputs">
-    <label>Model <select id="model-select" title="Choose a downloaded .onnx model"></select></label>
+    <label>Model
+      <select id="model-select" title="Choose a downloaded .onnx model">
+        <option value="" disabled selected>Select a model...</option>
+      </select>
+    </label>
     <label>Song spec (JSON or space-separated chords)
       <textarea id="song_spec" rows="3"></textarea>
     </label>

--- a/ui/onnx.js
+++ b/ui/onnx.js
@@ -79,10 +79,12 @@ async function tauriOnnxMain(){
       const installed = await invoke('list_models');
       const selected = modelSelect.value.split(/[\\/]/).pop();
       modelInstalled = installed.includes(selected);
-      refreshStartDisabled();
     } catch (e) {
       console.error(e);
+      modelInstalled = false;
     }
+    // Only update the Start button; do not modify the model selector itself
+    refreshStartDisabled();
   }
 
   async function populateModels(){

--- a/ui/theme.css
+++ b/ui/theme.css
@@ -27,3 +27,10 @@
   --log-fg: #070;
   --font: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 }
+
+/* Ensure the model dropdown stays visible and sized */
+#model-select {
+  position: relative;
+  z-index: 10;
+  min-width: 12rem;
+}


### PR DESCRIPTION
## Summary
- Preserve dropdown size with a "Select a model…" placeholder
- Keep model selection intact; `refreshModels` now only toggles Start button
- Ensure ONNX model dropdown stays visible using higher z-index and width

## Testing
- `node - <<'NODE'
const select = { value:'', options:[], appendChild(opt){ this.options.push(opt); }, get optionsLength(){ return this.options.length; } };
const startBtn = { disabled:true };
let modelInstalled = false;
function refreshStartDisabled(){ startBtn.disabled = !(modelInstalled); }
async function refreshModels(){
  try {
    const installed = await invoke('list_models');
    const selected = select.value.split(/[\\/]/).pop();
    modelInstalled = installed.includes(selected);
  } catch(e){
    console.error(e);
    modelInstalled = false;
  }
  refreshStartDisabled();
}
function invoke(cmd){ if(cmd==='list_models') return Promise.resolve(['modelA']); throw new Error('unknown cmd'); }
select.appendChild({ value:'', textContent:'Select a model...' });
select.appendChild({ value:'modelA', textContent:'Model A' });
select.value = 'modelA';
refreshModels().then(()=>{
  console.log('Options after refresh:', select.optionsLength);
  console.log('Start disabled:', startBtn.disabled);
});
NODE`
- `npm test` *(fails: Missing script "test")*
- `pytest tests/test_onnx_crafter_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c5243a3298832581f2934ed6ce77c5