### PR TITLE
Handle store set errors

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -240,7 +240,9 @@ fn list_whisper(app: AppHandle) -> Result<Value, String> {
 #[tauri::command]
 fn set_whisper(app: AppHandle, model: String) -> Result<(), String> {
     let store = models_store::<tauri::Wry>(&app)?;
-    store.set("whisper".to_string(), model.clone().into());
+    store
+        .set("whisper".to_string(), model.clone().into())
+        .map_err(|e| e.to_string())?;
     store.save().map_err(|e| e.to_string())?;
     std::env::set_var("WHISPER_MODEL", &model);
     app.emit("settings::models", json!({"whisper": model}))
@@ -273,7 +275,9 @@ fn list_piper(app: AppHandle) -> Result<Value, String> {
 #[tauri::command]
 fn set_piper(app: AppHandle, voice: String) -> Result<(), String> {
     let store = models_store::<tauri::Wry>(&app)?;
-    store.set("piper".to_string(), voice.clone().into());
+    store
+        .set("piper".to_string(), voice.clone().into())
+        .map_err(|e| e.to_string())?;
     store.save().map_err(|e| e.to_string())?;
     std::env::set_var("PIPER_VOICE", &voice);
     app.emit("settings::models", json!({"piper": voice}))
@@ -364,7 +368,9 @@ fn list_llm(app: AppHandle) -> Result<Value, String> {
 #[tauri::command]
 fn set_llm(app: AppHandle, model: String) -> Result<(), String> {
     let store = models_store::<tauri::Wry>(&app)?;
-    store.set("llm".to_string(), model.clone().into());
+    store
+        .set("llm".to_string(), model.clone().into())
+        .map_err(|e| e.to_string())?;
     store.save().map_err(|e| e.to_string())?;
     std::env::set_var("LLM_MODEL", &model);
     app.emit("settings::models", json!({"llm": model}))


### PR DESCRIPTION
## Summary
- propagate errors when persisting model selections for whisper, piper, and llm models

## Testing
- `cargo check` *(fails: failed to get `futures-sink` as a dependency - CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c61f5094f08325b175d86569b56052