### PR TITLE
feat: use dialog plugin

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -10,7 +10,7 @@ tempfile = "3"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"] }
-tauri-plugin-dialog = "2"
+tauri-plugin-dialog = "2.4.0"
 tauri-plugin-opener = "2.4.0"
 tauri-plugin-store = "2"
 url = "2"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -15,9 +15,9 @@ use std::{
 
 use regex::Regex;
 use serde_json::{json, Value};
-use tauri::api::dialog::blocking::message;
 use tauri::Emitter;
 use tauri::{async_runtime, AppHandle, Manager, State};
+use tauri_plugin_dialog::DialogExt;
 use tauri_plugin_opener::OpenerExt;
 use tauri_plugin_store::{Builder, StoreBuilder};
 use url::Url;
@@ -873,11 +873,9 @@ fn main() {
                 let status = Command::new("python").arg("start.py").status();
                 if !status.map(|s| s.success()).unwrap_or(false) {
                     if let Some(window) = app.get_window("main") {
-                        message(
-                            Some(&window),
-                            "Setup Error",
-                            "Failed to set up Python environment.",
-                        );
+                        window
+                            .dialog()
+                            .message("Setup Error", "Failed to set up Python environment.");
                     }
                     return Err("Python setup failed".into());
                 }


### PR DESCRIPTION
## Summary
- use tauri dialog plugin API for error messages
- declare tauri-plugin-dialog dependency

## Testing
- `cargo check` *(fails: Failed to download dependency index)*

------
https://chatgpt.com/codex/tasks/task_e_68c5eddaea5c8325bcf462a2ac6c4837