### PR TITLE
refactor: handle store deletion results

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -426,7 +426,9 @@ fn set_devices(app: AppHandle, input: Option<u32>, output: Option<u32>) -> Resul
             .map_err(|e| e.to_string())?;
         env::set_var("INPUT_DEVICE", id.to_string());
     } else {
-        store.remove("input");
+        store
+            .delete("input")
+            .map_err(|e| e.to_string())?;
         env::remove_var("INPUT_DEVICE");
     }
     if let Some(id) = output {
@@ -435,7 +437,9 @@ fn set_devices(app: AppHandle, input: Option<u32>, output: Option<u32>) -> Resul
             .map_err(|e| e.to_string())?;
         env::set_var("OUTPUT_DEVICE", id.to_string());
     } else {
-        store.remove("output");
+        store
+            .delete("output")
+            .map_err(|e| e.to_string())?;
         env::remove_var("OUTPUT_DEVICE");
     }
     store.save().map_err(|e| e.to_string())?;


### PR DESCRIPTION
## Summary
- replace deprecated `remove` with `delete` for device keys
- propagate store deletion errors using `map_err` in `set_devices`

## Testing
- `cargo test` *(fails: failed to download from `https://index.crates.io/config.json` [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*

------
https://chatgpt.com/codex/tasks/task_e_68c62768eb94832581091e8adb81ee54