### PR TITLE
Remove theme controls from top bar

### DIFF
--- a/ui/topbar.js
+++ b/ui/topbar.js
@@ -1,7 +1,3 @@
-import { setTheme } from './theme.js';
-
-window.setTheme = setTheme;
-
 (function() {
   const style = document.createElement('style');
   style.textContent = `


### PR DESCRIPTION
## Summary
- strip out unused theme helper from the top bar
- keep navigation limited to Back and About buttons

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'random')*

------
https://chatgpt.com/codex/tasks/task_e_68c5a9d3ee4c8325a64ccfe3538ebe97