### PR TITLE
Add optional runtime and MIDI dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,7 @@ SFZ instruments may reference WAV or FLAC samples. Loading FLAC samples requires
 pip install soundfile
 ```
 
-For enhanced MIDI import and export support, install the optional
-[mido](https://mido.readthedocs.io/) library:
-
-```bash
-pip install mido
-```
+The default requirements also bundle [mido](https://mido.readthedocs.io/) for enhanced MIDI import and export, along with `torch` and `onnxruntime` to support phrase model training and ONNX inference.
 
 To enable optional speaker diarization via
 [pyannote.audio](https://github.com/pyannote/pyannote-audio), install the
@@ -120,8 +115,7 @@ models are present.
 
 ### Training prerequisites and dataset
 
-Training requires [PyTorch](https://pytorch.org/) and, for ONNX export,
-`onnxruntime`.  Datasets consist of token sequences stored in `train.jsonl` and
+Training requires [PyTorch](https://pytorch.org/) and, for ONNX export, `onnxruntime`, both of which are included in `requirements.txt`.  Datasets consist of token sequences stored in `train.jsonl` and
 `val.jsonl` which can be created with `data/build_dataset.py` (see
 [`docs/datasets.md`](docs/datasets.md)).  Running
 

--- a/docs/phrase_models.md
+++ b/docs/phrase_models.md
@@ -6,8 +6,7 @@ either TorchScript (`.ts.pt`) or ONNX (`.onnx`) files.
 
 ## Training prerequisites and dataset
 
-Training depends on [PyTorch](https://pytorch.org/) and, for ONNX export,
-`onnxruntime`.  The models consume token sequences stored in `train.jsonl` and
+Training depends on [PyTorch](https://pytorch.org/) and, for ONNX export, `onnxruntime`; both are included in `requirements.txt`.  The models consume token sequences stored in `train.jsonl` and
 `val.jsonl`.  These files can be produced from rendered stems or MIDI data via
 `data/build_dataset.py` (see [datasets.md](datasets.md)).
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,8 @@ watchfiles
 piper-tts
 
 discord.py[voice] @ git+https://github.com/jg-l/discord.py
+
+# Optional: phrase models and MIDI support
+torch
+onnxruntime
+mido


### PR DESCRIPTION
## Summary
- append torch, onnxruntime, and mido to requirements with optional group
- document default inclusion of these packages in README and phrase model docs

## Testing
- `pip install torch onnxruntime mido` *(fails: Could not find a version that satisfies the requirement torch; 403 Forbidden)*
- `PYTHONDONTWRITEBYTECODE=1 pytest` *(fails: 16 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c52b0e87888325ba20e2b295c17e96