### PR TITLE
chore: clean up unused imports

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -14,7 +14,6 @@ use std::{
 };
 
 use regex::Regex;
-use tauri::Manager;
 use tauri::{AppHandle, State};
 use tauri_plugin_store::PluginBuilder;
 use tauri_plugin_shell::ShellExt;

--- a/src-tauri/src/musiclang.rs
+++ b/src-tauri/src/musiclang.rs
@@ -4,9 +4,9 @@ use serde_json::Value;
 use std::{
     fs::{self, File},
     io::{Read, Write},
-    path::{Path, PathBuf},
+    path::PathBuf,
 };
-use tauri::{AppHandle, Manager};
+use tauri::AppHandle;
 
 use crate::{util::list_from_dir, ProgressEvent};
 


### PR DESCRIPTION
## Summary
- remove unused `Manager` import in main.rs
- drop `Path` and `Manager` imports from musiclang.rs

## Testing
- `cargo build` *(fails: failed to download index.crates.io, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ad1e78c48325bae55d94600becee