### PR TITLE
Handle NPC JSON parsing errors

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -40,7 +40,7 @@ fn read_npcs() -> Result<Vec<Npc>, String> {
         return Ok(Vec::new());
     }
     let text = fs::read_to_string(path).map_err(|e| e.to_string())?;
-    let npcs = serde_json::from_str(&text).unwrap_or_default();
+    let npcs = serde_json::from_str(&text).map_err(|e| e.to_string())?;
     Ok(npcs)
 }
 


### PR DESCRIPTION
## Summary
- return JSON parsing error strings from `read_npcs`

## Testing
- `cargo check` *(fails: failed to download from https://index.crates.io/config.json: 403 CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c61f523cc88325bdbf9d9c760628d9