### PR TITLE
feat: add audio device enumeration

### DIFF
--- a/ears/__init__.py
+++ b/ears/__init__.py
@@ -23,6 +23,11 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # ImportError and runtime errors if backend missing
     pyannote_diarize = None  # type: ignore[assignment]
 
+try:  # pragma: no cover - optional dependency
+    from .devices import list_devices
+except Exception:  # ImportError and runtime errors if backend missing
+    list_devices = None  # type: ignore[assignment]
+
 __all__ = [
     "DiscordListener",
     "WhisperService",
@@ -30,4 +35,5 @@ __all__ = [
     "TranscriptLogger",
     "run_bot",
     "pyannote_diarize",
+    "list_devices",
 ]

--- a/ears/devices.py
+++ b/ears/devices.py
@@ -1,0 +1,39 @@
+"""List audio input/output devices using sounddevice."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+import json
+
+try:  # pragma: no cover - optional dependency
+    import sounddevice as sd
+except Exception:  # pragma: no cover - handled at runtime
+    sd = None  # type: ignore[assignment]
+
+
+def list_devices() -> Dict[str, List[Dict[str, object]]]:
+    """Return available input and output audio devices.
+
+    The result is a dictionary with ``"input"`` and ``"output"`` keys
+    mapping to lists of ``{"id": int, "name": str}`` objects.
+    """
+    if sd is None:
+        raise RuntimeError("sounddevice is required to list audio devices")
+
+    devices = sd.query_devices()
+    inputs: List[Dict[str, object]] = []
+    outputs: List[Dict[str, object]] = []
+    for idx, info in enumerate(devices):
+        name = info.get("name", f"Device {idx}")
+        if info.get("max_input_channels", 0) > 0:
+            inputs.append({"id": idx, "name": name})
+        if info.get("max_output_channels", 0) > 0:
+            outputs.append({"id": idx, "name": name})
+    return {"input": inputs, "output": outputs}
+
+
+__all__ = ["list_devices"]
+
+
+if __name__ == "__main__":
+    print(json.dumps(list_devices()))


### PR DESCRIPTION
## Summary
- expose list_devices utility for enumerating input/output devices
- add CLI that outputs device list as JSON
- export list_devices in ears package

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'scipy.signal')*

------
https://chatgpt.com/codex/tasks/task_e_68c5e2b4bcdc8325b9e1c19e259d3d92