### PR TITLE
chore: drop jinja2 and python-frontmatter dependencies

### DIFF
--- a/frontmatter.py
+++ b/frontmatter.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 """Minimal frontmatter parser used for tests.
 
-This provides a tiny subset of the :mod:`python-frontmatter` package.  It only
-implements :func:`load` and the :class:`Post` dataclass, which are sufficient
-for the unit tests in this repository.
+Implements a small subset of functionality with :func:`load` and the
+:class:`Post` dataclass, which are sufficient for the unit tests in this
+repository.
 """
 
 from dataclasses import dataclass

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,6 @@ faster-whisper
 pytest
 requests
 
-jinja2
-python-frontmatter
 faiss-cpu
 sentence-transformers
 watchfiles


### PR DESCRIPTION
## Summary
- remove unused jinja2 and python-frontmatter packages
- clean frontmatter parser docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy scipy soundfile -q` *(fails: Could not find a version that satisfies the requirement numpy (from versions: none))*

------
https://chatgpt.com/codex/tasks/task_e_68c52c46472c8325b58fb75b114bca0e