### PR TITLE
feat: export session combat and transcripts note via slash command

### DIFF
--- a/discord_bot.py
+++ b/discord_bot.py
@@ -158,7 +158,8 @@ class BlossomBot(commands.Bot):
         except Exception as exc:  # pragma: no cover - runtime errors
             await interaction.response.send_message(f"Error: {exc}", ephemeral=True)
             return
-        await interaction.response.send_message(f"Exported session log to {note_path}")
+        await interaction.response.send_message(
+            f"Exported session log to {str(note_path)}")
 
     # ------------------------------------------------------------------
     @scene_group.command(name="as", description="Switch the narrator TTS voice")

--- a/session_export.py
+++ b/session_export.py
@@ -46,9 +46,8 @@ def export_session(transcript_root: str | Path | None = None,
         if summary:
             summaries.append((channel, summary))
 
-    lines: list[str] = []
+    lines: list[str] = ["## Combat"]
     if events:
-        lines.append("## Combat")
         for event in events:
             ts = event.get("ts")
             desc = event.get("desc") or event.get("event") or event.get("text") or ""
@@ -57,11 +56,16 @@ def export_session(transcript_root: str | Path | None = None,
                 lines.append(f"- {ts_text} {desc}")
             else:
                 lines.append(f"- {desc}")
+    else:
+        lines.append("No combat events.")
+
+    lines.append("## Transcripts")
     if summaries:
-        lines.append("## Transcripts")
         for channel, summary in summaries:
             lines.append(f"### {channel}")
             lines.append(summary)
+    else:
+        lines.append("No transcripts.")
 
     content = "\n".join(lines)
     date_str = datetime.now().strftime("%Y-%m-%d")


### PR DESCRIPTION
## Summary
- ensure session export notes always include both Combat and Transcripts sections, even when empty
- export `/export session` command replies with created note path

## Testing
- `pytest tests/test_session_export.py tests/test_discord_permissions.py tests/test_discord_listener.py`

------
https://chatgpt.com/codex/tasks/task_e_68c5b301603883259860fa43d1744e51