### PR TITLE
Install UI packages before Tauri dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ falling back to `localStorage` when the plugin is not available.
    pip install -r requirements.txt
    ```
 
-2. Install Node dependencies and launch the desktop app in development mode:
+2. Install Node dependencies (including the `ui/` front-end) and launch the desktop app in development mode:
 
    ```bash
    npm install
+   npm install --prefix ui
    npm run tauri dev
    ```
 
@@ -40,7 +41,8 @@ falling back to `localStorage` when the plugin is not available.
 
 The `start.py` helper creates a persistent virtual environment in `.venv`
 (reusing it on subsequent runs), installs the packages from `requirements.txt`
-if needed, and aborts if installation fails.
+if needed, installs Node dependencies in both the repository root and `ui/`,
+and aborts if installation fails.
 
 ## Dependencies
 

--- a/start.py
+++ b/start.py
@@ -89,7 +89,10 @@ def main() -> None:
 
     npm_dir = Path.cwd()
     try:
+        # Install root-level dependencies first
         subprocess.run([npm_path, "install"], cwd=npm_dir, check=True)
+        # Then install UI dependencies (Vite, React, etc.)
+        subprocess.run([npm_path, "install"], cwd=npm_dir / "ui", check=True)
     except subprocess.CalledProcessError:
         print("Failed to install NPM dependencies", file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
## Summary
- install root and `ui/` npm packages in `start.py`
- document the `ui/` install step in README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'scipy.signal'; 'scipy' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e43c53208325946b9223e5ee21e5