### PR TITLE
feat(ui): add icon-only responsive sidebar

### DIFF
--- a/ui/sidebar.css
+++ b/ui/sidebar.css
@@ -3,9 +3,8 @@
   top: 2.5rem;
   left: 0;
   bottom: 0;
-  width: 200px;
+  width: 3.5rem;
   background: var(--panel-bg);
-  color: var(--fg);
   transform: translateX(-100%);
   transition: transform 0.3s;
   overflow-y: auto;
@@ -16,18 +15,20 @@
 }
 #sidebar a {
   display: flex;
-  align-items: center;
-  padding: 0.75rem 1rem;
+  justify-content: center;
+  padding: 0.75rem 0;
   color: var(--fg);
   text-decoration: none;
 }
 #sidebar a:hover {
   background: var(--panel-hover-bg);
 }
+#sidebar a span {
+  display: none;
+}
 #sidebar svg {
   width: 24px;
   height: 24px;
-  margin-right: 0.5rem;
   fill: var(--icon);
 }
 #sidebar-toggle {
@@ -35,7 +36,6 @@
   top: 3rem;
   left: 0.5rem;
   background: var(--button-bg);
-  color: var(--fg);
   border: none;
   padding: 0.25rem;
   cursor: pointer;
@@ -49,9 +49,6 @@
 @media (min-width: 768px) {
   #sidebar {
     transform: none;
-  }
-  body {
-    margin-left: 200px;
   }
   #sidebar-toggle {
     display: none;

--- a/ui/sidebar.js
+++ b/ui/sidebar.js
@@ -15,8 +15,8 @@
     },
     {
       href: 'dnd.html',
-      label: 'Dungeons & Dragons',
-      icon: `<svg viewBox="0 0 24 24" aria-hidden="true" fill="var(--icon)"><title>Dungeons and Dragons</title><polygon points="12,2 2,12 12,22 22,12"/></svg>`
+      label: 'D&D',
+      icon: `<svg viewBox="0 0 24 24" aria-hidden="true" fill="var(--icon)"><title>D&amp;D</title><polygon points="12,2 2,12 12,22 22,12"/></svg>`
     },
     {
       href: 'settings.html',
@@ -44,14 +44,14 @@
     const a = document.createElement('a');
     a.href = item.href;
     a.setAttribute('aria-label', item.label);
-    a.innerHTML = `${item.icon}<span>${item.label}</span>`;
+    a.innerHTML = item.icon;
     sidebar.appendChild(a);
   });
 
   const toggle = document.createElement('button');
   toggle.id = 'sidebar-toggle';
   toggle.setAttribute('aria-label', 'Toggle sidebar');
-  toggle.innerHTML = `<svg viewBox="0 0 24 24" fill="var(--icon)"><title>Toggle sidebar</title><path d="M4 6h16v2H4V6zm0 5h16v2H4v-2zm0 5h16v2H4v-2z"/></svg>`;
+  toggle.innerHTML = `<svg viewBox="0 0 24 24" aria-hidden="true" fill="var(--icon)"><title>Toggle sidebar</title><path d="M4 6h16v2H4V6zm0 5h16v2H4v-2zm0 5h16v2H4v-2z"/></svg>`;
   toggle.addEventListener('click', () => {
     sidebar.classList.toggle('open');
   });


### PR DESCRIPTION
## Summary
- create left-aligned navigation with SVG icon links for generator, D&D, settings, training, model management and ONNX pages
- style sidebar to float over content, hide text labels, and collapse to a hamburger on small screens
- ensure icons inherit `--icon` color for theme support

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c5a9e071788325843f83f6253efa32