### PR TITLE
Use checkbox to toggle theme in settings

### DIFF
--- a/ui/settings.html
+++ b/ui/settings.html
@@ -26,12 +26,10 @@
   </section>
   <section id="appearance">
     <h2>Appearance</h2>
-    <label for="theme">Theme</label>
-    <select id="theme">
-      <option value="light">Light</option>
-      <option value="dark">Dark</option>
-    </select>
-    <button id="set_dark" type="button">Use Dark Theme</button>
+    <label>
+      <input type="checkbox" id="theme_toggle">
+      Dark Theme
+    </label>
   </section>
   <button id="save" type="button">Save</button>
   <script src="./topbar.js"></script>

--- a/ui/settings.js
+++ b/ui/settings.js
@@ -5,30 +5,25 @@
     const outdir = localStorage.getItem('default_outdir') || '';
     const theme = localStorage.getItem('theme') || 'dark';
     const outInput = $('default_outdir');
-    const themeSel = $('theme');
+    const themeToggle = $('theme_toggle');
     if (outInput) outInput.value = outdir;
-    if (themeSel) {
-      themeSel.value = theme;
-      themeSel.addEventListener('change', () => window.setTheme(themeSel.value));
+    if (themeToggle) {
+      themeToggle.checked = theme === 'dark';
+      themeToggle.addEventListener('change', () => {
+        const newTheme = themeToggle.checked ? 'dark' : 'light';
+        window.setTheme(newTheme);
+      });
     }
   }
 
   function save() {
     const outInput = $('default_outdir');
-    const themeSel = $('theme');
     if (outInput) localStorage.setItem('default_outdir', outInput.value);
-    if (themeSel) window.setTheme(themeSel.value);
   }
 
   document.addEventListener('DOMContentLoaded', () => {
     load();
     const saveBtn = $('save');
     if (saveBtn) saveBtn.addEventListener('click', save);
-    const darkBtn = $('set_dark');
-    if (darkBtn) darkBtn.addEventListener('click', () => {
-      window.setTheme('dark');
-      const themeSel = $('theme');
-      if (themeSel) themeSel.value = 'dark';
-    });
   });
 })();


### PR DESCRIPTION
## Summary
- Replace theme dropdown and dark button with a single checkbox toggle
- Update settings script to handle toggle change and persist theme

## Testing
- `pytest tests/test_utils.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c524797a008325b0ced90db4bf5635