### PR TITLE
feat: add model selection settings

### DIFF
--- a/brain/ollama_client.py
+++ b/brain/ollama_client.py
@@ -13,8 +13,9 @@ Example
 >>> text = generate("Write a short poem about music.")
 >>> print(text)
 
-The model used can be configured with the ``OLLAMA_MODEL`` environment
-variable; it defaults to ``"mistral"``.
+The model used can be configured with the ``LLM_MODEL`` environment
+variable (falling back to ``OLLAMA_MODEL`` for compatibility) and defaults
+to ``"mistral"``.
 """
 
 import json
@@ -29,7 +30,7 @@ __all__ = ["generate", "OllamaError"]
 
 
 _URL = "http://localhost:11434/api/generate"
-_DEFAULT_MODEL = os.getenv("OLLAMA_MODEL", "mistral")
+_DEFAULT_MODEL = os.getenv("LLM_MODEL", os.getenv("OLLAMA_MODEL", "mistral"))
 _TIMEOUT = 30.0
 
 

--- a/ears/whisper_service.py
+++ b/ears/whisper_service.py
@@ -18,6 +18,7 @@ from typing import AsyncIterator, Optional
 
 import numpy as np
 from faster_whisper import WhisperModel
+import os
 
 
 @dataclass
@@ -50,11 +51,12 @@ class WhisperService:
 
     def __init__(
         self,
-        model_path: str = "small",
+        model_path: Optional[str] = None,
         *,
         device: str = "cuda",
         compute_type: str = "float16",
     ) -> None:
+        model_path = model_path or os.getenv("WHISPER_MODEL", "small")
         self._model = WhisperModel(model_path, device=device, compute_type=compute_type)
 
     async def transcribe(self, pcm: bytes) -> AsyncIterator[TranscriptionSegment]:

--- a/mouth/tts.py
+++ b/mouth/tts.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 import hashlib
 import json
 import time
+import os
 from pathlib import Path
 from typing import Optional, Union
 
@@ -93,6 +94,7 @@ class TTSEngine:
         if backend == "piper":
             from .backends.piper import PiperBackend
 
+            backend_kwargs.setdefault("model_path", os.getenv("PIPER_VOICE", "narrator"))
             self.backend: TTSBackend = PiperBackend(**backend_kwargs)
         else:  # pragma: no cover - defensive programming
             raise ValueError(f"Unsupported TTS backend: {backend}")

--- a/ui/src/api/models.js
+++ b/ui/src/api/models.js
@@ -1,0 +1,10 @@
+import { invoke } from "@tauri-apps/api/tauri";
+
+export const listWhisper = () => invoke("list_whisper");
+export const setWhisper = (model) => invoke("set_whisper", { model });
+
+export const listPiper = () => invoke("list_piper");
+export const setPiper = (voice) => invoke("set_piper", { voice });
+
+export const listLlm = () => invoke("list_llm");
+export const setLlm = (model) => invoke("set_llm", { model });

--- a/ui/src/pages/Settings.jsx
+++ b/ui/src/pages/Settings.jsx
@@ -1,7 +1,80 @@
+import { useEffect, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
+import {
+  listWhisper,
+  setWhisper as apiSetWhisper,
+  listPiper,
+  setPiper as apiSetPiper,
+  listLlm,
+  setLlm as apiSetLlm,
+} from "../api/models";
+
 export default function Settings() {
+  const [whisper, setWhisper] = useState({ options: [], selected: "" });
+  const [piper, setPiper] = useState({ options: [], selected: "" });
+  const [llm, setLlm] = useState({ options: [], selected: "" });
+
+  useEffect(() => {
+    const load = async () => {
+      setWhisper(await listWhisper());
+      setPiper(await listPiper());
+      setLlm(await listLlm());
+    };
+    load();
+    const unlisten = listen("settings::models", () => load());
+    return () => {
+      unlisten.then((f) => f());
+    };
+  }, []);
+
   return (
     <div>
       <h1>Settings</h1>
+      <div>
+        <label>
+          Whisper size
+          <select
+            value={whisper.selected || ""}
+            onChange={(e) => apiSetWhisper(e.target.value)}
+          >
+            {whisper.options.map((o) => (
+              <option key={o} value={o}>
+                {o}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <div>
+        <label>
+          Piper voice
+          <select
+            value={piper.selected || ""}
+            onChange={(e) => apiSetPiper(e.target.value)}
+          >
+            {piper.options.map((o) => (
+              <option key={o} value={o}>
+                {o}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <div>
+        <label>
+          LLM model
+          <select
+            value={llm.selected || ""}
+            onChange={(e) => apiSetLlm(e.target.value)}
+          >
+            {llm.options.map((o) => (
+              <option key={o} value={o}>
+                {o}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add Settings selects for Whisper size, Piper voice, and LLM model
- expose model selection APIs and Tauri commands using plugin store
- allow Python services to pick models from environment variables

## Testing
- `npm test` (fails: Missing script "test")
- `pytest` (fails: 15 errors during collection)
- `cargo test` (fails: failed to download from crates.io)

------
https://chatgpt.com/codex/tasks/task_e_68c5da4e725883258e285f322b76a45b