### PR TITLE
Add music generator navigation page

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -1,18 +1,21 @@
 import { Routes, Route } from 'react-router-dom';
 import Dashboard from './pages/Dashboard.jsx';
-import Generate from './pages/Generate.jsx';
 import Dnd from './pages/Dnd.jsx';
 import Settings from './pages/Settings.jsx';
 import Train from './pages/Train.jsx';
 import OnnxCrafter from './pages/OnnxCrafter.jsx';
 import Profiles from './pages/Profiles.jsx';
 import Models from './pages/Models.jsx';
+import Generate from './pages/Generate.jsx';
+import MusicGenerator from './pages/MusicGenerator.jsx';
 
 export default function App() {
   return (
     <>
       <Routes>
         <Route path="/" element={<Dashboard />} />
+        <Route path="/music-generator" element={<MusicGenerator />} />
+        <Route path="/music-generator/algorithmic" element={<Generate />} />
         <Route path="/generate" element={<Generate />} />
         <Route path="/dnd" element={<Dnd />} />
         <Route path="/settings" element={<Settings />} />

--- a/ui/src/pages/Dashboard.jsx
+++ b/ui/src/pages/Dashboard.jsx
@@ -8,7 +8,7 @@ export default function Dashboard() {
         <h1>Blossom Music Generation</h1>
       </header>
       <main className="dashboard">
-        <Card to="/generate" icon={Music} title="Music Generator" />
+        <Card to="/music-generator" icon={Music} title="Music Generator" />
         <Card to="/dnd" icon={Dice5} title="Dungeons & Dragons" />
         <Card to="/settings" icon={Settings} title="Settings" />
         <Card to="/train" icon={Sliders} title="Train Model" />

--- a/ui/src/pages/MusicGenerator.jsx
+++ b/ui/src/pages/MusicGenerator.jsx
@@ -1,0 +1,35 @@
+import Card from '../components/Card.jsx';
+import { Cpu, FileText, BookOpen, Music2 } from 'lucide-react';
+
+export default function MusicGenerator() {
+  return (
+    <>
+      <header>
+        <h1>Music Generator</h1>
+      </header>
+      <main className="dashboard">
+        <Card
+          to="/music-generator/algorithmic"
+          icon={Cpu}
+          title="Algorithmic"
+        />
+        <Card
+          to="/music-generator/phrase"
+          icon={FileText}
+          title="Phrase Model"
+        />
+        <Card
+          to="/music-generator/musiclang"
+          icon={BookOpen}
+          title="MusicLang"
+        />
+        <Card
+          to="/music-generator/musicgen"
+          icon={Music2}
+          title="MusicGen"
+        />
+      </main>
+    </>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add MusicGenerator page listing algorithmic, phrase model, MusicLang, and MusicGen options
- wire dashboard and application routes to new music generator page

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c6505b81048325ad09fb35dc94b978