### PR TITLE
Fix open_path usage for tauri plugin

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -431,7 +431,10 @@ fn open_path(app: AppHandle, path: String) -> Result<(), String> {
         if !path_buf.exists() {
             return Err("Path does not exist".into());
         }
-        app.opener().open_path(path_buf).map_err(|e| e.to_string())
+        app
+            .opener()
+            .open_path(path_buf, None)
+            .map_err(|e| e.to_string())
     }
 }
 


### PR DESCRIPTION
## Summary
- pass `None` to `open_path` to follow updated tauri-plugin-opener API

## Testing
- `cargo check` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68c5cd7eda6c8325a6ce0ea47a81c9dd