### PR TITLE
Add Discord voice orchestrator

### DIFF
--- a/brain/voice_orchestrator.py
+++ b/brain/voice_orchestrator.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+"""Discord-based speech assistant orchestrating STT, LLM and TTS."""
+
+import asyncio
+import contextlib
+from typing import Optional
+
+from ears import pipeline
+from brain import dialogue
+from mouth.discord_player import DiscordPlayer
+
+
+class DiscordOrchestrator:
+    """Coordinate speech recognition, dialogue generation and synthesis."""
+
+    def __init__(self, token: str, channel_id: int, *, debounce: float = 0.3) -> None:
+        self.token = token
+        self.channel_id = channel_id
+        self.debounce = debounce
+        self.player = DiscordPlayer()
+        self._play_task: Optional[asyncio.Task[None]] = None
+        self._worker_task: Optional[asyncio.Task[None]] = None
+        self._partial_reset: Optional[asyncio.Task[None]] = None
+        self._partial_count = 0
+        self._listening = True
+        self._queue: asyncio.Queue[str] = asyncio.Queue()
+
+    async def _reset_partials(self) -> None:
+        await asyncio.sleep(self.debounce)
+        self._partial_count = 0
+
+    async def _handle_segment(self, part, speaker) -> None:
+        """Callback for :func:`ears.pipeline.run_bot` transcription parts."""
+        if not part.is_final:
+            if self._play_task and not self._play_task.done():
+                self._partial_count += 1
+                if self._partial_reset is not None:
+                    self._partial_reset.cancel()
+                self._partial_reset = asyncio.create_task(self._reset_partials())
+                if self._partial_count >= 2:
+                    self._play_task.cancel()
+            return
+
+        if not self._listening:
+            return
+
+        text = part.text.strip()
+        if text:
+            await self._queue.put(text)
+
+    async def _worker(self) -> None:
+        while True:
+            text = await self._queue.get()
+            self._listening = False
+            reply = dialogue.respond(text)
+            message = getattr(reply, "narration", str(reply))
+            self._play_task = asyncio.create_task(self.player.speak(message))
+            try:
+                await self._play_task
+            except asyncio.CancelledError:
+                pass
+            finally:
+                self._play_task = None
+                self._listening = True
+
+    async def start(self) -> None:
+        """Run the orchestrator until stopped."""
+
+        @self.player.event
+        async def on_ready() -> None:
+            channel = self.player.get_channel(self.channel_id) or await self.player.fetch_channel(self.channel_id)
+            if channel is None or not hasattr(channel, "connect"):
+                raise RuntimeError("Channel is not a voice channel")
+            await self.player.join_voice(channel)  # type: ignore[arg-type]
+
+        self._worker_task = asyncio.create_task(self._worker())
+        player_task = asyncio.create_task(self.player.start(self.token))
+        try:
+            await pipeline.run_bot(
+                self.token,
+                self.channel_id,
+                part_callback=self._handle_segment,
+            )
+        finally:
+            if not player_task.done():
+                player_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await player_task
+            if self._worker_task and not self._worker_task.done():
+                self._worker_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self._worker_task

--- a/tests/brain/test_voice_orchestrator.py
+++ b/tests/brain/test_voice_orchestrator.py
@@ -1,0 +1,124 @@
+from pathlib import Path
+import sys
+import asyncio
+from types import SimpleNamespace
+import types
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+sys.modules.setdefault("numpy", types.SimpleNamespace())
+sys.modules.setdefault("resampy", types.SimpleNamespace(resample=lambda a, b, c: a))
+sys.modules.setdefault(
+    "scipy",
+    types.SimpleNamespace(signal=types.SimpleNamespace(resample_poly=lambda a, b, c: a)),
+)
+sys.modules.setdefault(
+    "discord",
+    types.SimpleNamespace(
+        Client=object,
+        Intents=types.SimpleNamespace(none=lambda: types.SimpleNamespace(voice_states=True)),
+        sinks=types.SimpleNamespace(RawData=object),
+        Member=object,
+        VoiceState=object,
+        VoiceChannel=object,
+        VoiceClient=object,
+        opus=types.SimpleNamespace(Encoder=object),
+    ),
+)
+sys.modules.setdefault("webrtcvad", types.SimpleNamespace(Vad=object))
+sys.modules.setdefault("faster_whisper", types.SimpleNamespace(WhisperModel=object))
+sys.modules.setdefault(
+    "service_api",
+    types.SimpleNamespace(
+        search=lambda q, tags=None: [],
+        create_note=lambda *a, **k: None,
+        get_vault=lambda: None,
+    ),
+)
+fake_requests = types.SimpleNamespace(post=lambda *a, **k: None)
+fake_requests.Response = type("_Resp", (), {})
+fake_requests.exceptions = types.SimpleNamespace(
+    HTTPError=Exception, RequestException=Exception, Timeout=Exception
+)
+sys.modules.setdefault("requests", fake_requests)
+sys.modules.setdefault("requests.exceptions", fake_requests.exceptions)
+
+class _StubPlayer:
+    def __init__(self, *a, **k):
+        pass
+
+    def event(self, func):
+        return func
+
+    async def start(self, token):
+        pass
+
+    def get_channel(self, cid):
+        return None
+
+    async def fetch_channel(self, cid):
+        return None
+
+    async def join_voice(self, channel):
+        pass
+
+    async def speak(self, text, profile=None):
+        pass
+
+sys.modules.setdefault("mouth.discord_player", types.SimpleNamespace(DiscordPlayer=_StubPlayer))
+
+from brain.voice_orchestrator import DiscordOrchestrator
+
+
+class DummyPart:
+    def __init__(self, text: str, is_final: bool) -> None:
+        self.text = text
+        self.is_final = is_final
+
+
+class DummyPlayer:
+    def __init__(self) -> None:
+        self.spoken = []
+
+    async def speak(self, text: str, profile=None) -> None:  # pragma: no cover - behaviour mocked
+        self.spoken.append(text)
+        try:
+            await asyncio.sleep(0.05)
+        except asyncio.CancelledError:
+            raise
+
+
+def test_interrupt_and_queue(monkeypatch):
+    async def run() -> None:
+        orch = DiscordOrchestrator("T", 1, debounce=0.01)
+        orch.player = DummyPlayer()
+
+        monkeypatch.setattr(
+            "brain.voice_orchestrator.dialogue.respond",
+            lambda msg: SimpleNamespace(narration=f"bot: {msg}"),
+        )
+
+        orch._worker_task = asyncio.create_task(orch._worker())
+
+        # enqueue initial utterance
+        await orch._handle_segment(DummyPart("hello", True), "user")
+        await asyncio.sleep(0.02)
+        assert orch._play_task is not None
+
+        # simulate user speech to interrupt
+        await orch._handle_segment(DummyPart("um", False), "user")
+        await orch._handle_segment(DummyPart("um", False), "user")
+        await asyncio.sleep(0.05)
+        assert orch._play_task is None
+
+        # new message after interruption
+        await orch._handle_segment(DummyPart("world", True), "user")
+        await asyncio.sleep(0.1)
+        assert orch.player.spoken[-1] == "bot: world"
+
+        orch._worker_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await orch._worker_task
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- implement `DiscordOrchestrator` that links speech recognition, dialogue generation and text-to-speech playback
- add test ensuring playback interrupts on user speech and resumes with queued reply

## Testing
- `pytest tests/brain/test_voice_orchestrator.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'scipy.signal'; 'scipy' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a3f5dd688325b22518e37068d166