### PR TITLE
feat: add NPCs section to DnD page

### DIFF
--- a/ui/src/pages/Dnd.jsx
+++ b/ui/src/pages/Dnd.jsx
@@ -45,13 +45,18 @@ export default function Dnd() {
     <div>
       <h1>Dungeons & Dragons</h1>
       <div style={{ display: "flex", gap: "0.5rem", marginBottom: "1rem" }}>
-        {["Lore", "Piper", "Discord", "Chat"].map((name) => (
+        {["Lore", "NPCs", "Piper", "Discord", "Chat"].map((name) => (
           <button key={name} type="button" onClick={() => setSection(name)}>
             {name}
           </button>
         ))}
       </div>
       {section === "Lore" && (
+        <div>
+          <p>Lore coming soon.</p>
+        </div>
+      )}
+      {section === "NPCs" && (
         <div>
           <button type="button" onClick={newNpc}>
             New NPC


### PR DESCRIPTION
## Summary
- add NPCs to DnD navigation buttons
- move NPC creation form to new NPCs section
- replace Lore section with placeholder content

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: vite not found)


------
https://chatgpt.com/codex/tasks/task_e_68c65f1f7cd4832591edbd36e416eea2