### PR TITLE
refactor: use webview window lookup

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -874,7 +874,7 @@ fn main() {
             if !version_ok {
                 let status = Command::new("python").arg("start.py").status();
                 if !status.map(|s| s.success()).unwrap_or(false) {
-                    if let Some(window) = app.get_window("main") {
+                    if let Some(window) = app.get_webview_window("main") {
                         window
                             .dialog()
                             .message("Setup Error", "Failed to set up Python environment.");


### PR DESCRIPTION
## Summary
- use `app.get_webview_window("main")` so plugin dialog attaches to webview window

## Testing
- `cargo check` *(fails: failed to download from https://index.crates.io/config.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f01199f4832598389f9617f64c5e