### PR TITLE
feat: add vault selection and settings export

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -533,6 +533,23 @@ fn job_status(registry: State<JobRegistry>, job_id: u64) -> JobState {
 }
 
 #[tauri::command]
+fn select_vault(path: String) -> Result<(), String> {
+    let status = Command::new("python")
+        .arg("-c")
+        .arg(
+            "import sys; from config.obsidian import select_vault; select_vault(sys.argv[1])",
+        )
+        .arg(&path)
+        .status()
+        .map_err(|e| e.to_string())?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err("Failed to select vault".into())
+    }
+}
+
+#[tauri::command]
 fn open_path(app: AppHandle, path: String) -> Result<(), String> {
     if let Ok(url) = Url::parse(&path) {
         // Use new tauri_plugin_opener API which requires an optional identifier
@@ -619,6 +636,7 @@ fn main() {
             onnx_generate,
             cancel_render,
             job_status,
+            select_vault,
             open_path,
             musiclang::list_musiclang_models,
             musiclang::download_model

--- a/ui/src/pages/Settings.jsx
+++ b/ui/src/pages/Settings.jsx
@@ -1,5 +1,9 @@
 import { useEffect, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
+import { invoke } from "@tauri-apps/api/tauri";
+import { open as openDialog, save as saveDialog } from "@tauri-apps/api/dialog";
+import { readTextFile, writeTextFile } from "@tauri-apps/api/fs";
+import { Store } from "@tauri-apps/plugin-store";
 import {
   listWhisper,
   setWhisper as apiSetWhisper,
@@ -11,11 +15,14 @@ import {
 import { listDevices, setDevices as apiSetDevices } from "../api/devices";
 
 export default function Settings() {
+  const store = new Store("settings.dat");
+  const VAULT_KEY = "vaultPath";
   const [whisper, setWhisper] = useState({ options: [], selected: "" });
   const [piper, setPiper] = useState({ options: [], selected: "" });
   const [llm, setLlm] = useState({ options: [], selected: "" });
   const [input, setInput] = useState({ options: [], selected: "" });
   const [output, setOutput] = useState({ options: [], selected: "" });
+  const [vault, setVault] = useState("");
 
   useEffect(() => {
     const load = async () => {
@@ -25,6 +32,8 @@ export default function Settings() {
       const devices = await listDevices();
       setInput(devices.input);
       setOutput(devices.output);
+      const path = await store.get(VAULT_KEY);
+      setVault(path || "");
     };
     load();
     const unlistenModels = listen("settings::models", () => load());
@@ -35,9 +44,60 @@ export default function Settings() {
     };
   }, []);
 
+  const chooseVault = async () => {
+    const selected = await openDialog({ directory: true });
+    if (typeof selected === "string") {
+      await invoke("select_vault", { path: selected });
+      await store.set(VAULT_KEY, selected);
+      await store.save();
+      setVault(selected);
+    }
+  };
+
+  const exportSettings = async () => {
+    const entries = await store.entries();
+    const data = Object.fromEntries(entries);
+    const filePath = await saveDialog({
+      filters: [{ name: "JSON", extensions: ["json"] }],
+    });
+    if (filePath) {
+      await writeTextFile(filePath, JSON.stringify(data, null, 2));
+    }
+  };
+
+  const importSettings = async () => {
+    const filePath = await openDialog({
+      filters: [{ name: "JSON", extensions: ["json"] }],
+      multiple: false,
+    });
+    if (typeof filePath === "string") {
+      const contents = await readTextFile(filePath);
+      const data = JSON.parse(contents);
+      for (const [key, value] of Object.entries(data)) {
+        await store.set(key, value);
+      }
+      await store.save();
+      if (data[VAULT_KEY]) {
+        setVault(data[VAULT_KEY]);
+      }
+    }
+  };
+
   return (
     <div>
       <h1>Settings</h1>
+      <div>
+        <p>Vault path: {vault || "(none)"}</p>
+        <button type="button" onClick={chooseVault}>
+          Choose Vault
+        </button>
+        <button type="button" onClick={exportSettings}>
+          Export Settings
+        </button>
+        <button type="button" onClick={importSettings}>
+          Import Settings
+        </button>
+      </div>
       <div>
         <label>
           Whisper size


### PR DESCRIPTION
## Summary
- add Tauri command to select an Obsidian vault via Python
- expose vault selection, export and import buttons in settings page

## Testing
- `cargo check -q` *(fails: failed to download from `https://index.crates.io`)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e70a6ab88325ab35c8d490a9759d