### PR TITLE
Allow training from multiple MIDI files

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -597,24 +597,21 @@ fn start_job(
 fn train_model(
     app: AppHandle,
     registry: State<JobRegistry>,
-    dataset: String,
+    midi_files: Vec<String>,
     epochs: u32,
     lr: f32,
 ) -> Result<u64, String> {
-    let script = if Path::new("training/simple_train.py").exists() {
-        "training/simple_train.py".to_string()
+    let script = if Path::new("training/run_phrase_train.py").exists() {
+        "training/run_phrase_train.py".to_string()
     } else {
-        "../training/simple_train.py".to_string()
+        "../training/run_phrase_train.py".to_string()
     };
-    let args = vec![
-        script,
-        "--dataset".into(),
-        dataset,
-        "--epochs".into(),
-        epochs.to_string(),
-        "--lr".into(),
-        lr.to_string(),
-    ];
+    let mut args = vec![script, "--midis".into()];
+    args.extend(midi_files);
+    args.push("--epochs".into());
+    args.push(epochs.to_string());
+    args.push("--lr".into());
+    args.push(lr.to_string());
     start_job(app, registry, args)
 }
 

--- a/training/phrase_models/train_phrase_models.py
+++ b/training/phrase_models/train_phrase_models.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Sequence, Union
 import argparse
 import json
+import sys
 
 import numpy as np
 import torch
@@ -103,17 +104,24 @@ def _collate(batch: Sequence[tuple[torch.Tensor, torch.Tensor]]) -> tuple[torch.
 
 
 def train_model(model: nn.Module, loader: DataLoader, epochs: int = 2) -> nn.Module:
-    """Very small training loop used for demonstration."""
+    """Very small training loop used for demonstration.
+
+    Emits progress information to ``stdout`` after each epoch so external
+    callers can track training status.
+    """
     optim = torch.optim.Adam(model.parameters(), lr=1e-3)
     criterion = nn.MSELoss()
     model.train()
-    for _ in range(epochs):
+    for epoch in range(1, epochs + 1):
         for data, styles in loader:
             optim.zero_grad()
             out = model(data, styles)
             loss = criterion(out, torch.zeros_like(out))
             loss.backward()
             optim.step()
+        percent = int(epoch * 100 / epochs)
+        print(f"train: {percent}% epoch {epoch}/{epochs}")
+        sys.stdout.flush()
     return model
 
 

--- a/training/run_phrase_train.py
+++ b/training/run_phrase_train.py
@@ -1,0 +1,50 @@
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--midis", nargs="+", required=True, help="MIDI files to include in the dataset")
+    parser.add_argument("--epochs", type=int, default=2)
+    parser.add_argument("--lr", type=float, default=0.001)  # unused but kept for interface compatibility
+    args = parser.parse_args()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        midi_dir = tmp_path / "midis"
+        midi_dir.mkdir()
+        for midi in args.midis:
+            src = Path(midi)
+            if src.exists():
+                shutil.copy(src, midi_dir / src.name)
+        build_cmd = [
+            "data/build_dataset.py",
+            "--midi-dir",
+            str(midi_dir),
+            "--out-dir",
+            str(tmp_path),
+        ]
+        subprocess.run([sys.executable] + build_cmd, check=True)
+        print("build: 100% dataset built")
+        sys.stdout.flush()
+
+        train_cmd = [
+            "training/phrase_models/train_phrase_models.py",
+            "--train",
+            str(tmp_path / "train.jsonl"),
+            "--val",
+            str(tmp_path / "val.jsonl"),
+            "--epochs",
+            str(args.epochs),
+        ]
+        subprocess.run([sys.executable] + train_cmd, check=True)
+        print("train: 100% done")
+        sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/ui/src/pages/Train.jsx
+++ b/ui/src/pages/Train.jsx
@@ -4,18 +4,18 @@ import { listen } from "@tauri-apps/api/event";
 import BackButton from "../components/BackButton.jsx";
 
 export default function Train() {
-  const [dataset, setDataset] = useState(null);
-  const [epochs, setEpochs] = useState(1);
+  const [midiFiles, setMidiFiles] = useState([]);
+  const [epochs, setEpochs] = useState(10);
   const [lr, setLr] = useState(0.001);
   const [progress, setProgress] = useState(0);
   const [status, setStatus] = useState("");
 
   const startTraining = async () => {
-    if (!dataset) return;
+    if (!midiFiles.length) return;
     setProgress(0);
     setStatus("Starting...");
     const id = await invoke("train_model", {
-      dataset: dataset.path || dataset.name,
+      midiFiles: midiFiles.map((f) => f.path || f.name),
       epochs: Number(epochs),
       lr: Number(lr),
     });
@@ -38,15 +38,16 @@ export default function Train() {
         }}
       >
         <label>
-          Dataset File
+          MIDI Files
           <input
             type="file"
-            accept=".mid,.midi,.npz,.json"
-            onChange={(e) => setDataset(e.target.files[0])}
+            accept=".mid,.midi"
+            multiple
+            onChange={(e) => setMidiFiles(Array.from(e.target.files))}
           />
         </label>
         <label>
-          Epochs
+          Epochs <small>(recommended: 10)</small>
           <input
             type="number"
             value={epochs}


### PR DESCRIPTION
## Summary
- Enable uploading multiple MIDI files in the Train page and display a recommended epoch count
- Run real phrase-model training with a new Python helper that builds datasets from the uploaded MIDIs
- Update Rust backend command and training loop to emit progress after each epoch

## Testing
- `pytest tests/test_dataset_split.py tests/test_phrase_model_sampling.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68c666d1768883259a7dfe5bf93739f2