### PR TITLE
feat: add piper voice discovery

### DIFF
--- a/ui/src/api/piper.js
+++ b/ui/src/api/piper.js
@@ -2,3 +2,6 @@ import { invoke } from "@tauri-apps/api/core";
 export const testPiper = (voice, text) =>
     invoke("piper_test", { voice, text });
 
+export const discoverPiperVoices = () =>
+    invoke("discover_piper_voices");
+


### PR DESCRIPTION
## Summary
- add `discover_piper_voices` command to query `piper --list`
- expose voice discovery via frontend API
- register voice discovery command in Tauri handler

## Testing
- `cargo test` *(fails: failed to get `futures-sink` as a dependency of package `blossom_tauri`)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c6639f12788325b47d2091042ff651