### PR TITLE
Highlight active sidebar link

### DIFF
--- a/ui/sidebar.css
+++ b/ui/sidebar.css
@@ -24,6 +24,7 @@
   border: none;
   width: 100%;
   cursor: pointer;
+  transition: background 0.2s, border-color 0.2s, color 0.2s;
 }
 #sidebar a:hover,
 #sidebar button:hover {
@@ -37,6 +38,22 @@
   width: 24px;
   height: 24px;
   fill: var(--icon);
+}
+
+#sidebar a:focus-visible {
+  outline: none;
+  background: var(--panel-hover-bg);
+}
+
+#sidebar a.active {
+  border-left: 4px solid var(--accent);
+  background: var(--panel-hover-bg);
+}
+
+#sidebar a.active svg,
+#sidebar a:hover svg,
+#sidebar a:focus-visible svg {
+  fill: var(--accent);
 }
 #sidebar-toggle {
   position: fixed;

--- a/ui/sidebar.js
+++ b/ui/sidebar.js
@@ -1,0 +1,30 @@
+(function () {
+  function init() {
+    const sidebar = document.getElementById('sidebar');
+    if (!sidebar) return;
+
+    const toggle = document.getElementById('sidebar-toggle');
+    if (toggle) {
+      toggle.addEventListener('click', () => {
+        sidebar.classList.toggle('open');
+      });
+    }
+
+    const current = window.location.pathname.replace(/\/index\.html$/, '/');
+    const links = sidebar.querySelectorAll('a[href]');
+    links.forEach(link => {
+      const linkPath = new URL(link.getAttribute('href'), window.location.href)
+        .pathname.replace(/\/index\.html$/, '/');
+      if (linkPath === current) {
+        link.classList.add('active');
+        link.setAttribute('aria-current', 'page');
+      }
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## Summary
- mark current page link as active within sidebar and toggle with aria-current
- add focus/active styles and transitions for sidebar links

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest` *(fails: ModuleNotFoundError: No module named 'scipy.signal'; 'scipy' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d88012a88325841c57b53436de89