### PR TITLE
Import tauri Emitter trait

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -16,6 +16,7 @@ use std::{
 use regex::Regex;
 use serde_json::{json, Value};
 use tauri::{AppHandle, State};
+use tauri::Emitter;
 use tauri_plugin_opener::OpenerExt;
 use tauri_plugin_store::Builder;
 mod musiclang;

--- a/src-tauri/src/musiclang.rs
+++ b/src-tauri/src/musiclang.rs
@@ -7,6 +7,7 @@ use std::{
     path::PathBuf,
 };
 use tauri::AppHandle;
+use tauri::Emitter;
 
 use crate::{util::list_from_dir, ProgressEvent};
 


### PR DESCRIPTION
## Summary
- import tauri::Emitter in main.rs and musiclang.rs so `emit` works

## Testing
- `cargo build` *(fails: failed to download from crates.io: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c5bea97dc08325912a495ef46a0e1b