### PR TITLE
Remove unused args field from JobInfo

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -47,7 +47,6 @@ fn extract_error_message(stderr: &str) -> Option<String> {
 
 struct JobInfo {
     child: Option<Child>,
-    args: Vec<String>,
     status: Option<bool>,
     stderr: Arc<Mutex<String>>,
 }
@@ -147,7 +146,6 @@ fn start_job(
     }
     let job = JobInfo {
         child: Some(child),
-        args,
         status: None,
         stderr: stderr_buf,
     };
@@ -201,7 +199,6 @@ fn onnx_generate(
     let stderr_buf = Arc::new(Mutex::new(String::new()));
     let job = JobInfo {
         child: Some(child),
-        args: full_args.clone(),
         status: None,
         stderr: stderr_buf.clone(),
     };


### PR DESCRIPTION
## Summary
- remove unused `args` field from `JobInfo`
- clean up job creation to match simplified struct

## Testing
- `cargo check` *(fails: failed to get `futures-sink` due to 403 CONNECT tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d58fc39c8325bdff397f55cca888