### PR TITLE
Add ambient dreamscape style preset

### DIFF
--- a/assets/styles/ambient_dreamscape.json
+++ b/assets/styles/ambient_dreamscape.json
@@ -1,0 +1,5 @@
+{ "swing": 0.0,
+  "drums": { "swing": 0.0 },
+  "synth_defaults": { "lpf_cutoff": 12000.0, "chorus": 0.2, "saturation": 0.05 },
+  "bass": { "tendencies": ["pedal","roots"] },
+  "sections": ["intro","theme","build","breakdown","climax","outro"] }

--- a/core/style.py
+++ b/core/style.py
@@ -15,6 +15,7 @@ class StyleToken(IntEnum):
     ROCK = 1
     CINEMATIC = 2
     CHILL_LOFI_JAM = 3
+    AMBIENT_DREAMSCAPE = 5
 
 
 # Mapping of human readable style names to token IDs used by phrase models


### PR DESCRIPTION
## Summary
- add AMBIENT_DREAMSCAPE style token
- add ambient_dreamscape style JSON preset

## Testing
- `python - <<'PY'
import importlib.util, pathlib
spec = importlib.util.spec_from_file_location('style', pathlib.Path('core/style.py'))
style = importlib.util.module_from_spec(spec)
spec.loader.exec_module(style)
print(style.load_style('ambient_dreamscape'))
PY`
- `pytest` *(fails: No module named 'scipy.signal'; 'scipy' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68c66378927483259e52598dc444c757