### PR TITLE
refactor: update tauri window event handler

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -320,8 +320,11 @@ fn hotword_set(
     if !status.success() {
         return Err("hotword configuration failed".into());
     }
-    app.emit("settings::hotwords", json!({ "name": name, "enabled": enabled }))
-        .map_err(|e| e.to_string())?;
+    app.emit(
+        "settings::hotwords",
+        json!({ "name": name, "enabled": enabled }),
+    )
+    .map_err(|e| e.to_string())?;
     Ok(())
 }
 
@@ -802,9 +805,7 @@ fn discord_profile_set(guild_id: u64, channel_id: u64, profile: Value) -> Result
 fn select_vault(path: String) -> Result<(), String> {
     let status = Command::new("python")
         .arg("-c")
-        .arg(
-            "import sys; from config.obsidian import select_vault; select_vault(sys.argv[1])",
-        )
+        .arg("import sys; from config.obsidian import select_vault; select_vault(sys.argv[1])")
         .arg(&path)
         .status()
         .map_err(|e| e.to_string())?;
@@ -916,9 +917,9 @@ fn main() {
             musiclang::list_musiclang_models,
             musiclang::download_model
         ])
-        .on_window_event(|event| {
-            if let tauri::WindowEvent::CloseRequested { .. } = event.event() {
-                let registry = event.window().app_handle().state::<JobRegistry>();
+        .on_window_event(|window, event| {
+            if let tauri::WindowEvent::CloseRequested { .. } = event {
+                let registry = window.app_handle().state::<JobRegistry>();
                 let mut jobs = registry.jobs.lock().unwrap();
                 for job in jobs.values_mut() {
                     if let Some(child) = job.child.as_mut() {


### PR DESCRIPTION
## Summary
- adapt Tauri window event callback to new signature

## Testing
- `cargo fmt`
- `cargo test` *(fails: Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*
- `cargo check` *(fails: Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*

------
https://chatgpt.com/codex/tasks/task_e_68c5ee11e6e8832592873a1ff0be6fdf