### PR TITLE
Add upbeat funk groove style

### DIFF
--- a/assets/styles/upbeat_funk_groove.json
+++ b/assets/styles/upbeat_funk_groove.json
@@ -1,0 +1,5 @@
+{ "swing": 0.05,
+  "drums": { "swing": 0.07 },
+  "synth_defaults": { "lpf_cutoff": 6000.0, "chorus": 0.3, "saturation": 0.2 },
+  "bass": { "tendencies": ["roots", "octaves","fifths"] },
+  "sections": ["intro","verse","chorus","verse","chorus","break","chorus"] }

--- a/core/style.py
+++ b/core/style.py
@@ -15,6 +15,7 @@ class StyleToken(IntEnum):
     ROCK = 1
     CINEMATIC = 2
     CHILL_LOFI_JAM = 3
+    UPBEAT_FUNK_GROOVE = 4
 
 
 # Mapping of human readable style names to token IDs used by phrase models


### PR DESCRIPTION
## Summary
- add upbeat_funk_groove style JSON with swing, synth defaults and bass tendencies
- extend StyleToken enum with UPBEAT_FUNK_GROOVE and automatic token mapping

## Testing
- `python -m py_compile core/style.py`
- `pytest tests/test_style_defaults.py tests/test_style_variations.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy==1.26.4 -q` *(fails: Could not find a version due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68c66377a3b48325857e4d6f39f164f6