### PR TITLE
feat(ui): highlight active cards

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -32,7 +32,9 @@ header {
   text-align: center;
   text-decoration: none;
   color: var(--text);
-  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+  border: 2px solid transparent;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease,
+    border-color 0.2s ease, color 0.2s ease;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -44,13 +46,22 @@ header {
 .card:focus {
   background: var(--card-hover-bg);
   box-shadow: var(--card-shadow);
-  transform: translateY(-4px);
+  transform: translateY(-4px) scale(1.02);
+}
+
+.card.active {
+  border-color: var(--accent);
+}
+
+.card.active .card-icon {
+  color: var(--accent);
 }
 
 .card-icon {
   color: var(--icon);
   width: 3rem;
   height: 3rem;
+  transition: color 0.2s ease;
 }
 
 .card-caption {

--- a/ui/src/components/Card.jsx
+++ b/ui/src/components/Card.jsx
@@ -1,11 +1,14 @@
-import { Link } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 
 export default function Card({ to, icon: Icon, title, children }) {
   return (
-    <Link className="card" to={to}>
+    <NavLink
+      className={({ isActive }) => `card${isActive ? ' active' : ''}`}
+      to={to}
+    >
       {Icon && <Icon className="card-icon" size={48} aria-hidden="true" />}
       <h2>{title}</h2>
       {children && <p className="card-caption">{children}</p>}
-    </Link>
+    </NavLink>
   );
 }


### PR DESCRIPTION
## Summary
- use `NavLink` for cards so the active route is styled
- accent active cards with border and icon color plus hover/focus animations

## Testing
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c662b907208325b5f63c2ece1cbc1c