### PR TITLE
chore: start tracking Cargo.lock for tauri project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 src-tauri/target
-src-tauri/Cargo.lock

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1,0 +1,1 @@
+# Placeholder Cargo.lock. Run `cargo generate-lockfile` when network is available.


### PR DESCRIPTION
## Summary
- remove `src-tauri/Cargo.lock` from gitignore
- add placeholder `Cargo.lock` file in `src-tauri`

## Testing
- `cargo generate-lockfile` *(failed: Failed to download from crates.io (403/connection))*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68c529f7c4288325b6e2abd879f80411