### PR TITLE
Add reusable navigation back button

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -10,23 +10,24 @@ import Generate from './pages/Generate.jsx';
 import MusicGenerator from './pages/MusicGenerator.jsx';
 import MusicLang from './pages/MusicLang.jsx';
 import MusicGen from './pages/MusicGen.jsx';
+import BackButton from './components/BackButton.jsx';
 
 export default function App() {
   return (
     <>
       <Routes>
         <Route path="/" element={<Dashboard />} />
-        <Route path="/music-generator" element={<MusicGenerator />} />
-        <Route path="/music-generator/algorithmic" element={<Generate />} />
-        <Route path="/music-generator/musiclang" element={<MusicLang />} />
-        <Route path="/music-generator/musicgen" element={<MusicGen />} />
-        <Route path="/generate" element={<Generate />} />
-        <Route path="/dnd" element={<Dnd />} />
-        <Route path="/settings" element={<Settings />} />
-        <Route path="/profiles" element={<Profiles />} />
-        <Route path="/train" element={<Train />} />
-        <Route path="/onnx" element={<OnnxCrafter />} />
-        <Route path="/models" element={<Models />} />
+        <Route path="/music-generator" element={<><BackButton /><MusicGenerator /></>} />
+        <Route path="/music-generator/algorithmic" element={<><BackButton /><Generate /></>} />
+        <Route path="/music-generator/musiclang" element={<><BackButton /><MusicLang /></>} />
+        <Route path="/music-generator/musicgen" element={<><BackButton /><MusicGen /></>} />
+        <Route path="/generate" element={<><BackButton /><Generate /></>} />
+        <Route path="/dnd" element={<><BackButton /><Dnd /></>} />
+        <Route path="/settings" element={<><BackButton /><Settings /></>} />
+        <Route path="/profiles" element={<><BackButton /><Profiles /></>} />
+        <Route path="/train" element={<><BackButton /><Train /></>} />
+        <Route path="/onnx" element={<><BackButton /><OnnxCrafter /></>} />
+        <Route path="/models" element={<><BackButton /><Models /></>} />
       </Routes>
     </>
   );

--- a/ui/src/components/BackButton.jsx
+++ b/ui/src/components/BackButton.jsx
@@ -1,0 +1,10 @@
+import { useNavigate } from 'react-router-dom';
+
+export default function BackButton() {
+  const navigate = useNavigate();
+  return (
+    <button onClick={() => navigate(-1)} style={{ marginBottom: '1rem' }}>
+      Back
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable `BackButton` component
- place back button on all non-dashboard routes for easier navigation

## Testing
- `npm --prefix ui run build` *(fails: vite not found)*
- `pytest` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'random')*

------
https://chatgpt.com/codex/tasks/task_e_68c65ba8ec8883258533fb9d00137fea