### PR TITLE
Explicitly specify Option for opener paths

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -425,17 +425,20 @@ fn job_status(registry: State<JobRegistry>, job_id: u64) -> JobState {
 #[tauri::command]
 fn open_path(app: AppHandle, path: String) -> Result<(), String> {
     if let Ok(url) = Url::parse(&path) {
-        app.opener().open_url(url, None).map_err(|e| e.to_string())
+        app.opener()
+            .open_url(url, Option::<String>::None)
+            .map_err(|e| e.to_string())
     } else {
         let path_buf = PathBuf::from(&path);
         if !path_buf.exists() {
             return Err("Path does not exist".into());
         }
-        let path_str =
-            path_buf.to_str().ok_or("Invalid Unicode in path")?.to_string();
-        app
-            .opener()
-            .open_path(path_str, None)
+        let path_str = path_buf
+            .to_str()
+            .ok_or("Invalid Unicode in path")?
+            .to_string();
+        app.opener()
+            .open_path(path_str, Option::<String>::None)
             .map_err(|e| e.to_string())
     }
 }


### PR DESCRIPTION
## Summary
- Specify Option::<String>::None when invoking opener URLs
- Specify Option::<String>::None when invoking opener paths

## Testing
- `cargo fmt`
- `cargo build` *(fails: failed to get `futures-sink` as a dependency of package `blossom_tauri`)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d39afdf883259d83362648d9f6b2