### PR TITLE
Add settings export/import via Tauri commands

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -914,7 +914,8 @@ fn main() {
             open_path,
             config::get_config,
             config::set_config,
-            config::export_config,
+            config::export_settings,
+            config::import_settings,
             musiclang::list_musiclang_models,
             musiclang::download_model
         ])

--- a/ui/src/api/config.js
+++ b/ui/src/api/config.js
@@ -2,4 +2,5 @@ import { invoke } from "@tauri-apps/api/tauri";
 
 export const getConfig = (key) => invoke("get_config", { key });
 export const setConfig = (key, value) => invoke("set_config", { key, value });
-export const exportConfig = (path) => invoke("export_config", { path });
+export const exportSettings = (path) => invoke("export_settings", { path });
+export const importSettings = (path) => invoke("import_settings", { path });

--- a/ui/src/pages/Settings.jsx
+++ b/ui/src/pages/Settings.jsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { invoke } from "@tauri-apps/api/tauri";
 import { open as openDialog, save as saveDialog } from "@tauri-apps/api/dialog";
-import { readTextFile } from "@tauri-apps/api/fs";
 import {
   listWhisper,
   setWhisper as apiSetWhisper,
@@ -13,7 +12,12 @@ import {
 } from "../api/models";
 import { listDevices, setDevices as apiSetDevices } from "../api/devices";
 import { listHotwords, setHotword as apiSetHotword } from "../api/hotwords";
-import { getConfig, setConfig, exportConfig } from "../api/config";
+import {
+  getConfig,
+  setConfig,
+  exportSettings as apiExportSettings,
+  importSettings as apiImportSettings,
+} from "../api/config";
 import LogPanel from "../components/LogPanel";
 
 export default function Settings() {
@@ -64,7 +68,7 @@ export default function Settings() {
       filters: [{ name: "JSON", extensions: ["json"] }],
     });
     if (filePath) {
-      await exportConfig(filePath);
+      await apiExportSettings(filePath);
     }
   };
 
@@ -74,14 +78,9 @@ export default function Settings() {
       multiple: false,
     });
     if (typeof filePath === "string") {
-      const contents = await readTextFile(filePath);
-      const data = JSON.parse(contents);
-      for (const [key, value] of Object.entries(data)) {
-        await setConfig(key, value);
-      }
-      if (data[VAULT_KEY]) {
-        setVault(data[VAULT_KEY]);
-      }
+      await apiImportSettings(filePath);
+      const path = await getConfig(VAULT_KEY);
+      setVault(path || "");
     }
   };
 


### PR DESCRIPTION
## Summary
- allow exporting and importing entire settings store via new Tauri commands
- expose export/import buttons in Settings page

## Testing
- `npm test` *(fails: Missing script "test")*
- `cargo test` *(fails: failed to download from crates.io: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c5efb2e2b8832597a247e326fca625