### PR TITLE
Specify futures-sink version for Tauri

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,6 +11,7 @@ serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 tauri-plugin-store = "2"
+futures-sink = "0.3.31"
 
 [build-dependencies]
 tauri-build = { version = "1", features = [] }


### PR DESCRIPTION
## Summary
- add explicit `futures-sink` v0.3.31 dependency for Tauri backend

## Testing
- `cargo update` *(fails: failed to download config.json; CONNECT tunnel failed with 403)*
- `npm run tauri dev` *(fails: failed to download config.json; CONNECT tunnel failed with 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c52e9bf1e48325a45843526b91496e