### PR TITLE
Avoid Output::default in list_llm

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -327,11 +327,12 @@ fn hotword_set(
 
 #[tauri::command]
 fn list_llm(app: AppHandle) -> Result<Value, String> {
-    let output = Command::new("ollama")
+    let stdout_bytes = Command::new("ollama")
         .arg("list")
         .output()
-        .unwrap_or_else(|_| Default::default());
-    let stdout = String::from_utf8_lossy(&output.stdout);
+        .map(|o| o.stdout)
+        .unwrap_or_default();
+    let stdout = String::from_utf8_lossy(&stdout_bytes);
     let mut options = Vec::new();
     for line in stdout.lines().skip(1) {
         if let Some(name) = line.split_whitespace().next() {


### PR DESCRIPTION
## Summary
- handle missing `ollama` command by capturing stdout bytes instead of using `Output::default`

## Testing
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ee04a464832590f713918f6b755d