### PR TITLE
feat(ui): add shared icon component

### DIFF
--- a/ui/src/components/Card.jsx
+++ b/ui/src/components/Card.jsx
@@ -1,9 +1,17 @@
 import { Link } from 'react-router-dom';
+import Icon from './Icon.jsx';
 
-export default function Card({ to, icon: Icon, title, children }) {
+export default function Card({ to, icon, title, children }) {
   return (
     <Link className="card" to={to}>
-      {Icon && <Icon className="card-icon" size={48} aria-hidden="true" />}
+      {icon && (
+        <Icon
+          name={icon}
+          size={48}
+          className="card-icon"
+          aria-hidden="true"
+        />
+      )}
       <h2>{title}</h2>
       {children && <p className="card-caption">{children}</p>}
     </Link>

--- a/ui/src/components/Icon.jsx
+++ b/ui/src/components/Icon.jsx
@@ -1,0 +1,32 @@
+import * as LucideIcons from 'lucide-react';
+
+export default function Icon({
+  name,
+  size = 24,
+  strokeWidth = 2,
+  variant = 'mono',
+  className,
+  ...props
+}) {
+  const IconComponent = LucideIcons[name];
+  if (!IconComponent) return null;
+
+  const style = { color: 'var(--icon)' };
+  if (variant === 'duo') {
+    style.fill = 'var(--accent)';
+  } else {
+    style.fill = 'none';
+  }
+
+  return (
+    <IconComponent
+      size={size}
+      strokeWidth={strokeWidth}
+      className={className}
+      style={style}
+      aria-hidden="true"
+      {...props}
+    />
+  );
+}
+

--- a/ui/src/pages/Dashboard.jsx
+++ b/ui/src/pages/Dashboard.jsx
@@ -1,5 +1,4 @@
 import Card from '../components/Card.jsx';
-import { Music, Dice5, Settings, Sliders, Package, Brain } from 'lucide-react';
 
 export default function Dashboard() {
   return (
@@ -8,12 +7,12 @@ export default function Dashboard() {
         <h1>Blossom Music Generation</h1>
       </header>
       <main className="dashboard">
-        <Card to="/music-generator" icon={Music} title="Music Generator" />
-        <Card to="/dnd" icon={Dice5} title="Dungeons & Dragons" />
-        <Card to="/settings" icon={Settings} title="Settings" />
-        <Card to="/train" icon={Sliders} title="Train Model" />
-        <Card to="/models" icon={Package} title="Available Models" />
-        <Card to="/onnx" icon={Brain} title="ONNX Crafter" />
+        <Card to="/music-generator" icon="Music" title="Music Generator" />
+        <Card to="/dnd" icon="Dice5" title="Dungeons & Dragons" />
+        <Card to="/settings" icon="Settings" title="Settings" />
+        <Card to="/train" icon="Sliders" title="Train Model" />
+        <Card to="/models" icon="Package" title="Available Models" />
+        <Card to="/onnx" icon="Brain" title="ONNX Crafter" />
       </main>
     </>
   );

--- a/ui/src/pages/MusicGenerator.jsx
+++ b/ui/src/pages/MusicGenerator.jsx
@@ -1,5 +1,4 @@
 import Card from '../components/Card.jsx';
-import { Cpu, FileText, BookOpen, Music2 } from 'lucide-react';
 
 export default function MusicGenerator() {
   return (
@@ -10,22 +9,22 @@ export default function MusicGenerator() {
       <main className="dashboard">
         <Card
           to="/music-generator/algorithmic"
-          icon={Cpu}
+          icon="Cpu"
           title="Algorithmic"
         />
         <Card
           to="/music-generator/phrase"
-          icon={FileText}
+          icon="FileText"
           title="Phrase Model"
         />
         <Card
           to="/music-generator/musiclang"
-          icon={BookOpen}
+          icon="BookOpen"
           title="MusicLang"
         />
         <Card
           to="/music-generator/musicgen"
-          icon={Music2}
+          icon="Music2"
           title="MusicGen"
         />
       </main>


### PR DESCRIPTION
## Summary
- add theme-aware Icon wrapper that standardizes lucide-react sizing and stroke
- refactor Card and dashboard pages to consume Icon by name

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c662b4740083259efec345237db4b7