### PR TITLE
feat(ui): modernize font stack and spacing

### DIFF
--- a/assets/images/onnx_download.svg
+++ b/assets/images/onnx_download.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="800" height="400" font-family="sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="400">
   <rect width="800" height="400" fill="#1e1e1e"/>
   <rect width="800" height="50" fill="#323232"/>
   <text x="10" y="30" fill="#fff" font-size="20">ONNX Crafter</text>

--- a/assets/images/onnx_result.svg
+++ b/assets/images/onnx_result.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="800" height="400" font-family="sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="400">
   <rect width="800" height="400" fill="#1e1e1e"/>
   <rect width="800" height="50" fill="#323232"/>
   <text x="10" y="30" fill="#fff" font-size="20">ONNX Crafter</text>

--- a/ui/src/components/LogPanel.jsx
+++ b/ui/src/components/LogPanel.jsx
@@ -25,8 +25,7 @@ export default function LogPanel() {
         color: "var(--log-fg)",
         padding: "0.5rem",
         maxHeight: "200px",
-        overflowY: "auto",
-        fontFamily: "monospace",
+        overflowY: "auto"
       }}
     >
       {lines.map((line, idx) => (

--- a/ui/theme.css
+++ b/ui/theme.css
@@ -1,12 +1,12 @@
 /* global tokens */
 :root {
-  --font: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  --font: "Inter", "Roboto", "Helvetica Neue", sans-serif;
   --base-font-size: 16px;
   --space-xs: 0.25rem;
-  --space-sm: 0.5rem;
-  --space-md: 1rem;
-  --space-lg: 1.5rem;
-  --space-xl: 2rem;
+  --space-sm: 0.6rem;
+  --space-md: 1.2rem;
+  --space-lg: 1.8rem;
+  --space-xl: 2.4rem;
 }
 
 body {


### PR DESCRIPTION
## Summary
- update global font token to Inter/Roboto/Helvetica Neue stack
- scale spacing tokens for improved hierarchy
- remove hardcoded font usage from log panel and SVG assets

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite not found after install attempt)*
- `pytest tests/test_utils.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68c655f17ab48325ba2650a676a8f437