### PR TITLE
fix: pin tauri plugin versions

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -10,9 +10,9 @@ tempfile = "3"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"] }
-tauri-plugin-dialog = "2.5.0"
-tauri-plugin-opener = "2.5.0"
-tauri-plugin-store = "2.5.0"
+tauri-plugin-dialog = { version = "2.0.0-rc.8" }
+tauri-plugin-opener = { version = "2.0.0-rc.8" }
+tauri-plugin-store = { version = "2.0.0-rc.8" }
 url = "2"
 futures-sink = "0.3.31"
 


### PR DESCRIPTION
## Summary
- specify explicit versions for tauri plugin dependencies

## Testing
- `cargo update --manifest-path src-tauri/Cargo.toml` *(fails: failed to download from `https://index.crates.io/config.json`)*
- `npm run tauri dev` *(fails: tauri: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c617be2ce08325a4b5967605c0a178