### PR TITLE
chore: update tauri config to v2 schema

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,14 +1,12 @@
 {
-  "$schema": "../node_modules/@tauri-apps/cli/schema.json",
-  "package": {
-    "productName": "Blossom Music Generator",
-    "version": "0.1.0"
+  "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
+  "identifier": "com.blossom.musicgen",
+  "productName": "Blossom Music Generator",
+  "version": "0.1.0",
+  "build": {
+    "frontendDist": "../ui"
   },
-    "build": {
-      "distDir": "../ui",
-      "devPath": "../ui"
-    },
-  "tauri": {
+  "app": {
     "windows": [
       {
         "title": "Music Generator",
@@ -16,5 +14,10 @@
         "height": 600
       }
     ]
+  },
+  "plugins": {
+    "dialog": {},
+    "shell": {},
+    "store": {}
   }
 }


### PR DESCRIPTION
## Summary
- migrate `tauri.conf.json` to the Tauri v2 schema with identifier, product name, and version
- configure build to use `../ui` and move window definition under `app`
- add plugin declarations for dialog, shell, and store

## Testing
- `npm run tauri info` *(fails: webkit2gtk-4.1 not installed, rsvg2 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5aac339088325bb833efe5d2ecee6