### PR TITLE
Add synthwave retro style preset

### DIFF
--- a/assets/styles/synthwave_retro.json
+++ b/assets/styles/synthwave_retro.json
@@ -1,0 +1,5 @@
+{ "swing": 0.05,
+  "drums": { "swing": 0.03 },
+  "synth_defaults": { "lpf_cutoff": 5000.0, "chorus": 0.5, "saturation": 0.4 },
+  "bass": { "tendencies": ["roots","octaves"] },
+  "sections": ["intro","verse","chorus","verse","chorus","outro"] }

--- a/core/style.py
+++ b/core/style.py
@@ -15,6 +15,7 @@ class StyleToken(IntEnum):
     ROCK = 1
     CINEMATIC = 2
     CHILL_LOFI_JAM = 3
+    SYNTHWAVE_RETRO = 7
 
 
 # Mapping of human readable style names to token IDs used by phrase models

--- a/tests/test_synthwave_style.py
+++ b/tests/test_synthwave_style.py
@@ -1,0 +1,24 @@
+import importlib.util
+from pathlib import Path
+
+style_path = Path(__file__).resolve().parents[1] / "core" / "style.py"
+spec = importlib.util.spec_from_file_location("style", style_path)
+style = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(style)
+
+StyleToken = style.StyleToken
+style_to_token = style.style_to_token
+load_style = style.load_style
+
+
+def test_synthwave_retro_token_mapped():
+    assert style_to_token("synthwave_retro") is StyleToken.SYNTHWAVE_RETRO
+
+
+def test_synthwave_retro_defaults():
+    style = load_style("assets/styles/synthwave_retro.json")
+    assert style["synth_defaults"] == {
+        "lpf_cutoff": 5000.0,
+        "chorus": 0.5,
+        "saturation": 0.4,
+    }


### PR DESCRIPTION
## Summary
- add synthwave retro arrangement preset
- expose SYNTHWAVE_RETRO style token
- test style mapping and defaults

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'scipy.signal'; 'scipy' is not a package)*
- `pytest tests/test_synthwave_style.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6637ac4888325a346a906e2f33cc5