### PR TITLE
chore: pin tauri plugin versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,9 +6,10 @@
     "": {
       "name": "blossom-music-gen",
       "dependencies": {
-        "@tauri-apps/plugin-dialog": "^2",
-        "@tauri-apps/plugin-shell": "^2",
-        "@tauri-apps/plugin-store": "^2"
+        "@tauri-apps/plugin-dialog": "2.4.0",
+        "@tauri-apps/plugin-shell": "2.3.1",
+        "@tauri-apps/plugin-store": "2.4.0",
+        "@tauri-apps/plugin-opener": "2.4.0"
       },
       "devDependencies": {
         "@tauri-apps/cli": "^2"
@@ -260,9 +261,17 @@
       }
     },
     "node_modules/@tauri-apps/plugin-store": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-store/-/plugin-store-2.0.0.tgz",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-store/-/plugin-store-2.4.0.tgz",
       "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/@tauri-apps/plugin-opener": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.4.0.tgz",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
     "tauri": "tauri"
   },
   "dependencies": {
-    "@tauri-apps/plugin-dialog": "^2",
-    "@tauri-apps/plugin-shell": "^2",
-    "@tauri-apps/plugin-store": "^2",
-    "@tauri-apps/plugin-opener": "^2"
+    "@tauri-apps/plugin-dialog": "2.4.0",
+    "@tauri-apps/plugin-shell": "2.3.1",
+    "@tauri-apps/plugin-store": "2.4.0",
+    "@tauri-apps/plugin-opener": "2.4.0"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2"


### PR DESCRIPTION
## Summary
- pin Tauri plugin dependencies to specific crate versions
- update lockfile for pinned plugin versions

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.4.0.tgz)*
- `npm run tauri dev` *(fails: Failed to parse version `2` for crate `tauri-plugin-opener`; download of config.json failed: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c39788708325905ed2f923a5c5dd