### PR TITLE
Gracefully handle Tauri app initialization errors

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -445,7 +445,7 @@ fn main() {
         eprintln!("failed to create models directory: {}", e);
     }
 
-    tauri::Builder::default()
+    if let Err(e) = tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(Builder::new().build())
@@ -464,5 +464,7 @@ fn main() {
             musiclang::download_model
         ])
         .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+    {
+        eprintln!("error while running tauri application: {}", e);
+    }
 }


### PR DESCRIPTION
## Summary
- Replace panic-based expect with error handling in main
- Log Tauri initialization errors instead of aborting

## Testing
- `cargo check` *(fails: failed to download config.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d89ab17c8325a34909808ff41d3a