### PR TITLE
Add chill lofi jam style token

### DIFF
--- a/assets/styles/chill_lofi_jam.json
+++ b/assets/styles/chill_lofi_jam.json
@@ -1,0 +1,5 @@
+{ "swing": 0.15,
+  "drums": { "swing": 0.08 },
+  "synth_defaults": { "lpf_cutoff": 2800.0, "chorus": 0.45, "saturation": 0.35 },
+  "bass": { "tendencies": ["roots", "fifths"] },
+  "sections": ["intro","verse","chorus","verse","chorus","bridge","outro"] }

--- a/core/style.py
+++ b/core/style.py
@@ -14,6 +14,7 @@ class StyleToken(IntEnum):
     LOFI = 0
     ROCK = 1
     CINEMATIC = 2
+    CHILL_LOFI_JAM = 3
 
 
 # Mapping of human readable style names to token IDs used by phrase models


### PR DESCRIPTION
## Summary
- add chill_lofi_jam style configuration
- expose CHILL_LOFI_JAM in StyleToken enum

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'scipy.signal')*

------
https://chatgpt.com/codex/tasks/task_e_68c660bdab90832593fd55ca418274f1