### PR TITLE
Add dialogue context injection with search integration

### DIFF
--- a/brain/dialogue.py
+++ b/brain/dialogue.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+"""Dialogue helpers with context injection from Obsidian notes."""
+
+from typing import List
+
+import service_api
+from . import prompt_router, ollama_client
+
+
+def _summarize(content: str) -> str:
+    """Return the first paragraph or bullet list from ``content``."""
+    content = content.strip()
+    if not content:
+        return ""
+    blocks = [block for block in content.split("\n\n") if block.strip()]
+    if not blocks:
+        return ""
+    first = blocks[0].strip()
+    lines = [ln.strip() for ln in first.splitlines() if ln.strip()]
+    if not lines:
+        return ""
+    if all(ln.startswith("-") for ln in lines):
+        # Return up to the first three bullet lines
+        return "\n".join(lines[:3])
+    return lines[0]
+
+
+def respond(message: str) -> str:
+    """Generate a response for ``message`` via Ollama.
+
+    If the message is classified as ``"lore"`` or ``"npc"``, relevant note
+    summaries are searched and prepended to the prompt. When no matching notes
+    are found the original message is used unchanged.
+    """
+
+    category = prompt_router.classify(message)
+    summaries: List[str] = []
+    if category in ("lore", "npc"):
+        results = service_api.search(message, tags=[category])
+        for res in results:
+            summary = _summarize(res.get("content", ""))
+            if summary:
+                summaries.append(summary)
+
+    prompt = message
+    if summaries:
+        notes = "\n".join(
+            s if s.startswith("-") else f"- {s}" for s in summaries
+        )
+        prompt = f"{message}\n\nRelevant notes:\n{notes}\n"
+
+    return ollama_client.generate(prompt)

--- a/tests/brain/test_dialogue.py
+++ b/tests/brain/test_dialogue.py
@@ -1,0 +1,147 @@
+from pathlib import Path
+import sys
+import sqlite3
+import numpy as np
+import faiss
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import service_api
+from brain import dialogue, ollama_client
+import notes.search as search_mod
+
+
+def _fake_embed(texts, model_name=None):
+    vecs = []
+    for text in texts:
+        t = text.lower()
+        if "dragon" in t:
+            vecs.append([1.0, 0.0])
+        elif "king" in t:
+            vecs.append([0.0, 1.0])
+        else:
+            vecs.append([0.0, 0.0])
+    return np.asarray(vecs, dtype="float32")
+
+
+def _build_vault(root: Path, chunks):
+    db_path = root / "chunks.sqlite"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE chunks (id TEXT PRIMARY KEY, path TEXT, heading TEXT, content TEXT, vector_id INTEGER)"
+    )
+    conn.execute("CREATE TABLE tags (chunk_id TEXT, tag TEXT)")
+    for ch in chunks:
+        conn.execute(
+            "INSERT INTO chunks VALUES (?, ?, ?, ?, ?)",
+            (ch["id"], ch["path"], ch["heading"], ch["content"], ch["vector_id"]),
+        )
+        for tag in ch["tags"]:
+            conn.execute(
+                "INSERT INTO tags VALUES (?, ?)", (ch["id"], tag)
+            )
+    conn.commit()
+    conn.close()
+
+    vectors = np.vstack([c["vector"] for c in chunks]).astype("float32")
+    index = faiss.IndexIDMap(faiss.IndexFlatL2(vectors.shape[1]))
+    ids = np.array([c["vector_id"] for c in chunks], dtype="int64")
+    index.add_with_ids(vectors, ids)
+    faiss.write_index(index, str(root / "obsidian_index.faiss"))
+
+
+def _patch_common(monkeypatch, vault):
+    monkeypatch.setattr(service_api, "get_vault", lambda: vault)
+    monkeypatch.setattr(dialogue.service_api, "get_vault", lambda: vault)
+    monkeypatch.setattr(search_mod, "embed_texts", _fake_embed)
+    captured = {}
+
+    def fake_generate(prompt: str) -> str:
+        captured["prompt"] = prompt
+        return prompt
+
+    monkeypatch.setattr(ollama_client, "generate", fake_generate)
+    monkeypatch.setattr(dialogue.ollama_client, "generate", fake_generate)
+    return captured
+
+
+def test_lore_injection(tmp_path, monkeypatch):
+    chunks = [
+        {
+            "id": "c1",
+            "path": "lore/dragons.md",
+            "heading": "Dragons",
+            "content": "Dragons are ancient creatures.\nThey rule the sky.",
+            "vector_id": 0,
+            "tags": ["lore"],
+            "vector": np.array([1.0, 0.0], dtype="float32"),
+        },
+        {
+            "id": "c2",
+            "path": "npcs/king.md",
+            "heading": "King",
+            "content": "- King Arthur\n- Ruler of Camelot\n- Brave and wise",
+            "vector_id": 1,
+            "tags": ["npc"],
+            "vector": np.array([0.0, 1.0], dtype="float32"),
+        },
+    ]
+    _build_vault(tmp_path, chunks)
+    captured = _patch_common(monkeypatch, tmp_path)
+
+    out = dialogue.respond("Tell me some lore about dragons")
+    assert "Relevant notes:" in out
+    assert "- Dragons are ancient creatures." in out
+    assert captured["prompt"] == out
+
+
+def test_npc_injection(tmp_path, monkeypatch):
+    chunks = [
+        {
+            "id": "c1",
+            "path": "lore/dragons.md",
+            "heading": "Dragons",
+            "content": "Dragons are ancient creatures.\nThey rule the sky.",
+            "vector_id": 0,
+            "tags": ["lore"],
+            "vector": np.array([1.0, 0.0], dtype="float32"),
+        },
+        {
+            "id": "c2",
+            "path": "npcs/king.md",
+            "heading": "King",
+            "content": "- King Arthur\n- Ruler of Camelot\n- Brave and wise",
+            "vector_id": 1,
+            "tags": ["npc"],
+            "vector": np.array([0.0, 1.0], dtype="float32"),
+        },
+    ]
+    _build_vault(tmp_path, chunks)
+    captured = _patch_common(monkeypatch, tmp_path)
+
+    out = dialogue.respond("Hello, what do I know about the king?")
+    assert "Relevant notes:" in out
+    assert "- King Arthur" in out
+    assert captured["prompt"] == out
+
+
+def test_no_notes_fallback(tmp_path, monkeypatch):
+    chunks = [
+        {
+            "id": "c2",
+            "path": "npcs/king.md",
+            "heading": "King",
+            "content": "- King Arthur\n- Ruler of Camelot\n- Brave and wise",
+            "vector_id": 0,
+            "tags": ["npc"],
+            "vector": np.array([0.0, 1.0], dtype="float32"),
+        }
+    ]
+    _build_vault(tmp_path, chunks)
+    captured = _patch_common(monkeypatch, tmp_path)
+
+    msg = "Tell me some lore about dragons"
+    out = dialogue.respond(msg)
+    assert out == msg
+    assert captured["prompt"] == msg


### PR DESCRIPTION
## Summary
- add dialogue module that classifies queries and searches Obsidian notes for lore or NPC context
- summarize matching note snippets and inject them into prompts for Ollama
- include integration tests building a temporary SQLite/FAISS index

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy faiss-cpu -q` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68c527ae50e88325af068866e791876f