### PR TITLE
Add acoustic folk ballad style

### DIFF
--- a/assets/styles/acoustic_folk_ballad.json
+++ b/assets/styles/acoustic_folk_ballad.json
@@ -1,0 +1,11 @@
+{
+  "swing": 0.02,
+  "drums": {"swing": 0.0},
+  "synth_defaults": {
+    "lpf_cutoff": 9000.0,
+    "chorus": 0.15,
+    "saturation": 0.05
+  },
+  "bass": {"tendencies": ["roots", "fifths"]},
+  "sections": ["intro", "verse", "chorus", "verse", "bridge", "chorus", "outro"]
+}

--- a/core/style.py
+++ b/core/style.py
@@ -15,6 +15,7 @@ class StyleToken(IntEnum):
     ROCK = 1
     CINEMATIC = 2
     CHILL_LOFI_JAM = 3
+    ACOUSTIC_FOLK_BALLAD = 6
 
 
 # Mapping of human readable style names to token IDs used by phrase models


### PR DESCRIPTION
## Summary
- add acoustic folk ballad style definition
- register acoustic folk ballad token

## Testing
- `pytest tests/test_style_defaults.py tests/test_style_variations.py -q` *(fails: No module named 'numpy')*
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy)*
- `npm --prefix ui run build` *(fails: sh: 1: vite: not found)*
- `node -e "require('fs').readdir('assets/styles', (err, files)=>console.log(files));"`


------
https://chatgpt.com/codex/tasks/task_e_68c66379b4088325ad9007da7ee62bdb