### PR TITLE
Use environment variable for Discord bot token

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,16 @@ during startup warms the cache and eliminates initial latency.
 See ``docs/examples/discord_piper_tts.py`` for an end-to-end snippet that
 joins a voice channel and speaks a line of dialog.
 
+### Running the Discord bot
+
+Set the bot token in the ``DISCORD_TOKEN`` environment variable before
+starting the bot:
+
+```bash
+export DISCORD_TOKEN="your_bot_token"
+python discord_bot.py
+```
+
 
 ## LLM Orchestrator
 

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -231,6 +231,6 @@ __all__ = ["BlossomBot"]
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution
-    TOKEN = "YOUR_DISCORD_TOKEN"  # Replace with the actual Blossombot token
+    TOKEN = os.environ["DISCORD_TOKEN"]
     bot = BlossomBot()
     bot.run(TOKEN)

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -1,5 +1,13 @@
 # Discord Configuration
 
+Set the bot token in the ``DISCORD_TOKEN`` environment variable before
+starting ``discord_bot.py``:
+
+```bash
+export DISCORD_TOKEN="your_bot_token"
+python discord_bot.py
+```
+
 The Discord bot reads command permission rules from `config/discord.yaml` on startup.
 Each top-level key in the file is the name of a slash command (use the full
 `group subcommand` name for grouped commands).  Every command maps to two lists:


### PR DESCRIPTION
## Summary
- Load Discord bot token from DISCORD_TOKEN environment variable instead of hard-coded value
- Document setting DISCORD_TOKEN before running the bot

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install scipy discord.py soundfile numpy` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c65f7846448325aa3edf83133466d6