### PR TITLE
refactor: centralize fonts and spacing tokens

### DIFF
--- a/ui/app.js
+++ b/ui/app.js
@@ -49,7 +49,7 @@ async function browserMain(){
         const link = document.createElement('a');
         link.textContent = 'bundle.zip';
         link.href = `/bundles/${job.id}`;
-        link.style.marginLeft = '8px';
+          link.style.marginLeft = 'var(--space-sm)';
         li.appendChild(link);
       }
       const btn = document.createElement('button');

--- a/ui/dnd.html
+++ b/ui/dnd.html
@@ -14,7 +14,6 @@
       align-items: center;
       height: 100vh;
       margin: 0;
-      font-family: sans-serif;
     }
   </style>
 </head>

--- a/ui/generate.html
+++ b/ui/generate.html
@@ -6,15 +6,12 @@
   <script type="module" src="./theme.js"></script>
   <link rel="stylesheet" href="/ui/theme.css">
   <style>
-    body { font-family: sans-serif; margin: 1em; background: var(--bg); color: var(--text); }
-    label { display: block; margin-bottom: 0.5em; }
-    #controls { margin-top: 1em; }
-    #log { background: var(--log-bg); color: var(--log-fg); padding: 0.5em; height: 200px; overflow-y: scroll; }
-    #results { margin-top: 1em; }
-    #recent { margin-top: 1em; }
+    body { background: var(--bg); color: var(--text); }
+    label { display: block; margin-bottom: var(--space-sm); }
+    #log { background: var(--log-bg); color: var(--log-fg); padding: var(--space-sm); height: 200px; overflow-y: scroll; }
   </style>
 </head>
-<body>
+<body class="m-md">
   <div id="inputs">
     <label>Preset <select id="preset"></select></label>
     <label>Style <select id="style"><option value="">(default)</option></select></label>
@@ -52,7 +49,7 @@
     <label>Outro <select id="outro"><option value="">(default)</option><option value="hit">hit</option><option value="ritard">ritard</option></select></label>
   </details>
 
-  <div id="controls">
+  <div id="controls" class="mt-md">
     <button id="start" type="button">Start</button>
     <button id="cancel" type="button" disabled>Cancel</button>
     <progress id="progress" value="0" max="100"></progress>
@@ -62,13 +59,13 @@
 
   <pre id="log"></pre>
 
-  <div id="results" hidden>
+  <div id="results" class="mt-md" hidden>
     <h3>Results</h3>
     <ul id="links"></ul>
     <ul id="summary"></ul>
     <pre id="metrics"></pre>
   </div>
-  <div id="recent">
+  <div id="recent" class="mt-md">
     <h3>Recent Renders</h3>
     <ul id="recent_list"></ul>
   </div>

--- a/ui/models.html
+++ b/ui/models.html
@@ -10,8 +10,6 @@
       background: var(--bg);
       color: var(--text);
       margin: 0;
-      font-family: sans-serif;
-      padding: 1rem;
     }
     a {
       color: var(--link);
@@ -21,11 +19,11 @@
       padding: 0;
     }
     li {
-      margin: 0.5rem 0;
+      margin: var(--space-sm) 0;
     }
   </style>
 </head>
-<body>
+<body class="p-md">
   <h1>Available Models</h1>
   <ul id="models"></ul>
   <script type="module" src="./topbar.js"></script>

--- a/ui/onnx.js
+++ b/ui/onnx.js
@@ -26,7 +26,7 @@ async function tauriOnnxMain(){
   const modelBanner = document.createElement('div');
   modelBanner.id = 'model-banner';
   modelBanner.style.color = 'red';
-  modelBanner.style.marginBottom = '1em';
+  modelBanner.style.marginBottom = 'var(--space-md)';
   modelBanner.hidden = true;
   inputsDiv.insertAdjacentElement('beforebegin', modelBanner);
   let jobId = null;
@@ -43,7 +43,7 @@ async function tauriOnnxMain(){
       err = document.createElement('span');
       err.id = errId;
       err.style.color = 'red';
-      err.style.marginLeft = '0.5em';
+      err.style.marginLeft = 'var(--space-sm)';
       input.insertAdjacentElement('afterend', err);
     }
     const raw = input.value.trim();

--- a/ui/settings.html
+++ b/ui/settings.html
@@ -6,20 +6,19 @@
   <script type="module" src="./theme.js"></script>
   <link rel="stylesheet" href="/ui/theme.css">
   <style>
-    body { font-family: sans-serif; margin: 1em; background: var(--bg); color: var(--text); }
-    section { margin-bottom: 2rem; }
-    label { display: block; margin-bottom: 0.5em; }
+    body { background: var(--bg); color: var(--text); }
+    label { display: block; margin-bottom: var(--space-sm); }
   </style>
 </head>
-<body>
+<body class="m-md">
   <h1>Settings</h1>
-  <section id="general">
+  <section id="general" class="mb-xl">
     <h2>General</h2>
     <label>Default Output Directory
       <input type="text" id="default_outdir" placeholder="/path/to/output" />
     </label>
   </section>
-  <section id="appearance">
+  <section id="appearance" class="mb-xl">
     <h2>Appearance</h2>
     <label for="theme_select">Theme</label>
     <select id="theme_select">

--- a/ui/sidebar.css
+++ b/ui/sidebar.css
@@ -1,9 +1,9 @@
 #sidebar {
   position: fixed;
-  top: 2.5rem;
+  top: calc(var(--space-xl) + var(--space-sm));
   left: 0;
   bottom: 0;
-  width: 3.5rem;
+  width: calc(var(--space-xl) + var(--space-lg));
   background: var(--panel-bg);
   transform: translateX(-100%);
   transition: transform 0.3s;
@@ -17,7 +17,7 @@
 #sidebar button {
   display: flex;
   justify-content: center;
-  padding: 0.75rem 0;
+  padding: calc(var(--space-sm) + var(--space-xs)) 0;
   color: var(--fg);
   text-decoration: none;
   background: none;
@@ -40,11 +40,11 @@
 }
 #sidebar-toggle {
   position: fixed;
-  top: 3rem;
-  left: 0.5rem;
+  top: calc(var(--space-xl) + var(--space-md));
+  left: var(--space-sm);
   background: var(--button-bg);
   border: none;
-  padding: 0.25rem;
+  padding: var(--space-xs);
   cursor: pointer;
   z-index: 1001;
 }

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -10,15 +10,15 @@ body {
 
 header {
   text-align: center;
-  padding: 2rem 1rem 0;
+  padding: var(--space-xl) var(--space-md) 0;
 }
 
 .dashboard {
   flex: 1;
   display: grid;
-  gap: 1.5rem;
+  gap: var(--space-lg);
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  padding: 2rem;
+  padding: var(--space-xl);
   max-width: 1200px;
   margin: 0 auto;
   width: 100%;
@@ -28,7 +28,7 @@ header {
 .card {
   background: var(--card-bg);
   border-radius: 12px;
-  padding: 2rem 1rem;
+  padding: var(--space-xl) var(--space-md);
   text-align: center;
   text-decoration: none;
   color: var(--text);
@@ -48,11 +48,11 @@ header {
 
 .card-icon {
   font-size: 3rem;
-  margin-bottom: 1rem;
+  margin-bottom: var(--space-md);
   color: var(--icon);
 }
 
 .card-caption {
-  margin-top: 0.5rem;
+  margin-top: var(--space-sm);
   font-size: 0.9rem;
 }

--- a/ui/src/pages/OnnxCrafter.css
+++ b/ui/src/pages/OnnxCrafter.css
@@ -1,17 +1,11 @@
-body {
-  font-family: sans-serif;
-  margin: 1em;
-  background: var(--bg);
-  color: var(--text);
-}
 label {
   display: block;
-  margin-bottom: 0.5em;
+  margin-bottom: var(--space-sm);
 }
 #log {
   background: var(--log-bg);
   color: var(--log-fg);
-  padding: 0.5em;
+  padding: var(--space-sm);
   height: 200px;
   overflow-y: auto;
 }
@@ -36,7 +30,7 @@ label {
   width: 40px;
   height: 40px;
   animation: spin 1s linear infinite;
-  margin-bottom: 1em;
+  margin-bottom: var(--space-md);
 }
 @keyframes spin {
   to {

--- a/ui/src/pages/OnnxCrafter.jsx
+++ b/ui/src/pages/OnnxCrafter.jsx
@@ -11,7 +11,7 @@ export default function OnnxCrafter() {
   };
 
   return (
-    <div>
+    <div className="m-md">
       <h1>ONNX Crafter</h1>
       <section id="instructions">
         <h2>Instructions</h2>

--- a/ui/theme.css
+++ b/ui/theme.css
@@ -1,3 +1,17 @@
+/* global tokens */
+:root {
+  --font: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  --space-xs: 0.25rem;
+  --space-sm: 0.5rem;
+  --space-md: 1rem;
+  --space-lg: 1.5rem;
+  --space-xl: 2rem;
+}
+
+body {
+  font-family: var(--font);
+}
+
 [data-theme="dark"] {
   --bg: #0d0d10;
   --text: #f5f5f7;
@@ -13,7 +27,6 @@
   --log-fg: #00d26a;
   --overlay-bg: rgba(0, 0, 0, 0.6);
   --topbar-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
-  --font: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   /* legacy variable mappings */
   --fg: var(--text);
   --panel-bg: var(--card-bg);
@@ -36,7 +49,6 @@
   --log-fg: #006b3c;
   --overlay-bg: rgba(255, 255, 255, 0.6);
   --topbar-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  --font: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   /* legacy variable mappings */
   --fg: var(--text);
   --panel-bg: var(--card-bg);
@@ -61,3 +73,36 @@ progress:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
+
+/* spacing utilities */
+.m-xs { margin: var(--space-xs); }
+.m-sm { margin: var(--space-sm); }
+.m-md { margin: var(--space-md); }
+.m-lg { margin: var(--space-lg); }
+.m-xl { margin: var(--space-xl); }
+
+.mt-sm { margin-top: var(--space-sm); }
+.mt-md { margin-top: var(--space-md); }
+.mt-lg { margin-top: var(--space-lg); }
+.mt-xl { margin-top: var(--space-xl); }
+
+.mb-sm { margin-bottom: var(--space-sm); }
+.mb-md { margin-bottom: var(--space-md); }
+.mb-lg { margin-bottom: var(--space-lg); }
+.mb-xl { margin-bottom: var(--space-xl); }
+
+.p-xs { padding: var(--space-xs); }
+.p-sm { padding: var(--space-sm); }
+.p-md { padding: var(--space-md); }
+.p-lg { padding: var(--space-lg); }
+.p-xl { padding: var(--space-xl); }
+
+.pt-sm { padding-top: var(--space-sm); }
+.pt-md { padding-top: var(--space-md); }
+.pt-lg { padding-top: var(--space-lg); }
+.pt-xl { padding-top: var(--space-xl); }
+
+.pb-sm { padding-bottom: var(--space-sm); }
+.pb-md { padding-bottom: var(--space-md); }
+.pb-lg { padding-bottom: var(--space-lg); }
+.pb-xl { padding-bottom: var(--space-xl); }

--- a/ui/topbar.js
+++ b/ui/topbar.js
@@ -8,17 +8,17 @@
       right: 0;
       background: var(--card-bg);
       color: var(--text);
-      padding: 0.5rem;
+      padding: var(--space-sm);
       display: flex;
       align-items: center;
       box-shadow: var(--topbar-shadow);
     }
-    body { padding-top: 2.5rem; }
+    body { padding-top: calc(var(--space-xl) + var(--space-sm)); }
     #top-bar button {
       background: var(--button-bg);
       color: var(--text);
       border: none;
-      padding: 0.25rem 0.5rem;
+      padding: var(--space-xs) var(--space-sm);
       cursor: pointer;
     }
     #top-bar button:hover {

--- a/ui/train.html
+++ b/ui/train.html
@@ -7,28 +7,25 @@
   <link rel="stylesheet" href="/ui/theme.css">
   <style>
     body {
-      font-family: sans-serif;
-      margin: 1em;
       background: var(--bg);
       color: var(--text);
     }
-    label { display:block; margin-bottom:0.5em; }
+    label { display:block; margin-bottom: var(--space-sm); }
     #log {
       background: var(--log-bg);
       color: var(--log-fg);
-      padding:0.5em;
+      padding: var(--space-sm);
       height:200px;
       overflow-y:scroll;
     }
-    #controls { margin-top:1em; }
   </style>
 </head>
-<body>
+<body class="m-md">
   <div id="inputs">
     <label>MIDI files <input type="file" id="midis" multiple accept=".mid,.midi" /></label>
     <label>Limit <input type="number" id="limit" /></label>
   </div>
-  <div id="controls">
+  <div id="controls" class="mt-md">
     <button id="start" type="button">Start</button>
     <button id="cancel" type="button" disabled>Cancel</button>
     <progress id="progress" value="0" max="100"></progress>


### PR DESCRIPTION
## Summary
- centralize fonts and spacing scales in shared theme
- replace inline font styles with themed variables
- add spacing utility classes for consistent layout

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: vite: not found)
- `npm install` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68c5d3b4bc3c832582bbf1bc0d979058