### PR TITLE
Set window title separately for Python setup error message

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -877,7 +877,8 @@ fn main() {
                 let status = Command::new("python").arg("start.py").status();
                 if !status.map(|s| s.success()).unwrap_or(false) {
                     if let Some(window) = app.get_webview_window("main") {
-                        window.dialog().title("Setup Error").message("Failed to set up Python environment.");
+                        let _ = window.set_title("Setup Error");
+                        window.dialog().message("Failed to set up Python environment.");
                     }
                     return Err("Python setup failed".into());
                 }


### PR DESCRIPTION
## Summary
- set window title before showing Python setup failure dialog

## Testing
- `cargo test` *(fails: spurious network error [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*

------
https://chatgpt.com/codex/tasks/task_e_68c61e0000d48325b9567cb8e1a8b2f3