### PR TITLE
refactor: update config directory error handling

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -8,7 +8,7 @@ fn config_store(app: &AppHandle) -> Result<Arc<Store<tauri::Wry>>, String> {
     let path = app
         .path()
         .app_config_dir()
-        .ok_or_else(|| "Unable to resolve app config directory".to_string())?
+        .map_err(|e| e.to_string())?
         .join("settings.json");
     StoreBuilder::new(app, path)
         .build()


### PR DESCRIPTION
## Summary
- adjust config store path resolution to use new `app_config_dir` API that returns `Result`

## Testing
- ⚠️ `cargo build` *(failed: [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*

------
https://chatgpt.com/codex/tasks/task_e_68c6240ebf1c832590fd6d800892c53d