### PR TITLE
feat(ui): centralize theme management

### DIFF
--- a/ui/dnd.html
+++ b/ui/dnd.html
@@ -3,12 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <title>Dungeons & Dragons</title>
-  <script>
-    const savedTheme = localStorage.getItem('theme');
-    if (savedTheme) {
-      document.documentElement.dataset.theme = savedTheme;
-    }
-  </script>
+  <script type="module" src="./theme.js"></script>
   <link rel="stylesheet" href="/ui/theme.css">
   <style>
     body {
@@ -25,6 +20,6 @@
 </head>
 <body>
   <h1>Under Construction</h1>
-  <script src="./topbar.js"></script>
+  <script type="module" src="./topbar.js"></script>
 </body>
 </html>

--- a/ui/generate.html
+++ b/ui/generate.html
@@ -3,12 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <title>Blossom Render</title>
-  <script>
-    const savedTheme = localStorage.getItem('theme');
-    if (savedTheme) {
-      document.documentElement.dataset.theme = savedTheme;
-    }
-  </script>
+  <script type="module" src="./theme.js"></script>
   <link rel="stylesheet" href="/ui/theme.css">
   <style>
     body { font-family: sans-serif; margin: 1em; background: var(--bg); color: var(--fg); }
@@ -78,7 +73,7 @@
     <ul id="recent_list"></ul>
   </div>
 
-  <script src="./topbar.js"></script>
+  <script type="module" src="./topbar.js"></script>
   <script src="/ui/app.js"></script>
 </body>
 </html>

--- a/ui/index.html
+++ b/ui/index.html
@@ -3,12 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <title>Blossom Music Generator</title>
-  <script>
-    const savedTheme = localStorage.getItem('theme');
-    if (savedTheme) {
-      document.documentElement.dataset.theme = savedTheme;
-    }
-  </script>
+  <script type="module" src="./theme.js"></script>
   <link rel="stylesheet" href="/ui/theme.css">
   <style>
     body {
@@ -101,7 +96,7 @@
       <h2>ONNX Crafter</h2>
     </a>
   </main>
-  <script src="./topbar.js"></script>
+  <script type="module" src="./topbar.js"></script>
   <script src="/ui/train.js"></script>
   <script>
     fetch('/models', { headers: { 'Accept': 'application/json' } })

--- a/ui/models.html
+++ b/ui/models.html
@@ -3,12 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <title>Available Models</title>
-  <script>
-    const savedTheme = localStorage.getItem('theme');
-    if (savedTheme) {
-      document.documentElement.dataset.theme = savedTheme;
-    }
-  </script>
+  <script type="module" src="./theme.js"></script>
   <link rel="stylesheet" href="/ui/theme.css">
   <style>
     body {
@@ -33,7 +28,7 @@
 <body>
   <h1>Available Models</h1>
   <ul id="models"></ul>
-  <script src="./topbar.js"></script>
+  <script type="module" src="./topbar.js"></script>
   <script src="/ui/models.js"></script>
 </body>
 </html>

--- a/ui/onnx.html
+++ b/ui/onnx.html
@@ -3,12 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <title>ONNX Crafter</title>
-  <script>
-    const savedTheme = localStorage.getItem('theme');
-    if (savedTheme) {
-      document.documentElement.dataset.theme = savedTheme;
-    }
-  </script>
+  <script type="module" src="./theme.js"></script>
   <link rel="stylesheet" href="/ui/theme.css">
   <style>
     body { font-family: sans-serif; margin: 1em; background: var(--bg); color: var(--fg); }
@@ -58,7 +53,7 @@
     <a id="midi_link" href="#"></a>
     <pre id="telemetry"></pre>
   </div>
-  <script src="./topbar.js"></script>
+  <script type="module" src="./topbar.js"></script>
   <script src="/ui/onnx.js"></script>
 </body>
 </html>

--- a/ui/settings.html
+++ b/ui/settings.html
@@ -3,12 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <title>Settings</title>
-  <script>
-    const savedTheme = localStorage.getItem('theme');
-    if (savedTheme) {
-      document.documentElement.dataset.theme = savedTheme;
-    }
-  </script>
+  <script type="module" src="./theme.js"></script>
   <link rel="stylesheet" href="/ui/theme.css">
   <style>
     body { font-family: sans-serif; margin: 1em; background: var(--bg); color: var(--fg); }
@@ -34,7 +29,7 @@
     <button id="set_dark" type="button">Use Dark Theme</button>
   </section>
   <button id="save" type="button">Save</button>
-  <script src="./topbar.js"></script>
-  <script src="/ui/settings.js"></script>
+  <script type="module" src="./topbar.js"></script>
+  <script type="module" src="/ui/settings.js"></script>
 </body>
 </html>

--- a/ui/settings.js
+++ b/ui/settings.js
@@ -1,34 +1,35 @@
-(function() {
-  function $(id) { return document.getElementById(id); }
+import { setTheme } from './theme.js';
 
-  function load() {
-    const outdir = localStorage.getItem('default_outdir') || '';
-    const theme = localStorage.getItem('theme') || 'dark';
-    const outInput = $('default_outdir');
-    const themeSel = $('theme');
-    if (outInput) outInput.value = outdir;
-    if (themeSel) {
-      themeSel.value = theme;
-      themeSel.addEventListener('change', () => window.setTheme(themeSel.value));
-    }
+function $(id) { return document.getElementById(id); }
+
+function load() {
+  const outdir = localStorage.getItem('default_outdir') || '';
+  const theme = localStorage.getItem('theme') || 'dark';
+  const outInput = $('default_outdir');
+  const themeSel = $('theme');
+  if (outInput) outInput.value = outdir;
+  if (themeSel) {
+    themeSel.value = theme;
+    themeSel.addEventListener('change', () => setTheme(themeSel.value));
   }
+}
 
-  function save() {
-    const outInput = $('default_outdir');
+function save() {
+  const outInput = $('default_outdir');
+  const themeSel = $('theme');
+  if (outInput) localStorage.setItem('default_outdir', outInput.value);
+  if (themeSel) setTheme(themeSel.value);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  load();
+  const saveBtn = $('save');
+  if (saveBtn) saveBtn.addEventListener('click', save);
+  const darkBtn = $('set_dark');
+  if (darkBtn) darkBtn.addEventListener('click', () => {
+    setTheme('dark');
     const themeSel = $('theme');
-    if (outInput) localStorage.setItem('default_outdir', outInput.value);
-    if (themeSel) window.setTheme(themeSel.value);
-  }
-
-  document.addEventListener('DOMContentLoaded', () => {
-    load();
-    const saveBtn = $('save');
-    if (saveBtn) saveBtn.addEventListener('click', save);
-    const darkBtn = $('set_dark');
-    if (darkBtn) darkBtn.addEventListener('click', () => {
-      window.setTheme('dark');
-      const themeSel = $('theme');
-      if (themeSel) themeSel.value = 'dark';
-    });
+    if (themeSel) themeSel.value = 'dark';
   });
-})();
+});
+

--- a/ui/theme.js
+++ b/ui/theme.js
@@ -1,0 +1,10 @@
+export function setTheme(theme) {
+  localStorage.setItem('theme', theme);
+  document.documentElement.dataset.theme = theme;
+}
+
+const savedTheme = localStorage.getItem('theme');
+if (savedTheme) {
+  setTheme(savedTheme);
+}
+

--- a/ui/topbar.js
+++ b/ui/topbar.js
@@ -1,14 +1,9 @@
-(function() {
-  window.setTheme = function(theme) {
-    localStorage.setItem('theme', theme);
-    document.documentElement.setAttribute('data-theme', theme);
-  };
+import { setTheme } from './theme.js';
 
-  let currentTheme = localStorage.getItem('theme') || 'dark';
-  document.documentElement.setAttribute('data-theme', currentTheme);
+let currentTheme = document.documentElement.dataset.theme || 'dark';
 
-  const style = document.createElement('style');
-  style.textContent = `
+const style = document.createElement('style');
+style.textContent = `
     #top-bar {
       position: fixed;
       top: 0;
@@ -33,36 +28,36 @@
       background: var(--button-hover-bg);
     }
   `;
-  document.head.appendChild(style);
+document.head.appendChild(style);
 
-  const bar = document.createElement('div');
-  bar.id = 'top-bar';
-  const back = document.createElement('button');
-  back.textContent = 'Back';
-  back.addEventListener('click', () => history.back());
-  bar.appendChild(back);
-  const about = document.createElement('button');
-  about.textContent = 'About';
-  about.addEventListener('click', async () => {
-    try {
-      const data = await window.__TAURI__.invoke('app_version');
-      alert(`App version: ${data.app}\nPython version: ${data.python}`);
-    } catch (err) {
-      alert('Failed to fetch version');
-    }
-  });
-  bar.appendChild(about);
-
-  const themeBtn = document.createElement('button');
-  function updateThemeBtn() {
-    themeBtn.textContent = currentTheme === 'dark' ? 'Light Mode' : 'Dark Mode';
+const bar = document.createElement('div');
+bar.id = 'top-bar';
+const back = document.createElement('button');
+back.textContent = 'Back';
+back.addEventListener('click', () => history.back());
+bar.appendChild(back);
+const about = document.createElement('button');
+about.textContent = 'About';
+about.addEventListener('click', async () => {
+  try {
+    const data = await window.__TAURI__.invoke('app_version');
+    alert(`App version: ${data.app}\nPython version: ${data.python}`);
+  } catch (err) {
+    alert('Failed to fetch version');
   }
-  themeBtn.addEventListener('click', () => {
-    currentTheme = currentTheme === 'dark' ? 'light' : 'dark';
-    window.setTheme(currentTheme);
-    updateThemeBtn();
-  });
+});
+bar.appendChild(about);
+
+const themeBtn = document.createElement('button');
+function updateThemeBtn() {
+  themeBtn.textContent = currentTheme === 'dark' ? 'Light Mode' : 'Dark Mode';
+}
+themeBtn.addEventListener('click', () => {
+  currentTheme = currentTheme === 'dark' ? 'light' : 'dark';
+  setTheme(currentTheme);
   updateThemeBtn();
-  bar.appendChild(themeBtn);
-  document.body.prepend(bar);
-})();
+});
+updateThemeBtn();
+bar.appendChild(themeBtn);
+document.body.prepend(bar);
+

--- a/ui/train.html
+++ b/ui/train.html
@@ -3,12 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <title>Train Model</title>
-  <script>
-    const savedTheme = localStorage.getItem('theme');
-    if (savedTheme) {
-      document.documentElement.dataset.theme = savedTheme;
-    }
-  </script>
+  <script type="module" src="./theme.js"></script>
   <link rel="stylesheet" href="/ui/theme.css">
   <style>
     body {
@@ -41,7 +36,7 @@
   </div>
   <pre id="log"></pre>
 
-  <script src="./topbar.js"></script>
+  <script type="module" src="./topbar.js"></script>
   <script src="/ui/train.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add reusable `theme.js` for setting and restoring user theme preference
- load `theme.js` ahead of other scripts and clean up inline theme code
- update topbar and settings to import `setTheme` from centralized module

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest tests/test_utils.py -k ensure_file_rejects_directory -q` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68c5246c03088325ad652de8850d0240