### PR TITLE
Add session log export and slash command

### DIFF
--- a/discord_bot.py
+++ b/discord_bot.py
@@ -11,6 +11,7 @@ import service_api
 from brain import dialogue
 from mouth.registry import VoiceRegistry
 from config.discord import get_permission_rules
+import session_export
 
 
 class BlossomBot(commands.Bot):
@@ -26,6 +27,10 @@ class BlossomBot(commands.Bot):
             name="scene", description="Scene related commands"
         )
         self.scene_group.command(name="as")(self.scene_as)
+        self.export_group = app_commands.Group(
+            name="export", description="Export utilities"
+        )
+        self.export_group.command(name="session")(self.export_session)
 
     async def setup_hook(self) -> None:  # pragma: no cover - Discord runtime
         """Register slash commands once the bot is ready."""
@@ -34,6 +39,7 @@ class BlossomBot(commands.Bot):
         self.tree.add_command(self.note)
         self.tree.add_command(self.track)
         self.tree.add_command(self.scene_group)
+        self.tree.add_command(self.export_group)
 
     # ------------------------------------------------------------------
     @app_commands.command(name="npc", description="Fetch NPC info or speak in their voice")
@@ -147,6 +153,16 @@ class BlossomBot(commands.Bot):
             return
 
         await interaction.response.send_message(f"{stat} is now {new_value}")
+
+    # ------------------------------------------------------------------
+    async def export_session(self, interaction: discord.Interaction) -> None:
+        """Handle the ``/export session`` command."""
+        try:
+            note_path = session_export.export_session()
+        except Exception as exc:  # pragma: no cover - runtime errors
+            await interaction.response.send_message(f"Error: {exc}", ephemeral=True)
+            return
+        await interaction.response.send_message(f"Exported session log to {note_path}")
 
     # ------------------------------------------------------------------
     async def scene_as(

--- a/session_export.py
+++ b/session_export.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+import os
+import requests
+
+from ears.transcript_logger import TranscriptLogger
+import service_api
+
+
+def export_session(transcript_root: str | Path | None = None,
+                   combat_url: str | None = None) -> Path:
+    """Export combat tracker events and transcript summaries to a note.
+
+    Parameters
+    ----------
+    transcript_root:
+        Directory containing transcript log files. When ``None``, the path is
+        taken from the ``TRANSCRIPT_ROOT`` environment variable and defaults to
+        ``"transcripts"``.
+    combat_url:
+        Base URL of the combat tracker service. When ``None``, the value is
+        taken from ``COMBAT_TRACKER_URL`` and defaults to
+        ``"http://localhost:8000"``.
+
+    Returns
+    -------
+    Path
+        The path to the created note within the vault.
+    """
+
+    combat_url = combat_url or os.getenv("COMBAT_TRACKER_URL", "http://localhost:8000")
+    resp = requests.get(f"{combat_url}/events", timeout=10)
+    resp.raise_for_status()
+    events = resp.json()
+
+    transcript_root = Path(transcript_root or os.getenv("TRANSCRIPT_ROOT", "transcripts"))
+    logger = TranscriptLogger(transcript_root)
+    session_id = logger.rotate()
+
+    summaries: list[tuple[str, str]] = []
+    for file in transcript_root.glob(f"*.{session_id}.jsonl"):
+        channel = file.stem.split(".")[0]
+        summary = logger.summary(channel, session_id)
+        if summary:
+            summaries.append((channel, summary))
+
+    lines: list[str] = []
+    if events:
+        lines.append("## Combat")
+        for event in events:
+            ts = event.get("ts")
+            desc = event.get("desc") or event.get("event") or event.get("text") or ""
+            if ts is not None:
+                ts_text = datetime.fromtimestamp(ts).isoformat(timespec="seconds")
+                lines.append(f"- {ts_text} {desc}")
+            else:
+                lines.append(f"- {desc}")
+    if summaries:
+        lines.append("## Transcripts")
+        for channel, summary in summaries:
+            lines.append(f"### {channel}")
+            lines.append(summary)
+
+    content = "\n".join(lines)
+    date_str = datetime.now().strftime("%Y-%m-%d")
+    note_path = service_api.create_note(f"Session Log/{date_str}.md", content)
+    return note_path
+
+
+__all__ = ["export_session"]

--- a/tests/test_session_export.py
+++ b/tests/test_session_export.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+import sys
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+sys.modules.setdefault(
+    "numpy",
+    types.SimpleNamespace(
+        asarray=lambda *a, **k: [],
+        array=lambda *a, **k: [],
+        vstack=lambda xs: xs,
+        arange=lambda n: list(range(n)),
+    ),
+)
+
+sys.modules.setdefault(
+    "watchfiles",
+    types.SimpleNamespace(Change=object, watch=lambda *a, **k: None),
+)
+
+sys.modules.setdefault("requests", types.SimpleNamespace(get=lambda *a, **k: None))
+
+import service_api
+from ears.transcript_logger import TranscriptLogger
+import session_export
+
+
+def test_session_export_creates_note(tmp_path, monkeypatch):
+    vault = tmp_path / "vault"
+    monkeypatch.setattr(service_api, "get_vault", lambda: vault)
+
+    transcripts = tmp_path / "transcripts"
+    logger = TranscriptLogger(transcripts)
+    logger.append("general", "GM", "Hello there")
+
+    class FakeResp:
+        def json(self):
+            return [{"ts": 1, "desc": "Goblin attacks"}]
+
+        def raise_for_status(self):
+            pass
+
+    monkeypatch.setattr(session_export.requests, "get", lambda url, timeout=10: FakeResp())
+
+    note_path = session_export.export_session(transcript_root=transcripts, combat_url="http://tracker")
+    assert note_path.exists()
+    content = note_path.read_text(encoding="utf-8")
+    assert "Goblin attacks" in content
+    assert "GM: Hello there" in content


### PR DESCRIPTION
## Summary
- export combat tracker events and transcript summaries into a dated session log note
- wire up new `/export session` slash command
- test session export creates note with combat and transcript entries

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'scipy.signal'; 'scipy' is not a package)*
- `pytest tests/test_session_export.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5a6199c948325aaa3b38508668a6d