### PR TITLE
feat: add brain orchestrator

### DIFF
--- a/brain/orchestrator.py
+++ b/brain/orchestrator.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+"""High level message orchestrator.
+
+The :func:`respond` function routes incoming user messages either to the
+conversation path handled by :mod:`brain.dialogue` or to a simple
+note‑taking path.  The decision is based on
+:func:`brain.prompt_router.classify`.
+
+A tiny :class:`Event` typed dictionary is exposed to provide a consistent
+structure for consumers of the orchestrator.  Two event types are emitted:
+``"dialogue"`` for regular assistant responses and ``"note"`` when the user
+wants to take a note.
+"""
+
+from typing import Literal, TypedDict
+
+from . import dialogue, prompt_router, ollama_client
+
+
+class Event(TypedDict):
+    """Small container describing an orchestrator outcome."""
+
+    type: Literal["dialogue", "note"]
+    content: str
+
+
+def _take_note(message: str) -> str:
+    """Return a short acknowledgement for ``message``.
+
+    The current implementation simply runs the text through the
+    :mod:`brain.ollama_client` to potentially clean up or summarize the
+    note.  Future versions could persist the note to an external store.
+    """
+
+    prompt = f"Summarise the following note succinctly:\n{message}\n"
+    return ollama_client.generate(prompt)
+
+
+def respond(user_message: str) -> Event:
+    """Return an :class:`Event` for ``user_message``."""
+
+    category = prompt_router.classify(user_message)
+    if category == "note":
+        text = _take_note(user_message)
+        return {"type": "note", "content": text}
+
+    text = dialogue.respond(user_message)
+    return {"type": "dialogue", "content": text}
+
+
+def main() -> None:
+    """Simple REPL for manual testing."""
+
+    while True:
+        try:
+            msg = input("You: ")
+        except EOFError:
+            break
+        if not msg:
+            break
+        event = respond(msg)
+        prefix = "Bot" if event["type"] == "dialogue" else "Note"
+        print(f"{prefix}: {event['content']}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual testing helper
+    main()

--- a/tests/brain/test_orchestrator.py
+++ b/tests/brain/test_orchestrator.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+import sys
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+# Provide lightweight stubs to avoid heavy dependencies during import.
+fake_service_api = types.SimpleNamespace(search=lambda q, tags=None: [])
+sys.modules.setdefault("service_api", fake_service_api)
+
+fake_requests = types.SimpleNamespace(post=lambda *a, **k: None)
+class _Resp:  # minimal placeholder for requests.Response
+    pass
+fake_requests.Response = _Resp
+fake_requests.exceptions = types.SimpleNamespace(
+    HTTPError=Exception, RequestException=Exception, Timeout=Exception
+)
+sys.modules.setdefault("requests", fake_requests)
+sys.modules.setdefault("requests.exceptions", fake_requests.exceptions)
+
+from brain import orchestrator, dialogue, ollama_client
+
+
+def _patch_ollama(monkeypatch):
+    captured = {}
+
+    def fake_generate(prompt: str) -> str:
+        captured["prompt"] = prompt
+        return f"LLM:{prompt}"
+
+    monkeypatch.setattr(ollama_client, "generate", fake_generate)
+    monkeypatch.setattr(dialogue.ollama_client, "generate", fake_generate)
+    monkeypatch.setattr(orchestrator.ollama_client, "generate", fake_generate)
+    return captured
+
+
+def test_dialogue_flow(monkeypatch):
+    captured = _patch_ollama(monkeypatch)
+    event = orchestrator.respond("Hello there")
+    assert event["type"] == "dialogue"
+    assert event["content"] == f"LLM:{captured['prompt']}"
+    assert captured["prompt"] == "Hello there"
+
+
+def test_note_flow(monkeypatch):
+    captured = _patch_ollama(monkeypatch)
+    event = orchestrator.respond("Note to self: buy milk")
+    assert event["type"] == "note"
+    assert event["content"] == f"LLM:{captured['prompt']}"
+    assert "buy milk" in captured["prompt"]


### PR DESCRIPTION
## Summary
- introduce `brain.orchestrator` to route messages for dialogue or notes
- add simple CLI for manual testing via `python -m brain.orchestrator`
- cover orchestrator behaviour with high-level tests using mocked LLM responses

## Testing
- `pytest tests/brain/test_orchestrator.py tests/brain/test_prompt_router.py`
- `pip install numpy requests` *(fails: Could not find a version that satisfies the requirement numpy)*
- `pytest` *(fails: 25 errors during collection: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68c528dea7f88325a1117c4f871cf285