### PR TITLE
Add async log panel for Python subprocess output

### DIFF
--- a/ui/src/components/LogPanel.jsx
+++ b/ui/src/components/LogPanel.jsx
@@ -1,0 +1,38 @@
+import { listen } from "@tauri-apps/api/event";
+import { useEffect, useRef, useState } from "react";
+
+export default function LogPanel() {
+  const [lines, setLines] = useState([]);
+  const endRef = useRef(null);
+
+  useEffect(() => {
+    const unlisten = listen("logs::line", (event) => {
+      setLines((prev) => [...prev, event.payload]);
+    });
+    return () => {
+      unlisten.then((f) => f());
+    };
+  }, []);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [lines]);
+
+  return (
+    <div
+      style={{
+        backgroundColor: "#000",
+        color: "#0f0",
+        padding: "0.5rem",
+        maxHeight: "200px",
+        overflowY: "auto",
+        fontFamily: "monospace",
+      }}
+    >
+      {lines.map((line, idx) => (
+        <div key={idx}>{line}</div>
+      ))}
+      <div ref={endRef} />
+    </div>
+  );
+}

--- a/ui/src/pages/Settings.jsx
+++ b/ui/src/pages/Settings.jsx
@@ -14,6 +14,7 @@ import {
 } from "../api/models";
 import { listDevices, setDevices as apiSetDevices } from "../api/devices";
 import { listHotwords, setHotword as apiSetHotword } from "../api/hotwords";
+import LogPanel from "../components/LogPanel";
 
 export default function Settings() {
   const store = new Store("settings.dat");
@@ -225,6 +226,7 @@ export default function Settings() {
           Upload Hotword Model
         </button>
       </div>
+      <LogPanel />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- stream Python subprocess stdout/stderr via `tauri::async_runtime::spawn` and emit `logs::line`
- introduce `LogPanel` React component that listens to these log events
- display the log panel in the Settings page for diagnostics

## Testing
- `cargo test` *(fails: failed to download from crates.io: CONNECT tunnel failed, response 403)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c5ebe5eb908325945207eeea3e1892