### PR TITLE
feat(ui): add back button navigation

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -57,3 +57,8 @@ header {
   margin-top: var(--space-sm);
   font-size: 0.9rem;
 }
+
+.back-button {
+  margin: var(--space-md);
+}
+

--- a/ui/src/components/BackButton.jsx
+++ b/ui/src/components/BackButton.jsx
@@ -1,0 +1,17 @@
+import { useNavigate } from 'react-router-dom';
+
+export default function BackButton() {
+  const navigate = useNavigate();
+  const goBack = () => {
+    if (window.history.state && window.history.state.idx > 0) {
+      navigate(-1);
+    } else {
+      navigate('/');
+    }
+  };
+  return (
+    <button type="button" onClick={goBack} className="back-button">
+      Back
+    </button>
+  );
+}

--- a/ui/src/pages/Dnd.jsx
+++ b/ui/src/pages/Dnd.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { listNpcs, saveNpc, deleteNpc } from "../api/npcs";
 import { listPiper, testPiper } from "../api/models";
+import BackButton from "../components/BackButton.jsx";
 
 export default function Dnd() {
   const emptyNpc = { name: "", description: "", prompt: "", voice: "" };
@@ -40,6 +41,7 @@ export default function Dnd() {
 
   return (
     <div>
+      <BackButton />
       <h1>Dungeons & Dragons</h1>
       <div style={{ display: "flex", gap: "0.5rem", marginBottom: "1rem" }}>
         {["Lore", "Piper", "Discord", "Chat"].map((name) => (

--- a/ui/src/pages/Generate.jsx
+++ b/ui/src/pages/Generate.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import BackButton from "../components/BackButton.jsx";
 
 export default function Generate() {
   const [preset, setPreset] = useState("");
@@ -160,6 +161,7 @@ export default function Generate() {
 
   return (
     <div>
+      <BackButton />
       <h1>Music Generator</h1>
       <div>
         <label>

--- a/ui/src/pages/Models.jsx
+++ b/ui/src/pages/Models.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { listModels } from "../api/models.js";
+import BackButton from "../components/BackButton.jsx";
 
 export default function Models() {
   const [models, setModels] = useState([]);
@@ -12,6 +13,7 @@ export default function Models() {
 
   return (
     <div className="p-md">
+      <BackButton />
       <h1 className="mb-md">Available Models</h1>
       <ul>
         {models.map((name) => (

--- a/ui/src/pages/MusicGen.jsx
+++ b/ui/src/pages/MusicGen.jsx
@@ -1,6 +1,9 @@
+import BackButton from "../components/BackButton.jsx";
+
 export default function MusicGen() {
   return (
     <>
+      <BackButton />
       <h1>Coming Soon</h1>
     </>
   );

--- a/ui/src/pages/MusicGenerator.jsx
+++ b/ui/src/pages/MusicGenerator.jsx
@@ -1,10 +1,12 @@
 import Card from '../components/Card.jsx';
 import { Cpu, FileText, BookOpen, Music2 } from 'lucide-react';
+import BackButton from "../components/BackButton.jsx";
 
 export default function MusicGenerator() {
   return (
     <>
       <header>
+        <BackButton />
         <h1>Music Generator</h1>
       </header>
       <main className="dashboard">

--- a/ui/src/pages/MusicLang.jsx
+++ b/ui/src/pages/MusicLang.jsx
@@ -1,6 +1,9 @@
+import BackButton from "../components/BackButton.jsx";
+
 export default function MusicLang() {
   return (
     <>
+      <BackButton />
       <h1>Coming Soon</h1>
     </>
   );

--- a/ui/src/pages/OnnxCrafter.jsx
+++ b/ui/src/pages/OnnxCrafter.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import './OnnxCrafter.css';
 import { open } from '@tauri-apps/plugin-dialog';
+import BackButton from "../components/BackButton.jsx";
 
 export default function OnnxCrafter() {
   const [log] = useState('');
@@ -12,6 +13,7 @@ export default function OnnxCrafter() {
 
   return (
     <div className="m-md">
+      <BackButton />
       <h1>ONNX Crafter</h1>
       <section id="instructions">
         <h2>Instructions</h2>

--- a/ui/src/pages/PhraseModel.jsx
+++ b/ui/src/pages/PhraseModel.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import BackButton from "../components/BackButton.jsx";
 
 export default function PhraseModel() {
   const [preset, setPreset] = useState("");
@@ -158,6 +159,7 @@ export default function PhraseModel() {
 
   return (
     <div>
+      <BackButton />
       <h1>Phrase Model</h1>
       <div>
         <label>

--- a/ui/src/pages/Profiles.jsx
+++ b/ui/src/pages/Profiles.jsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { getProfile, setProfile } from "../api/discordProfiles";
+import BackButton from "../components/BackButton.jsx";
 
 export default function Profiles() {
   const [guildId, setGuildId] = useState("");
@@ -32,6 +33,7 @@ export default function Profiles() {
 
   return (
     <div>
+      <BackButton />
       <h1>Profiles</h1>
       <div>
         <label>

--- a/ui/src/pages/Settings.jsx
+++ b/ui/src/pages/Settings.jsx
@@ -27,6 +27,7 @@ import {
   setBaseFontSize,
   getBaseFontSize,
 } from "../../theme.js";
+import BackButton from "../components/BackButton.jsx";
 
 export default function Settings() {
   const VAULT_KEY = "vaultPath";
@@ -132,6 +133,7 @@ export default function Settings() {
 
   return (
     <div>
+      <BackButton />
       <h1>Settings</h1>
       <div>
         <p>Vault path: {vault || "(none)"}</p>

--- a/ui/src/pages/Train.jsx
+++ b/ui/src/pages/Train.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { invoke } from "@tauri-apps/api/tauri";
 import { listen } from "@tauri-apps/api/event";
+import BackButton from "../components/BackButton.jsx";
 
 export default function Train() {
   const [dataset, setDataset] = useState(null);
@@ -28,6 +29,7 @@ export default function Train() {
 
   return (
     <div className="m-md">
+      <BackButton />
       <h1>Train Model</h1>
       <form
         onSubmit={(e) => {


### PR DESCRIPTION
## Summary
- add reusable `BackButton` component
- include back button on all pages and basic styling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c65de6b5b48325a7d2645427d63de5