### PR TITLE
chore: point Tauri to built Vite assets

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,7 +4,8 @@
   "productName": "Blossom Music Generator",
   "version": "0.1.0",
   "build": {
-    "frontendDist": "../ui"
+    "frontendDist": "../ui/dist",
+    "devUrl": "http://localhost:5173"
   },
   "app": {
     "windows": [


### PR DESCRIPTION
## Summary
- point Tauri build to `ui/dist`
- add `devUrl` for Vite live reloading

## Testing
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tauri-apps%2fapi)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d9b1163c83259e2320c3cbd4f7b7