### PR TITLE
Improve error handling for app config directory

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -8,7 +8,7 @@ fn config_store(app: &AppHandle) -> Result<Arc<Store<tauri::Wry>>, String> {
     let path = app
         .path()
         .app_config_dir()
-        .map_err(|e| e.to_string())?
+        .map_err(|_| "Unable to resolve app config directory".to_string())?
         .join("settings.json");
     StoreBuilder::new(app, path)
         .build()


### PR DESCRIPTION
## Summary
- clarify error when resolving app config directory

## Testing
- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: failed to get `futures-sink` as a dependency, 403 CONNECT)*

------
https://chatgpt.com/codex/tasks/task_e_68c625ef81dc8325ac84c4ad7101b0d5