### PR TITLE
Add Piper test API and handle playback path

### DIFF
--- a/ui/src/api/models.js
+++ b/ui/src/api/models.js
@@ -7,7 +7,6 @@ export const setWhisper = (model) => invoke("set_whisper", { model });
 
 export const listPiper = () => invoke("list_piper");
 export const setPiper = (voice) => invoke("set_piper", { voice });
-export const testPiper = (text, voice) => invoke("test_piper", { text, voice });
 
 export const listLlm = () => invoke("list_llm");
 export const setLlm = (model) => invoke("set_llm", { model });

--- a/ui/src/api/piper.js
+++ b/ui/src/api/piper.js
@@ -1,0 +1,4 @@
+import { invoke } from "@tauri-apps/api/core";
+export const testPiper = (voice, text) =>
+    invoke("piper_test", { voice, text });
+

--- a/ui/src/pages/Dnd.jsx
+++ b/ui/src/pages/Dnd.jsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import { listNpcs, saveNpc, deleteNpc } from "../api/npcs";
-import { listPiper, testPiper } from "../api/models";
+import { listPiper } from "../api/models";
+import { testPiper } from "../api/piper";
+import { convertFileSrc } from "@tauri-apps/api/core";
 
 export default function Dnd() {
   const emptyNpc = { name: "", description: "", prompt: "", voice: "" };
@@ -11,6 +13,7 @@ export default function Dnd() {
   const [piperVoice, setPiperVoice] = useState("");
   const [piperText, setPiperText] = useState("");
   const [piperAudio, setPiperAudio] = useState("");
+  const [piperPath, setPiperPath] = useState("");
 
   const refresh = async () => {
     setNpcs(await listNpcs());
@@ -135,9 +138,11 @@ export default function Dnd() {
             type="button"
             onClick={async () => {
               try {
-                const res = await testPiper(piperText, piperVoice);
+                const res = await testPiper(piperVoice, piperText);
                 if (res) {
-                  const url = res.url || res.path || res;
+                  const path = res.path || res;
+                  const url = res.url ? res.url : convertFileSrc(path);
+                  setPiperPath(path);
                   setPiperAudio(url);
                 }
               } catch (err) {
@@ -151,7 +156,7 @@ export default function Dnd() {
             <div>
               <audio controls src={piperAudio} />
               <div>
-                <a href={piperAudio} download="piper.mp3">
+                <a href={piperPath || piperAudio} download="piper.mp3">
                   Download
                 </a>
               </div>


### PR DESCRIPTION
## Summary
- add new Piper API helper to invoke `piper_test`
- wire Dnd page to call the helper and convert returned file path for playback
- store original path to enable MP3 download

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c65df5fe0083259b4c8a51ed75e8ae