### PR TITLE
chore: pin tauri plugin versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
     "tauri": "tauri"
   },
   "dependencies": {
-    "@tauri-apps/plugin-dialog": "^2",
-    "@tauri-apps/plugin-shell": "^2",
-    "@tauri-apps/plugin-store": "^2"
+    "@tauri-apps/plugin-dialog": "2.4.0",
+    "@tauri-apps/plugin-shell": "2.3.1",
+    "@tauri-apps/plugin-store": "2.4.0"
   },
   "devDependencies": {
-    "@tauri-apps/cli": "^2"
+    "@tauri-apps/cli": "2.8.5"
   }
 }


### PR DESCRIPTION
## Summary
- pin Tauri plugin dependencies to exact crate versions

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tauri-apps%2fcli)*
- `npm run tauri dev` *(fails: Failed to parse version `2` for crate `tauri-plugin-opener`; network 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c06cf3a883259776762b5227cadf