### PR TITLE
feat: centralize config management

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -1,0 +1,39 @@
+use std::fs;
+use serde_json::{json, Value, Map};
+use tauri::{AppHandle, Manager};
+use tauri_plugin_store::StoreBuilder;
+
+fn config_store(app: &AppHandle) -> Result<tauri_plugin_store::Store, String> {
+    let path = app
+        .path()
+        .app_config_dir()
+        .map_err(|e| e.to_string())?
+        .join("settings.json");
+    Ok(StoreBuilder::new(app.clone(), path).build())
+}
+
+#[tauri::command]
+pub fn get_config(app: AppHandle, key: String) -> Result<Value, String> {
+    let store = config_store(&app)?;
+    Ok(store.get(key).unwrap_or(Value::Null))
+}
+
+#[tauri::command]
+pub fn set_config(app: AppHandle, key: String, value: Value) -> Result<(), String> {
+    let store = config_store(&app)?;
+    store.insert(key.clone(), value.clone());
+    store.save().map_err(|e| e.to_string())?;
+    app.emit("settings::updated", json!({"key": key, "value": value}))
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn export_config(app: AppHandle, path: String) -> Result<(), String> {
+    let store = config_store(&app)?;
+    let entries = store.entries().map_err(|e| e.to_string())?;
+    let data: Map<String, Value> = entries.into_iter().collect();
+    let text = serde_json::to_string_pretty(&data).map_err(|e| e.to_string())?;
+    fs::write(path, text).map_err(|e| e.to_string())?;
+    Ok(())
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -23,6 +23,7 @@ use tauri_plugin_store::{Builder, StoreBuilder};
 use url::Url;
 mod musiclang;
 mod util;
+mod config;
 use crate::util::list_from_dir;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone)]
@@ -913,6 +914,9 @@ fn main() {
             discord_profile_set,
             select_vault,
             open_path,
+            config::get_config,
+            config::set_config,
+            config::export_config,
             musiclang::list_musiclang_models,
             musiclang::download_model
         ])

--- a/ui/src/api/config.js
+++ b/ui/src/api/config.js
@@ -1,0 +1,5 @@
+import { invoke } from "@tauri-apps/api/tauri";
+
+export const getConfig = (key) => invoke("get_config", { key });
+export const setConfig = (key, value) => invoke("set_config", { key, value });
+export const exportConfig = (path) => invoke("export_config", { path });

--- a/ui/theme.js
+++ b/ui/theme.js
@@ -1,87 +1,57 @@
-// Persist the UI theme using Tauri's store plugin when available.
-// Falls back to `localStorage` when the plugin cannot be loaded
-// (e.g. when running purely in a browser context).
-import { Store } from '@tauri-apps/plugin-store';
+import { getConfig, setConfig } from "./src/api/config.js";
 
 const THEME_KEY = 'theme';
 const ACCENT_KEY = 'accent';
 const FONT_SIZE_KEY = 'base_font_size';
-let store;
-try {
-  store = new Store('settings.dat');
-} catch (_) {
-  store = null;
-}
 
 export async function setTheme(theme) {
-  if (store) {
-    try {
-      await store.set(THEME_KEY, theme);
-      await store.save();
-    } catch (_) {
-      localStorage.setItem(THEME_KEY, theme);
-    }
-  } else {
+  try {
+    await setConfig(THEME_KEY, theme);
+  } catch (_) {
     localStorage.setItem(THEME_KEY, theme);
   }
   document.documentElement.dataset.theme = theme;
 }
 
 export async function getTheme() {
-  if (store) {
-    try {
-      const theme = await store.get(THEME_KEY);
-      if (theme) return theme;
-    } catch (_) {}
-  }
+  try {
+    const theme = await getConfig(THEME_KEY);
+    if (theme) return theme;
+  } catch (_) {}
   return localStorage.getItem(THEME_KEY);
 }
 
 export async function setAccent(color) {
-  if (store) {
-    try {
-      await store.set(ACCENT_KEY, color);
-      await store.save();
-    } catch (_) {
-      localStorage.setItem(ACCENT_KEY, color);
-    }
-  } else {
+  try {
+    await setConfig(ACCENT_KEY, color);
+  } catch (_) {
     localStorage.setItem(ACCENT_KEY, color);
   }
   document.documentElement.style.setProperty('--accent', color);
 }
 
 export async function getAccent() {
-  if (store) {
-    try {
-      const color = await store.get(ACCENT_KEY);
-      if (color) return color;
-    } catch (_) {}
-  }
+  try {
+    const color = await getConfig(ACCENT_KEY);
+    if (color) return color;
+  } catch (_) {}
   return localStorage.getItem(ACCENT_KEY);
 }
 
 export async function setBaseFontSize(size) {
-  if (store) {
-    try {
-      await store.set(FONT_SIZE_KEY, size);
-      await store.save();
-    } catch (_) {
-      localStorage.setItem(FONT_SIZE_KEY, size);
-    }
-  } else {
+  try {
+    await setConfig(FONT_SIZE_KEY, size);
+  } catch (_) {
     localStorage.setItem(FONT_SIZE_KEY, size);
   }
   document.documentElement.style.setProperty('--base-font-size', size);
 }
 
 export async function getBaseFontSize() {
-  if (store) {
-    try {
-      const size = await store.get(FONT_SIZE_KEY);
-      if (size) return size;
-    } catch (_) {}
-  }
+  try {
+    const size = await getConfig(FONT_SIZE_KEY);
+    if (size) return size;
+  } catch (_) {}
   return localStorage.getItem(FONT_SIZE_KEY);
 }
 


### PR DESCRIPTION
## Summary
- add `config.rs` module to handle app settings
- expose `get_config`, `set_config`, and `export_config` commands in `main.rs`
- update React app to use config API helpers and new theme persistence

## Testing
- `cargo check --manifest-path src-tauri/Cargo.toml` *(failed: failed to download crates)*
- `npm run build` *(failed: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5edd080c483258e4f2d991da8e133