### PR TITLE
Add placeholder MusicLang and MusicGen pages

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -8,6 +8,8 @@ import Profiles from './pages/Profiles.jsx';
 import Models from './pages/Models.jsx';
 import Generate from './pages/Generate.jsx';
 import MusicGenerator from './pages/MusicGenerator.jsx';
+import MusicLang from './pages/MusicLang.jsx';
+import MusicGen from './pages/MusicGen.jsx';
 
 export default function App() {
   return (
@@ -16,6 +18,8 @@ export default function App() {
         <Route path="/" element={<Dashboard />} />
         <Route path="/music-generator" element={<MusicGenerator />} />
         <Route path="/music-generator/algorithmic" element={<Generate />} />
+        <Route path="/music-generator/musiclang" element={<MusicLang />} />
+        <Route path="/music-generator/musicgen" element={<MusicGen />} />
         <Route path="/generate" element={<Generate />} />
         <Route path="/dnd" element={<Dnd />} />
         <Route path="/settings" element={<Settings />} />

--- a/ui/src/pages/MusicGen.jsx
+++ b/ui/src/pages/MusicGen.jsx
@@ -1,0 +1,8 @@
+export default function MusicGen() {
+  return (
+    <>
+      <h1>Coming Soon</h1>
+    </>
+  );
+}
+

--- a/ui/src/pages/MusicLang.jsx
+++ b/ui/src/pages/MusicLang.jsx
@@ -1,0 +1,8 @@
+export default function MusicLang() {
+  return (
+    <>
+      <h1>Coming Soon</h1>
+    </>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add placeholder pages for MusicLang and MusicGen
- wire new pages into router

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: vite: not found)


------
https://chatgpt.com/codex/tasks/task_e_68c653d73fa4832583e2f0f421e47db2