### PR TITLE
feat(ui): add card component and lucide icons

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -16,8 +16,8 @@ header {
 .dashboard {
   flex: 1;
   display: grid;
-  gap: var(--space-lg);
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-xl);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   padding: var(--space-xl);
   max-width: 1200px;
   margin: 0 auto;
@@ -27,29 +27,30 @@ header {
 
 .card {
   background: var(--card-bg);
-  border-radius: 12px;
-  padding: var(--space-xl) var(--space-md);
+  border-radius: 8px;
+  padding: var(--space-lg);
   text-align: center;
   text-decoration: none;
   color: var(--text);
-  box-shadow: var(--card-shadow);
-  transition: background 0.3s, transform 0.3s;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: var(--space-md);
 }
 
 .card:hover,
 .card:focus {
   background: var(--card-hover-bg);
+  box-shadow: var(--card-shadow);
   transform: translateY(-4px);
 }
 
 .card-icon {
-  font-size: 3rem;
-  margin-bottom: var(--space-md);
   color: var(--icon);
+  width: 3rem;
+  height: 3rem;
 }
 
 .card-caption {

--- a/ui/src/components/Card.jsx
+++ b/ui/src/components/Card.jsx
@@ -1,0 +1,11 @@
+import { Link } from 'react-router-dom';
+
+export default function Card({ to, icon: Icon, title, children }) {
+  return (
+    <Link className="card" to={to}>
+      {Icon && <Icon className="card-icon" size={48} aria-hidden="true" />}
+      <h2>{title}</h2>
+      {children && <p className="card-caption">{children}</p>}
+    </Link>
+  );
+}

--- a/ui/src/pages/Dashboard.jsx
+++ b/ui/src/pages/Dashboard.jsx
@@ -1,4 +1,5 @@
-import { Link } from 'react-router-dom';
+import Card from '../components/Card.jsx';
+import { Music, Dice5, Settings, Sliders, Package, Brain } from 'lucide-react';
 
 export default function Dashboard() {
   return (
@@ -7,30 +8,12 @@ export default function Dashboard() {
         <h1>Blossom Music Generation</h1>
       </header>
       <main className="dashboard">
-        <Link className="card" to="/generate">
-          <span className="card-icon">🎵</span>
-          <h2>Music Generator</h2>
-        </Link>
-        <Link className="card" to="/dnd">
-          <span className="card-icon">🐉</span>
-          <h2>Dungeons & Dragons</h2>
-        </Link>
-        <Link className="card" to="/settings">
-          <span className="card-icon">⚙️</span>
-          <h2>Settings</h2>
-        </Link>
-        <Link className="card" to="/train">
-          <span className="card-icon">🎚️</span>
-          <h2>Train Model</h2>
-        </Link>
-        <Link className="card" to="/models">
-          <span className="card-icon">📦</span>
-          <h2>Available Models</h2>
-        </Link>
-        <Link className="card" to="/onnx">
-          <span className="card-icon">🧠</span>
-          <h2>ONNX Crafter</h2>
-        </Link>
+        <Card to="/generate" icon={Music} title="Music Generator" />
+        <Card to="/dnd" icon={Dice5} title="Dungeons & Dragons" />
+        <Card to="/settings" icon={Settings} title="Settings" />
+        <Card to="/train" icon={Sliders} title="Train Model" />
+        <Card to="/models" icon={Package} title="Available Models" />
+        <Card to="/onnx" icon={Brain} title="ONNX Crafter" />
       </main>
     </>
   );


### PR DESCRIPTION
## Summary
- replace dashboard emojis with lucide icons and reusable Card component
- standardize card layout spacing and hover states for responsive grid

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: vite not found)

------
https://chatgpt.com/codex/tasks/task_e_68c64e2c0b208325a5c3bac257ee5938