### PR TITLE
feat: persist theme with Tauri store

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ A desktop interface built with [Tauri](https://tauri.app/) provides the front‑
 Templates and scripts live under the top‑level `ui/` directory.  Command‑line
 usage via `start.py` remains available for automation.
 
+Theme preference is persisted using Tauri's [store plugin](https://github.com/tauri-apps/plugins-workspace/),
+falling back to `localStorage` when the plugin is not available.
+
 ## Quick Start
 
 1. Create a virtual environment and install the Python dependencies:

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,9 @@
   "packages": {
     "": {
       "name": "blossom-music-gen",
+      "dependencies": {
+        "@tauri-apps/plugin-store": "^2"
+      },
       "devDependencies": {
         "@tauri-apps/cli": "^1"
       }
@@ -211,6 +214,12 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tauri-apps/plugin-store": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-store/-/plugin-store-2.0.0.tgz",
+      "integrity": "",
+      "license": "Apache-2.0 OR MIT"
+    },
     "node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -223,6 +232,11 @@
       "engines": {
         "node": ">=10"
       }
+    }
+  },
+  "dependencies": {
+    "@tauri-apps/plugin-store": {
+      "version": "^2"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "scripts": {
     "tauri": "tauri"
   },
+  "dependencies": {
+    "@tauri-apps/plugin-store": "^2"
+  },
   "devDependencies": {
     "@tauri-apps/cli": "^1"
   }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -10,6 +10,7 @@ tempfile = "3"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+tauri-plugin-store = "2"
 
 [build-dependencies]
 tauri-build = { version = "1", features = [] }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -16,6 +16,7 @@ use std::{
 use regex::Regex;
 use tauri::Manager;
 use tauri::{AppHandle, State};
+use tauri_plugin_store::PluginBuilder;
 use serde_json::{json, Value};
 mod musiclang;
 mod util;
@@ -411,6 +412,7 @@ fn main() {
     }
 
     tauri::Builder::default()
+        .plugin(PluginBuilder::default().build())
         .manage(JobRegistry::default())
         .invoke_handler(tauri::generate_handler![
             list_presets,

--- a/ui/settings.js
+++ b/ui/settings.js
@@ -1,11 +1,11 @@
-import { setTheme } from './theme.js';
+import { setTheme, getTheme } from './theme.js';
 
 (function() {
   function $(id) { return document.getElementById(id); }
 
-  function load() {
+  async function load() {
     const outdir = localStorage.getItem('default_outdir') || '';
-    const theme = localStorage.getItem('theme') || 'dark';
+    const theme = (await getTheme()) || 'dark';
     const outInput = $('default_outdir');
     const themeToggle = $('theme_toggle');
     if (outInput) outInput.value = outdir;

--- a/ui/theme.js
+++ b/ui/theme.js
@@ -1,7 +1,38 @@
-export function setTheme(theme) {
-  localStorage.setItem('theme', theme);
+// Persist the UI theme using Tauri's store plugin when available.
+// Falls back to `localStorage` when the plugin cannot be loaded
+// (e.g. when running purely in a browser context).
+import { Store } from '@tauri-apps/plugin-store';
+
+const THEME_KEY = 'theme';
+let store;
+try {
+  store = new Store('settings.dat');
+} catch (_) {
+  store = null;
+}
+
+export async function setTheme(theme) {
+  if (store) {
+    try {
+      await store.set(THEME_KEY, theme);
+      await store.save();
+    } catch (_) {
+      localStorage.setItem(THEME_KEY, theme);
+    }
+  } else {
+    localStorage.setItem(THEME_KEY, theme);
+  }
   document.documentElement.dataset.theme = theme;
 }
 
-const savedTheme = localStorage.getItem('theme') || 'dark';
-setTheme(savedTheme);
+export async function getTheme() {
+  if (store) {
+    try {
+      const theme = await store.get(THEME_KEY);
+      if (theme) return theme;
+    } catch (_) {}
+  }
+  return localStorage.getItem(THEME_KEY);
+}
+
+getTheme().then((savedTheme) => setTheme(savedTheme || 'dark'));


### PR DESCRIPTION
## Summary
- integrate `tauri-plugin-store` for persisting settings
- store and retrieve theme preference via Tauri store with localStorage fallback
- document new persistence mechanism

## Testing
- `npm test` *(fails: Missing script "test")*
- `cargo check` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68c52781878c8325822fa6d52d0aed1a