### PR TITLE
feat(ui): add theme selector

### DIFF
--- a/ui/settings.html
+++ b/ui/settings.html
@@ -21,10 +21,12 @@
   </section>
   <section id="appearance">
     <h2>Appearance</h2>
-    <label>
-      <input type="checkbox" id="theme_toggle">
-      Dark Theme
-    </label>
+    <label for="theme_select">Theme</label>
+    <select id="theme_select">
+      <option value="light">Light</option>
+      <option value="dark">Dark</option>
+    </select>
+    <p id="theme_help"></p>
   </section>
   <button id="save" type="button">Save</button>
   <script type="module" src="./topbar.js"></script>

--- a/ui/settings.js
+++ b/ui/settings.js
@@ -7,13 +7,24 @@ import { setTheme, getTheme } from './theme.js';
     const outInput = $('default_outdir');
     if (outInput) outInput.value = localStorage.getItem('default_outdir') || '';
 
-    const themeToggle = $('theme_toggle');
-    if (themeToggle) {
+    const themeSelect = $('theme_select');
+    const themeHelp = $('theme_help');
+    function updateThemeHelp(theme) {
+      if (themeHelp) {
+        themeHelp.textContent = theme === 'dark'
+          ? 'Dark mode reduces eye strain.'
+          : 'Light mode improves readability in bright environments.';
+      }
+    }
+
+    if (themeSelect) {
       const current = (await getTheme()) || 'dark';
-      themeToggle.checked = current === 'dark';
-      themeToggle.addEventListener('change', () => {
-        const newTheme = themeToggle.checked ? 'dark' : 'light';
+      themeSelect.value = current;
+      updateThemeHelp(current);
+      themeSelect.addEventListener('change', () => {
+        const newTheme = themeSelect.value;
         setTheme(newTheme);
+        updateThemeHelp(newTheme);
       });
     }
 


### PR DESCRIPTION
## Summary
- replace appearance checkbox with theme dropdown
- describe benefits for dark and light modes
- persist user theme choice via existing storage

## Testing
- `npm test` *(fails: Missing script: "test" - to see a list of scripts, run `npm run`)*
- `(cd ui && npm test)` *(fails: Missing script: "test" - to see a list of scripts, run `npm run`)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b9dca1c883259e729a272939383e