### PR TITLE
feat: add adjustable font size

### DIFF
--- a/ui/src/pages/Settings.jsx
+++ b/ui/src/pages/Settings.jsx
@@ -53,9 +53,11 @@ export default function Settings() {
         setAccentState(defaultAccent || "#ff4d6d");
       }
     });
-    getBaseFontSize().then((savedSize) =>
-      setBaseFontSizeState(savedSize || "16px")
-    );
+    getBaseFontSize().then((savedSize) => {
+      const size = savedSize || "16px";
+      setBaseFontSizeState(size);
+      setBaseFontSize(size);
+    });
   }, []);
 
   useEffect(() => {
@@ -266,7 +268,7 @@ export default function Settings() {
         </div>
         <div>
           <label>
-            Font size
+            Font Size
             <select
               value={baseFontSize}
               onChange={async (e) => {
@@ -279,6 +281,9 @@ export default function Settings() {
               <option value="18px">Large</option>
             </select>
           </label>
+          <p>
+            Larger fonts improve readability for visually impaired users.
+          </p>
         </div>
       </div>
       <div>

--- a/ui/theme.css
+++ b/ui/theme.css
@@ -9,9 +9,12 @@
   --space-xl: 2.4rem;
 }
 
+html {
+  font-size: var(--base-font-size);
+}
+
 body {
   font-family: var(--font);
-  font-size: var(--base-font-size);
 }
 
 [data-theme="dark"] {


### PR DESCRIPTION
## Summary
- allow switching base font size between default and large
- apply saved font size via CSS variable so text scales globally
- document how larger text improves readability

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd ui && npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c65825f61083258aa060c07ce578fe