### PR TITLE
Initialize theme toggle based on stored preference

### DIFF
--- a/ui/settings.js
+++ b/ui/settings.js
@@ -3,29 +3,26 @@ import { setTheme, getTheme } from './theme.js';
 (function() {
   function $(id) { return document.getElementById(id); }
 
-  async function load() {
-    const outdir = localStorage.getItem('default_outdir') || '';
-    const theme = (await getTheme()) || 'dark';
+  async function init() {
     const outInput = $('default_outdir');
+    if (outInput) outInput.value = localStorage.getItem('default_outdir') || '';
+
     const themeToggle = $('theme_toggle');
-    if (outInput) outInput.value = outdir;
     if (themeToggle) {
-      themeToggle.checked = theme === 'dark';
+      const current = (await getTheme()) || 'dark';
+      themeToggle.checked = current === 'dark';
       themeToggle.addEventListener('change', () => {
         const newTheme = themeToggle.checked ? 'dark' : 'light';
         setTheme(newTheme);
       });
     }
-  }
 
-  function save() {
-    const outInput = $('default_outdir');
-    if (outInput) localStorage.setItem('default_outdir', outInput.value);
-  }
-
-  document.addEventListener('DOMContentLoaded', () => {
-    load();
     const saveBtn = $('save');
-    if (saveBtn) saveBtn.addEventListener('click', save);
-  });
+    if (saveBtn) saveBtn.addEventListener('click', () => {
+      const outInput = $('default_outdir');
+      if (outInput) localStorage.setItem('default_outdir', outInput.value);
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
 })();


### PR DESCRIPTION
## Summary
- Initialize settings theme toggle from saved preference
- Persist theme selection via existing theme module

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c5aab7311c8325877768f6ecfeaa30