### PR TITLE
feat(ui): add models page

### DIFF
--- a/ui/src/api/models.js
+++ b/ui/src/api/models.js
@@ -1,5 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 
+export const listModels = () => invoke("list_models");
+
 export const listWhisper = () => invoke("list_whisper");
 export const setWhisper = (model) => invoke("set_whisper", { model });
 

--- a/ui/src/pages/Models.jsx
+++ b/ui/src/pages/Models.jsx
@@ -1,22 +1,22 @@
 import { useEffect, useState } from "react";
+import { listModels } from "../api/models.js";
 
 export default function Models() {
   const [models, setModels] = useState([]);
 
   useEffect(() => {
-    fetch("/models", { headers: { Accept: "application/json" } })
-      .then((r) => r.json())
-      .then((data) => setModels(data))
+    listModels()
+      .then(setModels)
       .catch((e) => console.error(e));
   }, []);
 
   return (
     <div className="p-md">
-      <h1>Available Models</h1>
+      <h1 className="mb-md">Available Models</h1>
       <ul>
-        {models.map((m) => (
-          <li key={m.name}>
-            <a href={m.url}>{m.name}</a>
+        {models.map((name) => (
+          <li key={name} className="mb-sm">
+            {name}
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- implement React models page powered by Tauri API
- expose listModels API helper

## Testing
- `npm run build` *(fails: sh: 1: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c65823d7388325afb5f968dbe5cb7a