### PR TITLE
Remove empty plugin configs from Tauri config

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,9 +16,5 @@
     ]
   },
   "plugins": {
-    "dialog": {},
-    "shell": {},
-    "store": {},
-    "opener": {}
   }
 }


### PR DESCRIPTION
## Summary
- remove empty plugin configuration objects that caused deserialization errors

## Testing
- `npm run tauri dev` (fails: failed to download from crates.io, but no plugin config errors)


------
https://chatgpt.com/codex/tasks/task_e_68c5d57f5b288325afc35ffd16a9e027