### PR TITLE
chore: update tauri-plugin-opener to v2.4.0

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,7 +11,7 @@ serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 tauri-plugin-dialog = "2"
-tauri-plugin-opener = "2"
+tauri-plugin-opener = "2.4.0"
 tauri-plugin-store = "2"
 url = "2"
 futures-sink = "0.3.31"


### PR DESCRIPTION
## Summary
- update tauri-plugin-opener to version 2.4.0

## Testing
- `cargo update -p tauri-plugin-opener` *(failed: CONNECT tunnel failed 403)*
- `cargo check` *(failed: failed to download config.json, CONNECT tunnel 403)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c5ec417b8c83258009717cac65c3c9