### PR TITLE
Add placeholder token to Discord bot

### DIFF
--- a/discord_bot.py
+++ b/discord_bot.py
@@ -228,3 +228,9 @@ class BlossomBot(commands.Bot):
 
 
 __all__ = ["BlossomBot"]
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    TOKEN = "YOUR_DISCORD_TOKEN"  # Replace with the actual Blossombot token
+    bot = BlossomBot()
+    bot.run(TOKEN)


### PR DESCRIPTION
## Summary
- allow manual execution of `discord_bot.py` by adding a main block and placeholder Blossombot token

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'scipy.signal'; 'scipy' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68c65c9c31308325a241d384b288f000