### PR TITLE
chore: use Tauri core and dialog plugin APIs in UI

### DIFF
--- a/ui/src/api/hotwords.js
+++ b/ui/src/api/hotwords.js
@@ -1,4 +1,4 @@
-import { invoke } from "@tauri-apps/api/tauri";
+import { invoke } from "@tauri-apps/api/core";
 
 export const listHotwords = () => invoke("hotword_get");
 export const setHotword = ({ name, enabled, file }) =>

--- a/ui/src/pages/Settings.jsx
+++ b/ui/src/pages/Settings.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
-import { invoke } from "@tauri-apps/api/tauri";
-import { open as openDialog, save as saveDialog } from "@tauri-apps/api/dialog";
+import { invoke } from "@tauri-apps/api/core";
+import { open as openDialog, save as saveDialog } from "@tauri-apps/plugin-dialog";
 import {
   listWhisper,
   setWhisper as apiSetWhisper,


### PR DESCRIPTION
## Summary
- refactor hotwords API to call invoke from `@tauri-apps/api/core`
- update Settings page to use `invoke` from core and dialog functions from plugin

## Testing
- ⚠️ `npm install` (failed: 403 Forbidden - GET https://registry.npmjs.org/@tauri-apps%2fapi)
- ⚠️ `npm test` (missing script: test)

------
https://chatgpt.com/codex/tasks/task_e_68c5f2639c6c8325981313b79128a3e8