### PR TITLE
feat: centralize theme handling

### DIFF
--- a/ui/dnd.html
+++ b/ui/dnd.html
@@ -3,12 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <title>Dungeons & Dragons</title>
-  <script>
-    const savedTheme = localStorage.getItem('theme');
-    if (savedTheme) {
-      document.documentElement.dataset.theme = savedTheme;
-    }
-  </script>
+  <script type="module" src="./theme.js"></script>
   <link rel="stylesheet" href="/ui/theme.css">
   <style>
     body {
@@ -25,6 +20,6 @@
 </head>
 <body>
   <h1>Under Construction</h1>
-  <script src="./topbar.js"></script>
+  <script type="module" src="./topbar.js"></script>
 </body>
 </html>

--- a/ui/generate.html
+++ b/ui/generate.html
@@ -3,12 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <title>Blossom Render</title>
-  <script>
-    const savedTheme = localStorage.getItem('theme');
-    if (savedTheme) {
-      document.documentElement.dataset.theme = savedTheme;
-    }
-  </script>
+  <script type="module" src="./theme.js"></script>
   <link rel="stylesheet" href="/ui/theme.css">
   <style>
     body { font-family: sans-serif; margin: 1em; background: var(--bg); color: var(--fg); }
@@ -78,7 +73,7 @@
     <ul id="recent_list"></ul>
   </div>
 
-  <script src="./topbar.js"></script>
+  <script type="module" src="./topbar.js"></script>
   <script src="/ui/app.js"></script>
 </body>
 </html>

--- a/ui/index.html
+++ b/ui/index.html
@@ -3,12 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <title>Blossom Music Generator</title>
-  <script>
-    const savedTheme = localStorage.getItem('theme');
-    if (savedTheme) {
-      document.documentElement.dataset.theme = savedTheme;
-    }
-  </script>
+  <script type="module" src="./theme.js"></script>
   <link rel="stylesheet" href="/ui/theme.css">
   <style>
     body {
@@ -101,7 +96,7 @@
       <h2>ONNX Crafter</h2>
     </a>
   </main>
-  <script src="./topbar.js"></script>
+  <script type="module" src="./topbar.js"></script>
   <script src="/ui/train.js"></script>
   <script>
     fetch('/models', { headers: { 'Accept': 'application/json' } })

--- a/ui/models.html
+++ b/ui/models.html
@@ -3,12 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <title>Available Models</title>
-  <script>
-    const savedTheme = localStorage.getItem('theme');
-    if (savedTheme) {
-      document.documentElement.dataset.theme = savedTheme;
-    }
-  </script>
+  <script type="module" src="./theme.js"></script>
   <link rel="stylesheet" href="/ui/theme.css">
   <style>
     body {
@@ -33,7 +28,7 @@
 <body>
   <h1>Available Models</h1>
   <ul id="models"></ul>
-  <script src="./topbar.js"></script>
+  <script type="module" src="./topbar.js"></script>
   <script src="/ui/models.js"></script>
 </body>
 </html>

--- a/ui/onnx.html
+++ b/ui/onnx.html
@@ -3,12 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <title>ONNX Crafter</title>
-  <script>
-    const savedTheme = localStorage.getItem('theme');
-    if (savedTheme) {
-      document.documentElement.dataset.theme = savedTheme;
-    }
-  </script>
+  <script type="module" src="./theme.js"></script>
   <link rel="stylesheet" href="/ui/theme.css">
   <style>
     body { font-family: sans-serif; margin: 1em; background: var(--bg); color: var(--fg); }
@@ -63,7 +58,7 @@
     <a id="midi_link" href="#"></a>
     <pre id="telemetry"></pre>
   </div>
-  <script src="./topbar.js"></script>
+  <script type="module" src="./topbar.js"></script>
   <script src="/ui/onnx.js"></script>
 </body>
 </html>

--- a/ui/settings.html
+++ b/ui/settings.html
@@ -3,12 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <title>Settings</title>
-  <script>
-    const savedTheme = localStorage.getItem('theme');
-    if (savedTheme) {
-      document.documentElement.dataset.theme = savedTheme;
-    }
-  </script>
+  <script type="module" src="./theme.js"></script>
   <link rel="stylesheet" href="/ui/theme.css">
   <style>
     body { font-family: sans-serif; margin: 1em; background: var(--bg); color: var(--fg); }
@@ -32,7 +27,7 @@
     </label>
   </section>
   <button id="save" type="button">Save</button>
-  <script src="./topbar.js"></script>
-  <script src="/ui/settings.js"></script>
+  <script type="module" src="./topbar.js"></script>
+  <script type="module" src="./settings.js"></script>
 </body>
 </html>

--- a/ui/settings.js
+++ b/ui/settings.js
@@ -1,3 +1,5 @@
+import { setTheme } from './theme.js';
+
 (function() {
   function $(id) { return document.getElementById(id); }
 
@@ -11,7 +13,7 @@
       themeToggle.checked = theme === 'dark';
       themeToggle.addEventListener('change', () => {
         const newTheme = themeToggle.checked ? 'dark' : 'light';
-        window.setTheme(newTheme);
+        setTheme(newTheme);
       });
     }
   }

--- a/ui/theme.js
+++ b/ui/theme.js
@@ -1,0 +1,7 @@
+export function setTheme(theme) {
+  localStorage.setItem('theme', theme);
+  document.documentElement.dataset.theme = theme;
+}
+
+const savedTheme = localStorage.getItem('theme') || 'dark';
+setTheme(savedTheme);

--- a/ui/topbar.js
+++ b/ui/topbar.js
@@ -1,11 +1,8 @@
+import { setTheme } from './theme.js';
+
+window.setTheme = setTheme;
+
 (function() {
-  window.setTheme = function(theme) {
-    localStorage.setItem('theme', theme);
-    document.documentElement.setAttribute('data-theme', theme);
-  };
-
-  window.setTheme(localStorage.getItem('theme') || 'dark');
-
   const style = document.createElement('style');
   style.textContent = `
     #top-bar {

--- a/ui/train.html
+++ b/ui/train.html
@@ -3,12 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <title>Train Model</title>
-  <script>
-    const savedTheme = localStorage.getItem('theme');
-    if (savedTheme) {
-      document.documentElement.dataset.theme = savedTheme;
-    }
-  </script>
+  <script type="module" src="./theme.js"></script>
   <link rel="stylesheet" href="/ui/theme.css">
   <style>
     body {
@@ -41,7 +36,7 @@
   </div>
   <pre id="log"></pre>
 
-  <script src="./topbar.js"></script>
+  <script type="module" src="./topbar.js"></script>
   <script src="/ui/train.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add reusable `theme.js` applying saved preference
- refactor topbar and settings to import `setTheme`
- load shared theme script on all HTML pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68c525e5a0b48325a45298f6476508c4