### PR TITLE
refactor: rename generate page to algorithmic

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -6,7 +6,7 @@ import Train from './pages/Train.jsx';
 import OnnxCrafter from './pages/OnnxCrafter.jsx';
 import Profiles from './pages/Profiles.jsx';
 import Models from './pages/Models.jsx';
-import Generate from './pages/Generate.jsx';
+import Algorithmic from './pages/Algorithmic.jsx';
 import MusicGenerator from './pages/MusicGenerator.jsx';
 
 export default function App() {
@@ -15,8 +15,7 @@ export default function App() {
       <Routes>
         <Route path="/" element={<Dashboard />} />
         <Route path="/music-generator" element={<MusicGenerator />} />
-        <Route path="/music-generator/algorithmic" element={<Generate />} />
-        <Route path="/generate" element={<Generate />} />
+        <Route path="/music-generator/algorithmic" element={<Algorithmic />} />
         <Route path="/dnd" element={<Dnd />} />
         <Route path="/settings" element={<Settings />} />
         <Route path="/profiles" element={<Profiles />} />

--- a/ui/src/pages/Algorithmic.jsx
+++ b/ui/src/pages/Algorithmic.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 
-export default function Generate() {
+export default function Algorithmic() {
   const [preset, setPreset] = useState("");
   const [presets, setPresets] = useState([]);
   const [style, setStyle] = useState("");
@@ -14,7 +14,6 @@ export default function Generate() {
   const [outdir, setOutdir] = useState("");
   const [mixConfig, setMixConfig] = useState(null);
   const [arrangeConfig, setArrangeConfig] = useState(null);
-  const [phrase, setPhrase] = useState(false);
   const [drumsModel, setDrumsModel] = useState("");
   const [bassModel, setBassModel] = useState("");
   const [keysModel, setKeysModel] = useState("");
@@ -100,7 +99,6 @@ export default function Generate() {
     if (bassSfz) fd.append("bass_sfz", bassSfz);
     if (drumsSfz) fd.append("drums_sfz", drumsSfz);
     if (melodyMidi) fd.append("melody_midi", melodyMidi);
-    if (phrase) fd.append("phrase", "true");
     if (drumsModel) fd.append("drums_model", drumsModel);
     if (bassModel) fd.append("bass_model", bassModel);
     if (keysModel) fd.append("keys_model", keysModel);
@@ -265,14 +263,6 @@ export default function Generate() {
             type="file"
             onChange={(e) => setArrangeConfig(e.target.files[0] || null)}
           />
-        </label>
-        <label>
-          <input
-            type="checkbox"
-            checked={phrase}
-            onChange={(e) => setPhrase(e.target.checked)}
-          />
-          Phrase backend
         </label>
         <label>
           Drums model


### PR DESCRIPTION
## Summary
- rename Generate page to Algorithmic and drop phrase backend option
- adjust route to serve Algorithmic generator at `/music-generator/algorithmic`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c653d161fc8325b4fdc166a4849812