### PR TITLE
feat: add vault selection command and settings export/import

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -217,6 +217,20 @@ fn set_llm(app: AppHandle, model: String) -> Result<(), String> {
 }
 
 #[tauri::command]
+fn select_vault(path: String) -> Result<String, String> {
+    let script = "import sys, pathlib; from config.obsidian import select_vault; print(select_vault(pathlib.Path(sys.argv[1])))";
+    let output = Command::new("python")
+        .args(["-c", script, &path])
+        .output()
+        .map_err(|e| e.to_string())?;
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        Err(String::from_utf8_lossy(&output.stderr).trim().to_string())
+    }
+}
+
+#[tauri::command]
 fn app_version() -> Result<Value, String> {
     let app = env!("CARGO_PKG_VERSION").to_string();
     let output = Command::new("python")
@@ -614,6 +628,7 @@ fn main() {
             set_piper,
             list_llm,
             set_llm,
+            select_vault,
             app_version,
             start_job,
             onnx_generate,

--- a/ui/src/pages/Settings.jsx
+++ b/ui/src/pages/Settings.jsx
@@ -1,5 +1,9 @@
 import { useEffect, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
+import { open, save } from "@tauri-apps/api/dialog";
+import { writeTextFile, readTextFile } from "@tauri-apps/api/fs";
+import { Store } from "@tauri-apps/plugin-store";
+import { invoke } from "@tauri-apps/api/tauri";
 import {
   listWhisper,
   setWhisper as apiSetWhisper,
@@ -13,12 +17,19 @@ export default function Settings() {
   const [whisper, setWhisper] = useState({ options: [], selected: "" });
   const [piper, setPiper] = useState({ options: [], selected: "" });
   const [llm, setLlm] = useState({ options: [], selected: "" });
+  const [vault, setVault] = useState("");
+
+  const settingsStore = new Store("settings.dat");
 
   useEffect(() => {
     const load = async () => {
       setWhisper(await listWhisper());
       setPiper(await listPiper());
       setLlm(await listLlm());
+      try {
+        const v = await settingsStore.get("vault_path");
+        if (v) setVault(v);
+      } catch (_) {}
     };
     load();
     const unlisten = listen("settings::models", () => load());
@@ -27,9 +38,50 @@ export default function Settings() {
     };
   }, []);
 
+  const chooseVault = async () => {
+    const selected = await open({ directory: true });
+    if (selected) {
+      await invoke("select_vault", { path: selected });
+      await settingsStore.set("vault_path", selected);
+      await settingsStore.save();
+      setVault(selected);
+    }
+  };
+
+  const exportSettings = async () => {
+    const file = await save({
+      defaultPath: "settings.json",
+      filters: [{ name: "JSON", extensions: ["json"] }],
+    });
+    if (file) {
+      const entries = await settingsStore.entries();
+      const data = Object.fromEntries(entries);
+      await writeTextFile(file, JSON.stringify(data, null, 2));
+    }
+  };
+
+  const importSettings = async () => {
+    const file = await open({ filters: [{ name: "JSON", extensions: ["json"] }] });
+    if (file) {
+      const text = await readTextFile(file);
+      const data = JSON.parse(text);
+      for (const [k, v] of Object.entries(data)) {
+        await settingsStore.set(k, v);
+      }
+      await settingsStore.save();
+      if (data.vault_path) setVault(data.vault_path);
+    }
+  };
+
   return (
     <div>
       <h1>Settings</h1>
+      <div>
+        <p>Vault: {vault || "(none)"}</p>
+        <button onClick={chooseVault}>Choose Vault</button>
+        <button onClick={exportSettings}>Export Settings</button>
+        <button onClick={importSettings}>Import Settings</button>
+      </div>
       <div>
         <label>
           Whisper size


### PR DESCRIPTION
## Summary
- add `select_vault` Tauri command invoking Python vault selection
- extend settings page with vault chooser and settings JSON export/import

## Testing
- `cargo test` *(fails: failed to download from crates.io: CONNECT tunnel failed, response 403)*
- `npm --prefix ui run build` *(fails: vite: not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'scipy.signal'; 'scipy' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e5d528248325b55d04bf9e30d7d5