### PR TITLE
refactor(ui): use lucide icons for sidebar

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -10,7 +10,8 @@
     "@tauri-apps/api": "^2",
     "react": "^18",
     "react-dom": "^18",
-    "react-router-dom": "^6"
+    "react-router-dom": "^6",
+    "lucide-react": "^0.379.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4",

--- a/ui/sidebar.css
+++ b/ui/sidebar.css
@@ -36,7 +36,7 @@
 #sidebar svg {
   width: 24px;
   height: 24px;
-  fill: var(--icon);
+  color: var(--icon);
 }
 #sidebar-toggle {
   position: fixed;
@@ -51,7 +51,7 @@
 #sidebar-toggle svg {
   width: 24px;
   height: 24px;
-  fill: var(--icon);
+  color: var(--icon);
 }
 @media (min-width: 768px) {
   #sidebar {

--- a/ui/src/components/Sidebar.jsx
+++ b/ui/src/components/Sidebar.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import '../../sidebar.css';
+import { Music, Dice1, Settings, BarChart2, Box, CircuitBoard, Menu } from 'lucide-react';
 
 export default function Sidebar() {
   const navigate = useNavigate();
@@ -20,48 +21,22 @@ export default function Sidebar() {
     <>
       <nav id="sidebar" className={open ? 'open' : ''}>
         <button aria-label="Music Generator" onClick={() => handleNavigate('/generate')}>
-          <svg viewBox="0 0 64 64" aria-hidden="true" fill="var(--icon)">
-            <path d="M48 4v32.9c-2.3-1.4-5-2.2-8-2.2-6.6 0-12 4.5-12 10s5.4 10 12 10 12-4.5 12-10V14h12V4H48z"/>
-          </svg>
+          <Music strokeWidth={2} />
         </button>
         <button aria-label="D&D" onClick={() => handleNavigate('/dnd')}>
-          <svg viewBox="0 0 24 24" aria-hidden="true" fill="var(--icon)">
-            <polygon points="12,2 2,12 12,22 22,12"/>
-          </svg>
+          <Dice1 strokeWidth={2} />
         </button>
         <button aria-label="Settings" onClick={() => handleNavigate('/settings')}>
-          <svg viewBox="0 0 24 24" aria-hidden="true" fill="var(--icon)">
-            <circle cx="12" cy="12" r="3"/>
-            <rect x="11" y="2" width="2" height="4"/>
-            <rect x="11" y="18" width="2" height="4"/>
-            <rect x="2" y="11" width="4" height="2"/>
-            <rect x="18" y="11" width="4" height="2"/>
-            <rect x="4.22" y="4.22" width="2" height="4" transform="rotate(-45 5.22 6.22)"/>
-            <rect x="17.78" y="15.78" width="2" height="4" transform="rotate(-45 18.78 17.78)"/>
-            <rect x="4.22" y="15.78" width="2" height="4" transform="rotate(45 5.22 17.78)"/>
-            <rect x="17.78" y="4.22" width="2" height="4" transform="rotate(45 18.78 6.22)"/>
-          </svg>
+          <Settings strokeWidth={2} />
         </button>
         <button aria-label="Train Model" onClick={() => handleNavigate('/train')}>
-          <svg viewBox="0 0 24 24" aria-hidden="true" fill="var(--icon)">
-            <rect x="4" y="10" width="3" height="10"/>
-            <rect x="10" y="6" width="3" height="14"/>
-            <rect x="16" y="2" width="3" height="18"/>
-          </svg>
+          <BarChart2 strokeWidth={2} />
         </button>
         <button aria-label="Manage Models" onClick={() => handleInvoke('open_path', { path: 'models' })}>
-          <svg viewBox="0 0 24 24" aria-hidden="true" fill="var(--icon)">
-            <path d="M3 7l9-5 9 5-9 5-9-5zm0 5l9 5 9-5v10l-9 5-9-5z"/>
-          </svg>
+          <Box strokeWidth={2} />
         </button>
         <button aria-label="ONNX Crafter" onClick={() => handleNavigate('/onnx')}>
-          <svg viewBox="0 0 24 24" aria-hidden="true" fill="var(--icon)">
-            <circle cx="12" cy="5" r="3"/>
-            <circle cx="6" cy="12" r="3"/>
-            <circle cx="18" cy="12" r="3"/>
-            <circle cx="12" cy="19" r="3"/>
-            <path d="M12 8v8M9 12h6M8 11l-2 2M16 11l2 2" stroke="var(--icon)" strokeWidth="1" fill="none"/>
-          </svg>
+          <CircuitBoard strokeWidth={2} />
         </button>
       </nav>
       <button
@@ -69,9 +44,7 @@ export default function Sidebar() {
         aria-label="Toggle sidebar"
         onClick={() => setOpen(o => !o)}
       >
-        <svg viewBox="0 0 24 24" aria-hidden="true" fill="var(--icon)">
-          <path d="M4 6h16v2H4V6zm0 5h16v2H4v-2zm0 5h16v2H4v-2z"/>
-        </svg>
+        <Menu strokeWidth={2} />
       </button>
     </>
   );


### PR DESCRIPTION
## Summary
- replace inline sidebar SVGs with Lucide icons for consistent styling
- color icons via CSS variable for theme compatibility
- add Lucide icon library dependency

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite: not found)*
- `pytest` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'random')*

------
https://chatgpt.com/codex/tasks/task_e_68c5d858273c83258500e07ad7d690f6