### PR TITLE
refactor: chain setup error dialog

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -883,9 +883,7 @@ fn main() {
                 let status = Command::new("python").arg("start.py").status();
                 if !status.map(|s| s.success()).unwrap_or(false) {
                     if let Some(window) = app.get_webview_window("main") {
-                        window
-                            .dialog()
-                            .message("Setup Error", "Failed to set up Python environment.");
+                        window.dialog().title("Setup Error").message("Failed to set up Python environment.");
                     }
                     return Err("Python setup failed".into());
                 }


### PR DESCRIPTION
## Summary
- chain title+message on setup error dialog in Tauri main window

## Testing
- `cargo check` *(fails: failed to download from crates.io: [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*
- `pytest` *(fails: 15 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fda22a0883259cb5db5af41f89f2