### PR TITLE
Use tauri opener API correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "dependencies": {
     "@tauri-apps/plugin-dialog": "^2",
     "@tauri-apps/plugin-shell": "^2",
-    "@tauri-apps/plugin-store": "^2"
+    "@tauri-apps/plugin-store": "^2",
+    "@tauri-apps/plugin-opener": "^2"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,6 +13,7 @@ reqwest = { version = "0.11", default-features = false, features = ["blocking", 
 tauri-plugin-dialog = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-store = "2"
+url = "2"
 futures-sink = "0.3.31"
 
 [build-dependencies]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,7 +4,7 @@ use std::{
     collections::HashMap,
     fs,
     io::{BufRead, BufReader},
-    path::Path,
+    path::{Path, PathBuf},
     process::{Child, Command, Stdio},
     sync::{
         atomic::{AtomicU64, Ordering},
@@ -19,6 +19,7 @@ use tauri::{AppHandle, State};
 use tauri::Emitter;
 use tauri_plugin_opener::OpenerExt;
 use tauri_plugin_store::Builder;
+use url::Url;
 mod musiclang;
 mod util;
 use crate::util::list_from_dir;
@@ -423,10 +424,19 @@ fn job_status(registry: State<JobRegistry>, job_id: u64) -> JobState {
 
 #[tauri::command]
 fn open_path(app: AppHandle, path: String) -> Result<(), String> {
-    if !Path::new(&path).exists() {
-        return Err("Path does not exist".into());
+    if let Ok(url) = Url::parse(&path) {
+        app.opener()
+            .open_url(url)
+            .map_err(|e| e.to_string())
+    } else {
+        let path_buf = PathBuf::from(&path);
+        if !path_buf.exists() {
+            return Err("Path does not exist".into());
+        }
+        app.opener()
+            .open_path(path_buf)
+            .map_err(|e| e.to_string())
     }
-    app.opener().open(path, None).map_err(|e| e.to_string())
 }
 
 fn main() {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,6 +18,7 @@
   "plugins": {
     "dialog": {},
     "shell": {},
-    "store": {}
+    "store": {},
+    "opener": {}
   }
 }


### PR DESCRIPTION
## Summary
- Swap deprecated `app.opener().open` for `open_url`/`open_path` with URL detection
- Configure opener plugin for both Rust and JavaScript sides
- Add `url` crate to support parsing

## Testing
- ⚠️ `npm install` *(403 Forbidden while fetching @tauri-apps/plugin-opener)*
- ⚠️ `cargo test --manifest-path src-tauri/Cargo.toml` *(failed to download crates: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c05d5b708325bc6b843302c7eca5