### PR TITLE
Allow specifying ONNX asset path for model download

### DIFF
--- a/src-tauri/src/musiclang.rs
+++ b/src-tauri/src/musiclang.rs
@@ -75,6 +75,7 @@ pub fn list_musiclang_models() -> Result<Vec<ModelInfo>, String> {
 pub fn download_model(
     app: AppHandle,
     name: &str,
+    onnx_path: &str,
     force: Option<bool>,
 ) -> Result<Vec<String>, String> {
     let file_name = name.split('/').last().unwrap_or(name);
@@ -96,7 +97,10 @@ pub fn download_model(
         return list_from_dir(path.parent().unwrap());
     }
 
-    let url = format!("https://huggingface.co/{}/resolve/main/model.onnx", name);
+    let url = format!(
+        "https://huggingface.co/{}/resolve/main/{}",
+        name, onnx_path
+    );
     let mut response = blocking::get(&url)
         .and_then(|res| res.error_for_status())
         .map_err(|e| {


### PR DESCRIPTION
## Summary
- Accept `onnx_path` argument in `download_model`
- Build model download URL dynamically using the provided path

## Testing
- `cargo test` *(fails: failed to download from https://index.crates.io/config.json [403])*


------
https://chatgpt.com/codex/tasks/task_e_68c644b55bf8832596bee910bd231082