### PR TITLE
Add structured Event dataclass and JSON dialogue handling

### DIFF
--- a/brain/events.py
+++ b/brain/events.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+"""Data models for narrative events used by :mod:`brain.dialogue`."""
+
+from dataclasses import dataclass, field, asdict
+from typing import List
+import json
+
+
+@dataclass
+class Event:
+    """Structured representation of a narrative event.
+
+    Attributes
+    ----------
+    who:
+        The actor performing the action.
+    action:
+        Description of the action being taken.
+    targets:
+        Entities that are the targets of the action.
+    effects:
+        Consequences that result from the action.
+    narration:
+        Natural language description of the event.
+    """
+
+    who: str
+    action: str
+    targets: List[str] = field(default_factory=list)
+    effects: List[str] = field(default_factory=list)
+    narration: str = ""
+
+    @classmethod
+    def from_json(cls, data: str | dict) -> "Event":
+        """Create an :class:`Event` from a JSON string or dictionary.
+
+        Raises
+        ------
+        ValueError
+            If the JSON is malformed or missing required fields.
+        """
+
+        if isinstance(data, str):
+            try:
+                payload = json.loads(data)
+            except json.JSONDecodeError as exc:  # pragma: no cover - error path
+                raise ValueError("Invalid JSON") from exc
+        else:
+            payload = data
+        try:
+            return cls(
+                who=payload["who"],
+                action=payload["action"],
+                targets=list(payload.get("targets", [])),
+                effects=list(payload.get("effects", [])),
+                narration=payload.get("narration", ""),
+            )
+        except KeyError as exc:  # pragma: no cover - error path
+            raise ValueError(f"Missing field: {exc.args[0]}") from exc
+        except TypeError as exc:  # pragma: no cover - error path
+            raise ValueError("Invalid event fields") from exc
+
+    def to_json(self) -> str:
+        """Return a JSON representation of the event."""
+
+        return json.dumps(asdict(self))

--- a/brain/orchestrator.py
+++ b/brain/orchestrator.py
@@ -45,8 +45,8 @@ def respond(user_message: str) -> Event:
         text = _take_note(user_message)
         return {"type": "note", "content": text}
 
-    text = dialogue.respond(user_message)
-    return {"type": "dialogue", "content": text}
+    event = dialogue.respond(user_message)
+    return {"type": "dialogue", "content": event.narration}
 
 
 def main() -> None:

--- a/tests/brain/test_events_json.py
+++ b/tests/brain/test_events_json.py
@@ -1,0 +1,62 @@
+import json
+from pathlib import Path
+import sys
+import pytest
+import json
+import types
+
+sys.modules.setdefault(
+    "numpy",
+    types.SimpleNamespace(
+        asarray=lambda *a, **k: [],
+        array=lambda *a, **k: [],
+        vstack=lambda xs: xs,
+        arange=lambda n: list(range(n)),
+    ),
+)
+
+sys.modules.setdefault(
+    "watchfiles",
+    types.SimpleNamespace(Change=object, watch=lambda *a, **k: None),
+)
+
+requests_stub = types.SimpleNamespace(post=lambda *a, **k: None)
+requests_stub.Response = type("Response", (), {})
+requests_stub.exceptions = types.SimpleNamespace(
+    HTTPError=Exception, RequestException=Exception, Timeout=Exception
+)
+sys.modules.setdefault("requests", requests_stub)
+sys.modules.setdefault("requests.exceptions", requests_stub.exceptions)
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from brain import dialogue
+
+
+def _setup(monkeypatch, response: str):
+    monkeypatch.setattr(dialogue.prompt_router, "classify", lambda _: "other")
+    monkeypatch.setattr(dialogue.ollama_client, "generate", lambda _: response)
+
+
+def test_parses_valid_json(monkeypatch):
+    payload = {
+        "who": "hero",
+        "action": "attack",
+        "targets": ["dragon"],
+        "effects": ["fire"],
+        "narration": "The hero breathes fire on the dragon.",
+    }
+    _setup(monkeypatch, json.dumps(payload))
+    event = dialogue.respond("Attack the dragon")
+    assert event.who == "hero"
+    assert event.action == "attack"
+    assert event.targets == ["dragon"]
+    assert event.effects == ["fire"]
+    assert event.narration.startswith("The hero")
+    assert json.loads(event.to_json()) == payload
+
+
+def test_invalid_json_raises(monkeypatch):
+    _setup(monkeypatch, "not-json")
+    with pytest.raises(ValueError):
+        dialogue.respond("Attack the dragon")


### PR DESCRIPTION
## Summary
- introduce `Event` dataclass to capture who/action/targets/effects/narration
- parse LLM responses as JSON into `Event` and serialize with `to_json`
- adapt orchestrator and dialogue tests for structured events and add JSON parsing tests

## Testing
- `pytest tests/brain/test_dialogue.py`
- `pytest tests/brain/test_orchestrator.py`
- `pytest tests/test_dialogue_note.py`
- `pytest tests/brain/test_events_json.py`


------
https://chatgpt.com/codex/tasks/task_e_68c52b401fd08325b08a73c96e99cb09