### PR TITLE
feat: run UI dev server automatically

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,6 +4,7 @@
   "productName": "Blossom Music Generator",
   "version": "0.1.0",
   "build": {
+    "beforeDevCommand": "npm --prefix ui run dev",
     "frontendDist": "../ui/dist",
     "devUrl": "http://localhost:5173"
   },


### PR DESCRIPTION
## Summary
- run UI dev server with `beforeDevCommand` in Tauri config

## Testing
- `npm run tauri dev` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e0e733d88325b15270f34b3f6272