### PR TITLE
Ignore environment files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ audio_stems/
 .venv/
 node_modules
 src-tauri/target
+
+# Environment variables
+.env
+*.env.local


### PR DESCRIPTION
## Summary
- ignore `.env` and `.env.local` files

## Testing
- `pytest` *(fails: ModuleNotFoundError for scipy, discord, soundfile and AttributeError in core.sampling)*

------
https://chatgpt.com/codex/tasks/task_e_68c660d262f88325b22d0c8f80e4157d