### PR TITLE
feat: add vault selection and settings import/export

### DIFF
--- a/ui/src/pages/Settings.jsx
+++ b/ui/src/pages/Settings.jsx
@@ -1,5 +1,8 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { listen } from "@tauri-apps/api/event";
+import { open, save } from "@tauri-apps/api/dialog";
+import { Store } from "@tauri-apps/plugin-store";
+import { invoke } from "@tauri-apps/api/tauri";
 import {
   listWhisper,
   setWhisper as apiSetWhisper,
@@ -13,12 +16,15 @@ export default function Settings() {
   const [whisper, setWhisper] = useState({ options: [], selected: "" });
   const [piper, setPiper] = useState({ options: [], selected: "" });
   const [llm, setLlm] = useState({ options: [], selected: "" });
+  const [vault, setVault] = useState("");
+  const settingsStore = useRef(new Store("settings.json"));
 
   useEffect(() => {
     const load = async () => {
       setWhisper(await listWhisper());
       setPiper(await listPiper());
       setLlm(await listLlm());
+      setVault((await settingsStore.current.get("vault")) || "");
     };
     load();
     const unlisten = listen("settings::models", () => load());
@@ -27,9 +33,44 @@ export default function Settings() {
     };
   }, []);
 
+  const chooseVault = async () => {
+    const dir = await open({ directory: true });
+    if (typeof dir === "string") {
+      await invoke("select_vault", { path: dir });
+      await settingsStore.current.set("vault", dir);
+      await settingsStore.current.save();
+      setVault(dir);
+    }
+  };
+
+  const exportSettings = async () => {
+    const file = await save({
+      filters: [{ name: "JSON", extensions: ["json"] }],
+    });
+    if (file) {
+      await settingsStore.current.save(file);
+    }
+  };
+
+  const importSettings = async () => {
+    const file = await open({
+      filters: [{ name: "JSON", extensions: ["json"] }],
+    });
+    if (typeof file === "string") {
+      await settingsStore.current.load(file);
+      setVault((await settingsStore.current.get("vault")) || "");
+    }
+  };
+
   return (
     <div>
       <h1>Settings</h1>
+      <div>
+        <p>Vault: {vault || "(none)"}</p>
+        <button onClick={chooseVault}>Choose Vault</button>
+        <button onClick={exportSettings}>Export Settings</button>
+        <button onClick={importSettings}>Import Settings</button>
+      </div>
       <div>
         <label>
           Whisper size


### PR DESCRIPTION
## Summary
- add `select_vault` Tauri command invoking Python's vault selection
- expose vault selection and settings export/import controls in Settings page

## Testing
- `cargo test` *(fails: failed to download config.json 403)*
- `npm test` *(fails: Missing script: "test")*
- `pytest` *(fails: 15 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e4330dfc8325ac64f7d152c7ac94