### PR TITLE
docs: clarify open_url call

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -422,6 +422,7 @@ fn job_status(registry: State<JobRegistry>, job_id: u64) -> JobState {
 #[tauri::command]
 fn open_path(app: AppHandle, path: String) -> Result<(), String> {
     if let Ok(url) = Url::parse(&path) {
+        // Use new tauri_plugin_opener API which requires an optional identifier
         app.opener()
             .open_url(url, Option::<String>::None)
             .map_err(|e| e.to_string())


### PR DESCRIPTION
## Summary
- document new tauri_plugin_opener API usage for open_url

## Testing
- `cargo build` *(fails: Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*
- `cargo build --locked --offline` *(fails: no matching package named `regex` found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5db99b2648325bba668fd4377e20f