### PR TITLE
Use theme variables for log panel colors

### DIFF
--- a/ui/src/components/LogPanel.jsx
+++ b/ui/src/components/LogPanel.jsx
@@ -21,8 +21,8 @@ export default function LogPanel() {
   return (
     <div
       style={{
-        backgroundColor: "#000",
-        color: "#0f0",
+        backgroundColor: "var(--log-bg)",
+        color: "var(--log-fg)",
         padding: "0.5rem",
         maxHeight: "200px",
         overflowY: "auto",


### PR DESCRIPTION
## Summary
- replace hard-coded log panel colors with CSS variables
- ensure log color variables exist for dark and light themes

## Testing
- `node -e "const fs=require('fs');const css=fs.readFileSync('ui/theme.css','utf8');const dark=css.match(/\[data-theme=\"dark\"]\s*{[^}]*--log-bg:\s*([^;]+);[^}]*--log-fg:\s*([^;]+);/s);const light=css.match(/\[data-theme=\"light\"]\s*{[^}]*--log-bg:\s*([^;]+);[^}]*--log-fg:\s*([^;]+);/s);console.log('dark',dark[1].trim(),dark[2].trim());console.log('light',light[1].trim(),light[2].trim());"`
- `node -e "const fs=require('fs');const c=fs.readFileSync('ui/src/components/LogPanel.jsx','utf8');console.log('bgVar',/backgroundColor:\s*\"var\(--log-bg\)\"/.test(c));console.log('fgVar',/color:\s*\"var\(--log-fg\)\"/.test(c));"`
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c644ae432483258e75e429d4fe004d