### PR TITLE
fix: reference existing UI directory in Tauri config

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,7 +4,7 @@
   "productName": "Blossom Music Generator",
   "version": "0.1.0",
   "build": {
-    "frontendDist": "../ui/dist"
+    "frontendDist": "../ui"
   },
   "app": {
     "windows": [


### PR DESCRIPTION
## Summary
- point Tauri's `frontendDist` to the existing `ui` directory to avoid missing `dist`

## Testing
- `npm run tauri dev` *(fails: Failed to parse version 2 for crate `tauri-plugin-opener`; mismatched versions)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c06944588325a2ed8659d717cdb9