### PR TITLE
Handle missing app config directory explicitly

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -8,7 +8,7 @@ fn config_store(app: &AppHandle) -> Result<Arc<Store<tauri::Wry>>, String> {
     let path = app
         .path()
         .app_config_dir()
-        .map_err(|e| e.to_string())?
+        .ok_or_else(|| "Unable to resolve app config directory".to_string())?
         .join("settings.json");
     StoreBuilder::new(app, path)
         .build()


### PR DESCRIPTION
## Summary
- improve config store creation by providing explicit error when app config directory can't be resolved

## Testing
- `cargo fmt`
- `cargo check` *(fails: failed to download from `https://index.crates.io/config.json` - CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c61f1996608325ab45bb978e547b15