### PR TITLE
refactor: migrate emit_all to emit

### DIFF
--- a/src-tauri/src/musiclang.rs
+++ b/src-tauri/src/musiclang.rs
@@ -75,7 +75,9 @@ pub fn download_model(
     force: Option<bool>,
 ) -> Result<Vec<String>, String> {
     let file_name = name.split('/').last().unwrap_or(name);
-    let path = PathBuf::from("models").join(file_name).with_extension("onnx");
+    let path = PathBuf::from("models")
+        .join(file_name)
+        .with_extension("onnx");
     fs::create_dir_all(path.parent().unwrap()).map_err(|e| e.to_string())?;
 
     if path.exists() && !force.unwrap_or(false) {
@@ -87,7 +89,7 @@ pub fn download_model(
             step: None,
             total: None,
         };
-        let _ = app.emit_all(&format!("download::progress::{}", name), event);
+        let _ = app.emit(&format!("download::progress::{}", name), event);
         return list_from_dir(path.parent().unwrap());
     }
 
@@ -120,7 +122,7 @@ pub fn download_model(
             step: None,
             total: None,
         };
-        let _ = app.emit_all(&format!("download::progress::{}", name), event);
+        let _ = app.emit(&format!("download::progress::{}", name), event);
     }
 
     list_from_dir(path.parent().unwrap())


### PR DESCRIPTION
## Summary
- replace deprecated `emit_all` calls with `emit`
- maintain existing event names and payloads

## Testing
- `cargo test` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b8b1648c8325869fd3a1edc67b55