### PR TITLE
Use Tauri invoke for models link

### DIFF
--- a/ui/src/pages/Dashboard.jsx
+++ b/ui/src/pages/Dashboard.jsx
@@ -23,10 +23,15 @@ export default function Dashboard() {
           <span className="card-icon">🎚️</span>
           <h2>Train Model</h2>
         </Link>
-        <a className="card" href="/models" title="Manage or download models">
+        <button
+          className="card"
+          type="button"
+          title="Manage or download models"
+          onClick={() => window.__TAURI__?.invoke('open_path', { path: 'models' })}
+        >
           <span className="card-icon">📦</span>
           <h2>Manage/Download Models</h2>
-        </a>
+        </button>
         <Link className="card" to="/onnx">
           <span className="card-icon">🧠</span>
           <h2>ONNX Crafter</h2>


### PR DESCRIPTION
## Summary
- Replace dashboard anchor with a button invoking Tauri to open the models directory, avoiding page reloads

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c5b7c5418c832597bc5f46dbcc436b