### PR TITLE
Parse Ollama JSON into Event dataclass

### DIFF
--- a/brain/events.py
+++ b/brain/events.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+"""Event dataclasses used for structured dialogue responses."""
+
+from dataclasses import dataclass, field, asdict
+from typing import List
+import json
+
+
+@dataclass
+class Event:
+    """Structured description of a dialogue event."""
+
+    who: str
+    action: str
+    targets: List[str] = field(default_factory=list)
+    effects: List[str] = field(default_factory=list)
+    narration: str = ""
+
+    @classmethod
+    def from_json(cls, data: str) -> "Event":
+        """Parse *data* and return an :class:`Event` instance.
+
+        Raises :class:`ValueError` if ``data`` is not valid JSON or missing
+        required fields.
+        """
+
+        try:
+            payload = json.loads(data)
+        except json.JSONDecodeError as exc:
+            raise ValueError("Malformed JSON") from exc
+
+        try:
+            return cls(
+                who=payload["who"],
+                action=payload["action"],
+                targets=list(payload.get("targets", [])),
+                effects=list(payload.get("effects", [])),
+                narration=payload.get("narration", ""),
+            )
+        except KeyError as exc:
+            raise ValueError(f"Missing field: {exc.args[0]}") from exc
+
+    def to_json(self) -> str:
+        """Serialize the event to a JSON string."""
+
+        return json.dumps(asdict(self))


### PR DESCRIPTION
## Summary
- add `Event` dataclass for structured dialogue events
- request JSON from Ollama and parse into `Event`
- test JSON parsing and malformed responses

## Testing
- `PYTHONPATH=$PWD pytest tests/brain/test_dialogue.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c528cedc0c8325b1d6b184340fbbb1