### PR TITLE
Add Discord command permission configuration

### DIFF
--- a/config/discord.py
+++ b/config/discord.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+"""Load and cache Discord command permission rules."""
+
+from pathlib import Path
+from typing import Dict, List
+
+__all__ = ["get_permission_rules"]
+
+# Location of the permission configuration file.
+PERMISSIONS_FILE = Path(__file__).with_name("discord.yaml")
+
+# Internal cache of loaded permission rules.
+_RULE_CACHE: Dict[str, Dict[str, List[int]]] | None = None
+
+
+def _parse_list(value: str) -> List[int]:
+    """Parse a ``[1, 2, 3]`` style list into integers."""
+    if not value.startswith("[") or not value.endswith("]"):
+        raise ValueError("Expected list in square brackets")
+    items = [v.strip() for v in value[1:-1].split(",") if v.strip()]
+    return [int(v) for v in items]
+
+
+def _load_file() -> Dict[str, Dict[str, List[int]]]:
+    text = PERMISSIONS_FILE.read_text(encoding="utf-8")
+    result: Dict[str, Dict[str, List[int]]] = {}
+    current: Dict[str, List[int]] | None = None
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip()
+        if not line or line.lstrip().startswith("#"):
+            continue
+        if not line.startswith(" ") and line.endswith(":"):
+            key = line[:-1].strip()
+            current = result.setdefault(key, {"channels": [], "roles": []})
+        elif line.startswith(" ") and current is not None:
+            stripped = line.strip()
+            if ":" not in stripped:
+                raise ValueError(f"Malformed line: {line}")
+            subkey, value = [s.strip() for s in stripped.split(":", 1)]
+            if subkey not in ("channels", "roles"):
+                raise ValueError(f"Unknown key '{subkey}' in permissions file")
+            current[subkey] = _parse_list(value)
+        else:
+            raise ValueError(f"Malformed line: {line}")
+    return result
+
+
+def get_permission_rules() -> Dict[str, Dict[str, List[int]]]:
+    """Return cached command permission rules."""
+    global _RULE_CACHE
+    if _RULE_CACHE is None:
+        if PERMISSIONS_FILE.exists():
+            _RULE_CACHE = _load_file()
+        else:
+            _RULE_CACHE = {}
+    return _RULE_CACHE

--- a/config/discord.yaml
+++ b/config/discord.yaml
@@ -1,0 +1,23 @@
+# Command permission configuration
+# Each command lists allowed channel IDs and role IDs.
+# Empty lists mean no restrictions.
+
+npc:
+  channels: [1000]
+  roles: [2000]
+
+lore:
+  channels: [1000]
+  roles: []
+
+note:
+  channels: [1000]
+  roles: [2000]
+
+track:
+  channels: []
+  roles: [3000]
+
+"scene as":
+  channels: [4000]
+  roles: [5000]

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -1,0 +1,31 @@
+# Discord Configuration
+
+The Discord bot reads command permission rules from `config/discord.yaml` on startup.
+Each top-level key in the file is the name of a slash command (use the full
+`group subcommand` name for grouped commands).  Every command maps to two lists:
+
+- `channels` – channel IDs where the command is allowed.  If omitted or empty,
+  the command may be used in any channel.
+- `roles` – role IDs permitted to invoke the command.  If omitted or empty,
+  any member may use the command regardless of role.
+
+Example configuration:
+
+```yaml
+npc:
+  channels: [1234567890]
+  roles: [111111]
+
+lore:
+  channels: [1234567890]
+  roles: []
+
+"scene as":
+  channels: [222222]
+  roles: [333333]
+```
+
+In the example above `npc` can only run in channel `1234567890` by members with
+role `111111`.  The `lore` command is restricted to the same channel but has no
+role requirement.  Grouped commands such as `scene as` use their qualified
+command name as the key.

--- a/tests/test_discord_permissions.py
+++ b/tests/test_discord_permissions.py
@@ -1,0 +1,59 @@
+import os
+import sys
+from unittest.mock import MagicMock, AsyncMock
+
+import pytest
+
+# Skip tests if discord.py is not installed
+pytest.importorskip("discord")
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from discord_bot import BlossomBot
+import config.discord as discord_config
+
+
+def _write_config(path):
+    path.write_text(
+        """npc:\n  channels: [1]\n  roles: [2]\n""",
+        encoding="utf-8",
+    )
+
+
+def _make_interaction(cmd_name, channel_id=1, role_ids=None):
+    interaction = MagicMock()
+    interaction.command = MagicMock()
+    interaction.command.qualified_name = cmd_name
+    interaction.channel = MagicMock(id=channel_id)
+    interaction.user = MagicMock()
+    interaction.user.roles = [MagicMock(id=r) for r in (role_ids or [])]
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    return interaction
+
+
+def test_load_permissions(tmp_path):
+    cfg = tmp_path / "discord.yaml"
+    _write_config(cfg)
+    discord_config.PERMISSIONS_FILE = cfg
+    discord_config._RULE_CACHE = None
+    rules = discord_config.get_permission_rules()
+    assert rules == {"npc": {"channels": [1], "roles": [2]}}
+
+
+@pytest.mark.asyncio
+async def test_permission_check(tmp_path):
+    cfg = tmp_path / "discord.yaml"
+    _write_config(cfg)
+    discord_config.PERMISSIONS_FILE = cfg
+    discord_config._RULE_CACHE = None
+
+    bot = BlossomBot()
+    interaction = _make_interaction("npc", channel_id=2, role_ids=[3])
+    allowed = await bot._permission_check(interaction)
+    assert not allowed
+    interaction.response.send_message.assert_called_once()
+
+    interaction_ok = _make_interaction("npc", channel_id=1, role_ids=[2])
+    allowed_ok = await bot._permission_check(interaction_ok)
+    assert allowed_ok


### PR DESCRIPTION
## Summary
- Define Discord command permissions in `config/discord.yaml`
- Load and cache permissions at bot startup
- Enforce channel and role checks before executing commands
- Document Discord configuration format

## Testing
- `pytest` *(fails: Module 'numpy' missing and cannot be installed - ProxyError)*

------
https://chatgpt.com/codex/tasks/task_e_68c59f6e3be4832585edaeb4e478b48e