### PR TITLE
feat(ui): add base font size setting

### DIFF
--- a/ui/settings.html
+++ b/ui/settings.html
@@ -28,6 +28,11 @@
     <p id="theme_help"></p>
     <label for="accent_color">Accent Color</label>
     <input type="color" id="accent_color" />
+    <label for="font_size_select">Font Size</label>
+    <select id="font_size_select">
+      <option value="16px">Default</option>
+      <option value="20px">Large</option>
+    </select>
   </section>
   <button id="save" type="button">Save</button>
   <script type="module" src="./topbar.js"></script>

--- a/ui/settings.js
+++ b/ui/settings.js
@@ -1,4 +1,11 @@
-import { setTheme, getTheme, setAccent, getAccent } from './theme.js';
+import {
+  setTheme,
+  getTheme,
+  setAccent,
+  getAccent,
+  setBaseFontSize,
+  getBaseFontSize
+} from './theme.js';
 
 (function() {
   function $(id) { return document.getElementById(id); }
@@ -10,6 +17,7 @@ import { setTheme, getTheme, setAccent, getAccent } from './theme.js';
     const themeSelect = $('theme_select');
     const themeHelp = $('theme_help');
     const accentInput = $('accent_color');
+    const fontSizeSelect = $('font_size_select');
     function updateThemeHelp(theme) {
       if (themeHelp) {
         themeHelp.textContent = theme === 'dark'
@@ -34,6 +42,14 @@ import { setTheme, getTheme, setAccent, getAccent } from './theme.js';
       if (saved) accentInput.value = saved;
       accentInput.addEventListener('input', () => {
         setAccent(accentInput.value);
+      });
+    }
+
+    if (fontSizeSelect) {
+      const savedSize = (await getBaseFontSize()) || '16px';
+      fontSizeSelect.value = savedSize;
+      fontSizeSelect.addEventListener('change', () => {
+        setBaseFontSize(fontSizeSelect.value);
       });
     }
 

--- a/ui/theme.css
+++ b/ui/theme.css
@@ -1,6 +1,7 @@
 /* global tokens */
 :root {
   --font: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  --base-font-size: 16px;
   --space-xs: 0.25rem;
   --space-sm: 0.5rem;
   --space-md: 1rem;
@@ -10,6 +11,7 @@
 
 body {
   font-family: var(--font);
+  font-size: var(--base-font-size);
 }
 
 [data-theme="dark"] {

--- a/ui/theme.js
+++ b/ui/theme.js
@@ -5,6 +5,7 @@ import { Store } from '@tauri-apps/plugin-store';
 
 const THEME_KEY = 'theme';
 const ACCENT_KEY = 'accent';
+const FONT_SIZE_KEY = 'base_font_size';
 let store;
 try {
   store = new Store('settings.dat');
@@ -60,5 +61,30 @@ export async function getAccent() {
   return localStorage.getItem(ACCENT_KEY);
 }
 
+export async function setBaseFontSize(size) {
+  if (store) {
+    try {
+      await store.set(FONT_SIZE_KEY, size);
+      await store.save();
+    } catch (_) {
+      localStorage.setItem(FONT_SIZE_KEY, size);
+    }
+  } else {
+    localStorage.setItem(FONT_SIZE_KEY, size);
+  }
+  document.documentElement.style.setProperty('--base-font-size', size);
+}
+
+export async function getBaseFontSize() {
+  if (store) {
+    try {
+      const size = await store.get(FONT_SIZE_KEY);
+      if (size) return size;
+    } catch (_) {}
+  }
+  return localStorage.getItem(FONT_SIZE_KEY);
+}
+
 getTheme().then((savedTheme) => setTheme(savedTheme || 'dark'));
 getAccent().then((savedAccent) => savedAccent && setAccent(savedAccent));
+getBaseFontSize().then((savedSize) => savedSize && setBaseFontSize(savedSize));


### PR DESCRIPTION
## Summary
- add font size dropdown to settings
- persist selected base font size across sessions
- apply `--base-font-size` to body styling for scalable typography

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: vite: not found)


------
https://chatgpt.com/codex/tasks/task_e_68c5d81298e483259296e11a5fe9e745