### PR TITLE
feat(ui): add audio device selectors

### DIFF
--- a/ui/src/api/devices.js
+++ b/ui/src/api/devices.js
@@ -1,0 +1,5 @@
+import { invoke } from "@tauri-apps/api/tauri";
+
+export const listDevices = () => invoke("list_devices");
+export const setDevices = ({ input, output }) =>
+  invoke("set_devices", { input, output });

--- a/ui/src/pages/Settings.jsx
+++ b/ui/src/pages/Settings.jsx
@@ -8,22 +8,30 @@ import {
   listLlm,
   setLlm as apiSetLlm,
 } from "../api/models";
+import { listDevices, setDevices as apiSetDevices } from "../api/devices";
 
 export default function Settings() {
   const [whisper, setWhisper] = useState({ options: [], selected: "" });
   const [piper, setPiper] = useState({ options: [], selected: "" });
   const [llm, setLlm] = useState({ options: [], selected: "" });
+  const [input, setInput] = useState({ options: [], selected: "" });
+  const [output, setOutput] = useState({ options: [], selected: "" });
 
   useEffect(() => {
     const load = async () => {
       setWhisper(await listWhisper());
       setPiper(await listPiper());
       setLlm(await listLlm());
+      const devices = await listDevices();
+      setInput(devices.input);
+      setOutput(devices.output);
     };
     load();
-    const unlisten = listen("settings::models", () => load());
+    const unlistenModels = listen("settings::models", () => load());
+    const unlistenDevices = listen("settings::devices", () => load());
     return () => {
-      unlisten.then((f) => f());
+      unlistenModels.then((f) => f());
+      unlistenDevices.then((f) => f());
     };
   }, []);
 
@@ -70,6 +78,46 @@ export default function Settings() {
             {llm.options.map((o) => (
               <option key={o} value={o}>
                 {o}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <div>
+        <label>
+          Input device
+          <select
+            value={input.selected || ""}
+            onChange={(e) =>
+              apiSetDevices({
+                input: Number(e.target.value),
+                output: output.selected,
+              })
+            }
+          >
+            {input.options.map((o) => (
+              <option key={o.id} value={o.id}>
+                {o.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <div>
+        <label>
+          Output device
+          <select
+            value={output.selected || ""}
+            onChange={(e) =>
+              apiSetDevices({
+                input: input.selected,
+                output: Number(e.target.value),
+              })
+            }
+          >
+            {output.options.map((o) => (
+              <option key={o.id} value={o.id}>
+                {o.name}
               </option>
             ))}
           </select>


### PR DESCRIPTION
## Summary
- add Tauri API bindings for listing and setting audio devices
- extend Settings page with input/output device selectors and event handling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite: not found)*
- `npm install` *(fails: 403 Forbidden for @tauri-apps/api)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e44e24a48325b33c80bc38887612