### PR TITLE
chore: update tauri plugin versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
     "tauri": "tauri"
   },
   "dependencies": {
-    "@tauri-apps/plugin-dialog": "2.5.0",
-    "@tauri-apps/plugin-shell": "2.3.1",
-    "@tauri-apps/plugin-store": "2.5.0",
-    "@tauri-apps/plugin-opener": "2.5.0"
+    "@tauri-apps/plugin-dialog": "^2.0.0",
+    "@tauri-apps/plugin-shell": "^2.0.0",
+    "@tauri-apps/plugin-store": "^2.0.0",
+    "@tauri-apps/plugin-opener": "^2.0.0"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2"


### PR DESCRIPTION
## Summary
- replace @tauri-apps plugin versions with ^2.0.0 to avoid nonexistent versions

## Testing
- `npm install` *(fails: 403 Forbidden accessing registry)*

------
https://chatgpt.com/codex/tasks/task_e_68c6198e9f44832590a010b4917f27f7