### PR TITLE
Fix open_path API usage in Tauri backend

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -434,7 +434,7 @@ fn open_path(app: AppHandle, path: String) -> Result<(), String> {
             return Err("Path does not exist".into());
         }
         app.opener()
-            .open_path(path_buf)
+            .open_path(path_buf.to_string_lossy().to_string(), None)
             .map_err(|e| e.to_string())
     }
 }


### PR DESCRIPTION
## Summary
- adjust open_path call for tauri_plugin_opener's new signature

## Testing
- `cargo build` *(fails: failed to download index due to 403 CONNECT tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c7897858832597479e09b58ced25