### PR TITLE
Avoid cloning AppHandle when building models store

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -204,7 +204,7 @@ fn models_store(app: &AppHandle) -> Result<tauri_plugin_store::Store, String> {
         .app_config_dir()
         .map_err(|e| e.to_string())?
         .join("models.json");
-    Ok(StoreBuilder::new(app.clone(), path).build())
+    Ok(StoreBuilder::new(app, path).build())
 }
 
 fn devices_store(app: &AppHandle) -> Result<tauri_plugin_store::Store, String> {


### PR DESCRIPTION
## Summary
- Avoid unnecessary clone by passing `app` directly to `StoreBuilder` in `models_store`

## Testing
- `cargo test` *(fails: Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*
- `cargo test --locked --offline` *(fails: no matching package named `futures-sink` found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ee0181ec8325a01a29fb4cae3ecc