### PR TITLE
Replace shell plugin with opener

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,7 +11,7 @@ serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 tauri-plugin-dialog = "2"
-tauri-plugin-shell = "2"
+tauri-plugin-opener = "2"
 tauri-plugin-store = "2"
 futures-sink = "0.3.31"
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -16,7 +16,7 @@ use std::{
 use regex::Regex;
 use tauri::{AppHandle, State};
 use tauri_plugin_store::Builder;
-use tauri_plugin_shell::ShellExt;
+use tauri_plugin_opener::OpenerExt;
 use serde_json::{json, Value};
 mod musiclang;
 mod util;
@@ -403,7 +403,7 @@ fn open_path(app: AppHandle, path: String) -> Result<(), String> {
     if !Path::new(&path).exists() {
         return Err("Path does not exist".into());
     }
-    app.shell().open(path, None).map_err(|e| e.to_string())
+    app.opener().open(path, None).map_err(|e| e.to_string())
 }
 
 fn main() {
@@ -413,7 +413,7 @@ fn main() {
 
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
-        .plugin(tauri_plugin_shell::init())
+        .plugin(tauri_plugin_opener::init())
         .plugin(Builder::new().build())
         .manage(JobRegistry::default())
         .invoke_handler(tauri::generate_handler![


### PR DESCRIPTION
## Summary
- switch Tauri backend dependency from shell plugin to opener plugin
- update plugin initialization and API usage to opener

## Testing
- `cargo check` *(fails: failed to download from https://index.crates.io/config.json - [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c5b2d3a22c83259154b9b7317bf8bc