### PR TITLE
Convert path to string in open_path

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -431,9 +431,11 @@ fn open_path(app: AppHandle, path: String) -> Result<(), String> {
         if !path_buf.exists() {
             return Err("Path does not exist".into());
         }
+        let path_str =
+            path_buf.to_str().ok_or("Invalid Unicode in path")?.to_string();
         app
             .opener()
-            .open_path(path_buf, None)
+            .open_path(path_str, None)
             .map_err(|e| e.to_string())
     }
 }


### PR DESCRIPTION
## Summary
- Convert `PathBuf` to `String` before passing to `open_path`
- Return an error when the path contains invalid Unicode

## Testing
- `cargo check` *(fails: Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*
- `cargo check --locked --offline` *(fails: no matching package named `regex` found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d1791f1c83258be4718b63999add