### PR TITLE
chore: align tauri plugin versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
     "tauri": "tauri"
   },
   "dependencies": {
-    "@tauri-apps/plugin-dialog": "2.4.0",
+    "@tauri-apps/plugin-dialog": "2.5.0",
     "@tauri-apps/plugin-shell": "2.3.1",
-    "@tauri-apps/plugin-store": "2.4.0",
-    "@tauri-apps/plugin-opener": "2.4.0"
+    "@tauri-apps/plugin-store": "2.5.0",
+    "@tauri-apps/plugin-opener": "2.5.0"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -10,9 +10,9 @@ tempfile = "3"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"] }
-tauri-plugin-dialog = "2.4.0"
-tauri-plugin-opener = "2.4.0"
-tauri-plugin-store = "2"
+tauri-plugin-dialog = "2.5.0"
+tauri-plugin-opener = "2.5.0"
+tauri-plugin-store = "2.5.0"
 url = "2"
 futures-sink = "0.3.31"
 


### PR DESCRIPTION
## Summary
- align tauri plugin versions to 2.5.0 in Cargo.toml and package.json

## Testing
- `cargo update` *(fails: failed to download config.json; CONNECT tunnel failed, response 403)*
- `npm install` *(fails: 403 Forbidden when fetching @tauri-apps/plugin-dialog)*
- `cargo test` *(fails: failed to download config.json; CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f3b0fd58832582dc3d18ff207bec