### PR TITLE
Show loading state while searching ONNX models

### DIFF
--- a/ui/onnx.html
+++ b/ui/onnx.html
@@ -9,6 +9,32 @@
     body { font-family: sans-serif; margin: 1em; background: var(--bg); color: var(--fg); }
     label { display: block; margin-bottom: 0.5em; }
     #log { background: var(--log-bg); color: var(--log-fg); padding: 0.5em; height: 200px; overflow-y: auto; }
+    #loading-overlay {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0, 0, 0, 0.6);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      z-index: 1000;
+      color: var(--fg);
+    }
+    #loading-overlay .spinner {
+      border: 4px solid var(--fg);
+      border-top: 4px solid transparent;
+      border-radius: 50%;
+      width: 40px;
+      height: 40px;
+      animation: spin 1s linear infinite;
+      margin-bottom: 1em;
+    }
+    @keyframes spin {
+      to { transform: rotate(360deg); }
+    }
   </style>
 </head>
 <body>
@@ -57,6 +83,10 @@
     <h3>Result</h3>
     <a id="midi_link" href="#"></a>
     <pre id="telemetry"></pre>
+  </div>
+  <div id="loading-overlay" hidden>
+    <div class="spinner" aria-hidden="true"></div>
+    <p>ONNX is loading, searching for MusicLang models…</p>
   </div>
   <script type="module" src="./topbar.js"></script>
   <script src="/ui/onnx.js"></script>

--- a/ui/onnx.js
+++ b/ui/onnx.js
@@ -101,6 +101,14 @@ async function tauriOnnxMain(){
   async function populateModels(){
     modelBanner.hidden = true;
     modelBanner.textContent = '';
+    const loadingOverlay = document.getElementById('loading-overlay');
+    const loadingMsg = 'ONNX is loading, searching for MusicLang models…';
+    if (loadingOverlay) loadingOverlay.hidden = false;
+    if (dialog && typeof dialog.message === 'function') {
+      dialog.message(loadingMsg);
+    } else if (typeof window !== 'undefined' && typeof window.alert === 'function') {
+      window.alert(loadingMsg);
+    }
     try {
       const models = await invoke('list_musiclang_models');
       modelSelect.innerHTML = '';
@@ -149,6 +157,8 @@ async function tauriOnnxMain(){
       modelBanner.textContent = `${msg}. Install models in the models folder or retry.`;
       modelBanner.hidden = false;
       if (typeof alert === 'function') alert(`${msg}. Install models in the models folder or retry.`);
+    } finally {
+      if (loadingOverlay) loadingOverlay.hidden = true;
     }
   }
 


### PR DESCRIPTION
## Summary
- add a loading overlay and spinner to the ONNX page
- show a message before listing MusicLang models and hide the overlay when finished

## Testing
- `pytest tests/test_utils.py::test_ensure_file_rejects_directory -q` *(fails: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68c5283ca444832597f3c1ba238bb3bb