### PR TITLE
feat: add Piper section to DnD page

### DIFF
--- a/ui/src/api/models.js
+++ b/ui/src/api/models.js
@@ -7,6 +7,7 @@ export const setWhisper = (model) => invoke("set_whisper", { model });
 
 export const listPiper = () => invoke("list_piper");
 export const setPiper = (voice) => invoke("set_piper", { voice });
+export const testPiper = (text, voice) => invoke("test_piper", { text, voice });
 
 export const listLlm = () => invoke("list_llm");
 export const setLlm = (model) => invoke("set_llm", { model });

--- a/ui/src/pages/Dnd.jsx
+++ b/ui/src/pages/Dnd.jsx
@@ -1,12 +1,16 @@
 import { useEffect, useState } from "react";
 import { listNpcs, saveNpc, deleteNpc } from "../api/npcs";
-import { listPiper } from "../api/models";
+import { listPiper, testPiper } from "../api/models";
 
 export default function Dnd() {
   const emptyNpc = { name: "", description: "", prompt: "", voice: "" };
   const [npcs, setNpcs] = useState([]);
   const [voices, setVoices] = useState([]);
   const [current, setCurrent] = useState(emptyNpc);
+  const [section, setSection] = useState("Lore");
+  const [piperVoice, setPiperVoice] = useState("");
+  const [piperText, setPiperText] = useState("");
+  const [piperAudio, setPiperAudio] = useState("");
 
   const refresh = async () => {
     setNpcs(await listNpcs());
@@ -14,7 +18,12 @@ export default function Dnd() {
 
   useEffect(() => {
     refresh();
-    listPiper().then((v) => setVoices(v.options || []));
+    listPiper().then((v) => {
+      setVoices(v.options || []);
+      if (v.selected) {
+        setPiperVoice(v.selected);
+      }
+    });
   }, []);
 
   const edit = (npc) => setCurrent(npc);
@@ -32,46 +41,83 @@ export default function Dnd() {
   return (
     <div>
       <h1>Dungeons & Dragons</h1>
-      <button type="button" onClick={newNpc}>
-        New NPC
-      </button>
-      <div style={{ display: "flex", gap: "1rem" }}>
-        <ul>
-          {npcs.map((npc) => (
-            <li key={npc.name}>
-              <span
-                style={{ cursor: "pointer" }}
-                onClick={() => edit(npc)}
+      <div style={{ display: "flex", gap: "0.5rem", marginBottom: "1rem" }}>
+        {["Lore", "Piper", "Discord", "Chat"].map((name) => (
+          <button key={name} type="button" onClick={() => setSection(name)}>
+            {name}
+          </button>
+        ))}
+      </div>
+      {section === "Lore" && (
+        <div>
+          <button type="button" onClick={newNpc}>
+            New NPC
+          </button>
+          <div style={{ display: "flex", gap: "1rem" }}>
+            <ul>
+              {npcs.map((npc) => (
+                <li key={npc.name}>
+                  <span
+                    style={{ cursor: "pointer" }}
+                    onClick={() => edit(npc)}
+                  >
+                    {npc.name}
+                  </span>
+                  <button type="button" onClick={() => remove(npc.name)}>
+                    Delete
+                  </button>
+                </li>
+              ))}
+            </ul>
+            <div
+              style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}
+            >
+              <input
+                placeholder="Name"
+                value={current.name}
+                onChange={(e) =>
+                  setCurrent({ ...current, name: e.target.value })
+                }
+              />
+              <textarea
+                placeholder="Description"
+                value={current.description}
+                onChange={(e) =>
+                  setCurrent({ ...current, description: e.target.value })
+                }
+              />
+              <textarea
+                placeholder="Prompt"
+                value={current.prompt}
+                onChange={(e) =>
+                  setCurrent({ ...current, prompt: e.target.value })
+                }
+              />
+              <select
+                value={current.voice}
+                onChange={(e) =>
+                  setCurrent({ ...current, voice: e.target.value })
+                }
               >
-                {npc.name}
-              </span>
-              <button type="button" onClick={() => remove(npc.name)}>
-                Delete
+                <option value="">Select voice</option>
+                {voices.map((v) => (
+                  <option key={v} value={v}>
+                    {v}
+                  </option>
+                ))}
+              </select>
+              <button type="button" onClick={save}>
+                Save
               </button>
-            </li>
-          ))}
-        </ul>
+            </div>
+          </div>
+        </div>
+      )}
+      {section === "Piper" && (
         <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
-          <input
-            placeholder="Name"
-            value={current.name}
-            onChange={(e) => setCurrent({ ...current, name: e.target.value })}
-          />
-          <textarea
-            placeholder="Description"
-            value={current.description}
-            onChange={(e) =>
-              setCurrent({ ...current, description: e.target.value })
-            }
-          />
-          <textarea
-            placeholder="Prompt"
-            value={current.prompt}
-            onChange={(e) => setCurrent({ ...current, prompt: e.target.value })}
-          />
           <select
-            value={current.voice}
-            onChange={(e) => setCurrent({ ...current, voice: e.target.value })}
+            value={piperVoice}
+            onChange={(e) => setPiperVoice(e.target.value)}
           >
             <option value="">Select voice</option>
             {voices.map((v) => (
@@ -80,11 +126,49 @@ export default function Dnd() {
               </option>
             ))}
           </select>
-          <button type="button" onClick={save}>
-            Save
+          <textarea
+            placeholder="Enter text"
+            value={piperText}
+            onChange={(e) => setPiperText(e.target.value)}
+          />
+          <button
+            type="button"
+            onClick={async () => {
+              try {
+                const res = await testPiper(piperText, piperVoice);
+                if (res) {
+                  const url = res.url || res.path || res;
+                  setPiperAudio(url);
+                }
+              } catch (err) {
+                console.error(err);
+              }
+            }}
+          >
+            Test
           </button>
+          {piperAudio && (
+            <div>
+              <audio controls src={piperAudio} />
+              <div>
+                <a href={piperAudio} download="piper.mp3">
+                  Download
+                </a>
+              </div>
+            </div>
+          )}
         </div>
-      </div>
+      )}
+      {section === "Discord" && (
+        <div>
+          <p>Discord integration coming soon.</p>
+        </div>
+      )}
+      {section === "Chat" && (
+        <div>
+          <p>Chat coming soon.</p>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add tab navigation to DnD page with Lore, Piper, Discord, Chat sections
- enable testing Piper voices with selectable voice, text input, and audio playback
- expose `testPiper` API wrapper in frontend

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c65b71ad008325898ceefbd8a67593