### PR TITLE
Use relative asset paths in UI HTML

### DIFF
--- a/ui/dnd.html
+++ b/ui/dnd.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <title>Dungeons & Dragons</title>
   <script type="module" src="./theme.js"></script>
-  <link rel="stylesheet" href="/ui/theme.css">
+  <link rel="stylesheet" href="./theme.css">
   <style>
     body {
       background: var(--bg);

--- a/ui/generate.html
+++ b/ui/generate.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <title>Blossom Render</title>
   <script type="module" src="./theme.js"></script>
-  <link rel="stylesheet" href="/ui/theme.css">
+  <link rel="stylesheet" href="./theme.css">
   <style>
     body { background: var(--bg); color: var(--text); }
     label { display: block; margin-bottom: var(--space-sm); }
@@ -71,6 +71,6 @@
   </div>
 
   <script type="module" src="./topbar.js"></script>
-  <script src="/ui/app.js"></script>
+  <script src="./app.js"></script>
 </body>
 </html>

--- a/ui/models.html
+++ b/ui/models.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <title>Available Models</title>
   <script type="module" src="./theme.js"></script>
-  <link rel="stylesheet" href="/ui/theme.css">
+  <link rel="stylesheet" href="./theme.css">
   <style>
     body {
       background: var(--bg);
@@ -27,6 +27,6 @@
   <h1>Available Models</h1>
   <ul id="models"></ul>
   <script type="module" src="./topbar.js"></script>
-  <script src="/ui/models.js"></script>
+  <script src="./models.js"></script>
 </body>
 </html>

--- a/ui/settings.html
+++ b/ui/settings.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <title>Settings</title>
   <script type="module" src="./theme.js"></script>
-  <link rel="stylesheet" href="/ui/theme.css">
+  <link rel="stylesheet" href="./theme.css">
   <style>
     body { background: var(--bg); color: var(--text); }
     label { display: block; margin-bottom: var(--space-sm); }

--- a/ui/train.html
+++ b/ui/train.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <title>Train Model</title>
   <script type="module" src="./theme.js"></script>
-  <link rel="stylesheet" href="/ui/theme.css">
+  <link rel="stylesheet" href="./theme.css">
   <style>
     body {
       background: var(--bg);
@@ -34,6 +34,6 @@
   <pre id="log"></pre>
 
   <script type="module" src="./topbar.js"></script>
-  <script src="/ui/train.js"></script>
+  <script src="./train.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Use relative paths for CSS/JS assets in UI HTML pages so they work when opened directly

## Testing
- `curl -I http://localhost:8000/generate.html`
- `curl -I http://localhost:8000/train.html`
- `curl -I http://localhost:8000/models.html`
- `curl -I http://localhost:8000/settings.html`
- `curl -I http://localhost:8000/dnd.html`
- `curl -I http://localhost:8000/theme.css`
- `curl -I http://localhost:8000/app.js`
- `curl -I http://localhost:8000/train.js`
- `curl -I http://localhost:8000/models.js`


------
https://chatgpt.com/codex/tasks/task_e_68c5d9b7544c8325a980ae7c46f1af5d