### PR TITLE
feat: persist theme via Tauri store

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Simple demos for algorithmic music pattern generation.
 
 A desktop interface built with [Tauri](https://tauri.app/) provides the front‑end.
 Templates and scripts live under the top‑level `ui/` directory.  Command‑line
-usage via `start.py` remains available for automation.
+usage via `start.py` remains available for automation.  Theme selection is
+remembered using Tauri's store plugin with a `localStorage` fallback.
 
 ## Quick Start
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "scripts": {
     "tauri": "tauri"
   },
+  "dependencies": {
+    "@tauri-apps/plugin-store": "^2"
+  },
   "devDependencies": {
     "@tauri-apps/cli": "^1"
   }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -10,6 +10,7 @@ tempfile = "3"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+tauri-plugin-store = "0.1"
 
 [build-dependencies]
 tauri-build = { version = "1", features = [] }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -406,6 +406,7 @@ fn main() {
     }
 
     tauri::Builder::default()
+        .plugin(tauri_plugin_store::Builder::default().build())
         .manage(JobRegistry::default())
         .invoke_handler(tauri::generate_handler![
             list_presets,

--- a/ui/dnd.html
+++ b/ui/dnd.html
@@ -25,6 +25,7 @@
 </head>
 <body>
   <h1>Under Construction</h1>
+  <script src="./theme.js"></script>
   <script src="./topbar.js"></script>
 </body>
 </html>

--- a/ui/generate.html
+++ b/ui/generate.html
@@ -78,6 +78,7 @@
     <ul id="recent_list"></ul>
   </div>
 
+  <script src="./theme.js"></script>
   <script src="./topbar.js"></script>
   <script src="/ui/app.js"></script>
 </body>

--- a/ui/index.html
+++ b/ui/index.html
@@ -101,7 +101,8 @@
       <h2>ONNX Crafter</h2>
     </a>
   </main>
-  <script src="./topbar.js"></script>
+    <script src="./theme.js"></script>
+    <script src="./topbar.js"></script>
   <script src="/ui/train.js"></script>
   <script>
     fetch('/models', { headers: { 'Accept': 'application/json' } })

--- a/ui/models.html
+++ b/ui/models.html
@@ -33,7 +33,8 @@
 <body>
   <h1>Available Models</h1>
   <ul id="models"></ul>
-  <script src="./topbar.js"></script>
-  <script src="/ui/models.js"></script>
+    <script src="./theme.js"></script>
+    <script src="./topbar.js"></script>
+    <script src="/ui/models.js"></script>
 </body>
 </html>

--- a/ui/onnx.html
+++ b/ui/onnx.html
@@ -58,6 +58,7 @@
     <a id="midi_link" href="#"></a>
     <pre id="telemetry"></pre>
   </div>
+  <script src="./theme.js"></script>
   <script src="./topbar.js"></script>
   <script src="/ui/onnx.js"></script>
 </body>

--- a/ui/settings.html
+++ b/ui/settings.html
@@ -34,7 +34,8 @@
     <button id="set_dark" type="button">Use Dark Theme</button>
   </section>
   <button id="save" type="button">Save</button>
-  <script src="./topbar.js"></script>
-  <script src="/ui/settings.js"></script>
+    <script src="./theme.js"></script>
+    <script src="./topbar.js"></script>
+    <script src="/ui/settings.js"></script>
 </body>
 </html>

--- a/ui/settings.js
+++ b/ui/settings.js
@@ -3,7 +3,7 @@
 
   function load() {
     const outdir = localStorage.getItem('default_outdir') || '';
-    const theme = localStorage.getItem('theme') || 'dark';
+    const theme = (window.getTheme && window.getTheme()) || 'dark';
     const outInput = $('default_outdir');
     const themeSel = $('theme');
     if (outInput) outInput.value = outdir;

--- a/ui/theme.js
+++ b/ui/theme.js
@@ -1,0 +1,39 @@
+/**
+ * Persist the UI theme using Tauri's store plugin when available,
+ * falling back to localStorage otherwise.
+ */
+let store = null;
+let currentTheme = localStorage.getItem('theme') || 'dark';
+document.documentElement.setAttribute('data-theme', currentTheme);
+
+window.setTheme = async function(theme) {
+  currentTheme = theme;
+  document.documentElement.setAttribute('data-theme', theme);
+  if (store) {
+    await store.set('theme', theme);
+    await store.save();
+  }
+  localStorage.setItem('theme', theme);
+};
+
+window.getTheme = function() {
+  return currentTheme;
+};
+
+(async () => {
+  try {
+    const { Store } = await import('@tauri-apps/plugin-store');
+    store = new Store('.settings.dat');
+    const saved = await store.get('theme');
+    if (saved) {
+      currentTheme = saved;
+      document.documentElement.setAttribute('data-theme', saved);
+      localStorage.setItem('theme', saved);
+    } else {
+      await store.set('theme', currentTheme);
+      await store.save();
+    }
+  } catch (_) {
+    // Store plugin not available; localStorage already handles persistence.
+  }
+})();

--- a/ui/topbar.js
+++ b/ui/topbar.js
@@ -1,11 +1,5 @@
 (function() {
-  window.setTheme = function(theme) {
-    localStorage.setItem('theme', theme);
-    document.documentElement.setAttribute('data-theme', theme);
-  };
-
-  let currentTheme = localStorage.getItem('theme') || 'dark';
-  document.documentElement.setAttribute('data-theme', currentTheme);
+  let currentTheme = (window.getTheme && window.getTheme()) || 'dark';
 
   const style = document.createElement('style');
   style.textContent = `
@@ -57,9 +51,13 @@
   function updateThemeBtn() {
     themeBtn.textContent = currentTheme === 'dark' ? 'Light Mode' : 'Dark Mode';
   }
-  themeBtn.addEventListener('click', () => {
+  themeBtn.addEventListener('click', async () => {
     currentTheme = currentTheme === 'dark' ? 'light' : 'dark';
-    window.setTheme(currentTheme);
+    if (window.setTheme) {
+      await window.setTheme(currentTheme);
+    } else {
+      document.documentElement.setAttribute('data-theme', currentTheme);
+    }
     updateThemeBtn();
   });
   updateThemeBtn();

--- a/ui/train.html
+++ b/ui/train.html
@@ -41,6 +41,7 @@
   </div>
   <pre id="log"></pre>
 
+  <script src="./theme.js"></script>
   <script src="./topbar.js"></script>
   <script src="/ui/train.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- remember theme using Tauri's store plugin with localStorage fallback
- register Store plugin in Tauri backend
- document new persistence mechanism

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `cargo test` *(fails: failed to download crates index: 403)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c5247862a08325b5efec810b67b9a7