### PR TITLE
Add prompt router with keyword heuristics

### DIFF
--- a/brain/prompt_router.py
+++ b/brain/prompt_router.py
@@ -1,0 +1,36 @@
+import re
+from typing import Callable, Literal, Optional
+
+Category = Literal["npc", "rules", "lore", "note"]
+
+_llm_classifier: Optional[Callable[[str], Optional[Category]]] = None
+
+def register_llm_classifier(func: Callable[[str], Optional[Category]]) -> None:
+    """Register a fallback LLM-based classifier."""
+    global _llm_classifier
+    _llm_classifier = func
+
+def classify(message: str) -> Category:
+    """Classify a message into one of the known categories.
+
+    The function first applies simple keyword/regex heuristics. If none of the
+    heuristics match and an LLM classifier has been registered via
+    :func:`register_llm_classifier`, it will be consulted as a fallback.
+    """
+    text = message.lower()
+
+    if re.search(r"\bnpc\b|hello|hi|hey|greet|talk to", text):
+        return "npc"
+    if re.search(r"\brules?\b|must|should|policy|guideline", text):
+        return "rules"
+    if re.search(r"\blore\b|story|background|history|world", text):
+        return "lore"
+    if re.search(r"\bnote\b|todo|to-do|remember", text):
+        return "note"
+
+    if _llm_classifier:
+        result = _llm_classifier(message)
+        if result in ("npc", "rules", "lore", "note"):
+            return result
+
+    return "note"

--- a/tests/brain/test_prompt_router.py
+++ b/tests/brain/test_prompt_router.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from brain.prompt_router import classify
+
+
+def test_classify_npc():
+    assert classify("Hello there!") == "npc"
+
+
+def test_classify_rules():
+    msg = "The rules state that all entries must be kept tidy."
+    assert classify(msg) == "rules"
+
+
+def test_classify_lore():
+    msg = "Ancient lore tells of the hero's journey."
+    assert classify(msg) == "lore"
+
+
+def test_classify_note():
+    assert classify("Note to self: buy milk.") == "note"


### PR DESCRIPTION
## Summary
- add prompt_router with keyword-based classify and optional LLM hook
- add unit tests for routing examples

## Testing
- `pytest tests/brain/test_prompt_router.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c526f06e34832595b782d1745470de