### PR TITLE
docs: add LLM orchestrator guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,3 +417,7 @@ during startup warms the cache and eliminates initial latency.
 See ``docs/examples/discord_piper_tts.py`` for an end-to-end snippet that
 joins a voice channel and speaks a line of dialog.
 
+
+## LLM Orchestrator
+
+Orchestrate local LLM responses with context pulled from an Obsidian vault. See [docs/orchestrator.md](docs/orchestrator.md) for setup and usage details.

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -1,0 +1,76 @@
+# LLM Orchestrator
+
+Coordinate local large language model responses with context drawn from Obsidian notes.
+
+## Setup
+
+1. **Install and run Ollama**
+
+   ```bash
+   curl -fsSL https://ollama.ai/install.sh | sh
+   ollama run mistral  # downloads the model and starts the server
+   ```
+
+2. **Select an Obsidian vault**
+
+   ```bash
+   python - <<'PY'
+   from pathlib import Path
+   from config.obsidian import select_vault
+
+   select_vault(Path('~/Obsidian/MyCampaign'))
+   PY
+   ```
+
+   The path is stored in `config/obsidian_vault.txt` and reused on subsequent runs.
+
+## Command-line usage
+
+Send a message to the orchestrator via the `dialogue.respond` helper:
+
+```bash
+python - <<'PY'
+from brain import dialogue
+
+print(dialogue.respond("Hello there!"))
+PY
+```
+
+### NPC dialogue
+
+```python
+from brain import dialogue
+
+reply = dialogue.respond("Hello, what do I know about the king?")
+print(reply)
+```
+
+### Rules Q&A
+
+```python
+from brain import dialogue
+
+reply = dialogue.respond("What are the house rules for resting?")
+print(reply)
+```
+
+## JSON schema
+
+Requests and responses can be represented with the following fields:
+
+```json
+{
+  "message": "User's input text",
+  "response": "Model output",
+  "notes": [
+    {
+      "path": "npcs/king.md",
+      "heading": "King",
+      "content": "- King Arthur\n- Ruler of Camelot",
+      "score": 0.12
+    }
+  ]
+}
+```
+
+`notes` lists any matching note summaries injected into the prompt. Each entry records the source `path`, the note `heading`, the extracted `content` and the search `score`.


### PR DESCRIPTION
## Summary
- document setup and usage of the local LLM orchestrator
- link orchestrator guide from the README

## Testing
- `python -m pip install -r requirements.txt` *(fails: HTTP 403 cloning dependency)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68c528df5a808325902f91109daaf6f7