### PR TITLE
Add synthwave retro style preset

### DIFF
--- a/assets/styles/synthwave_retro.json
+++ b/assets/styles/synthwave_retro.json
@@ -1,0 +1,11 @@
+{
+  "swing": 0.05,
+  "drums": {"swing": 0.03},
+  "synth_defaults": {
+    "lpf_cutoff": 5000.0,
+    "chorus": 0.5,
+    "saturation": 0.4
+  },
+  "bass": {"tendencies": ["roots", "octaves"]},
+  "sections": ["intro", "verse", "chorus", "verse", "chorus", "outro"]
+}

--- a/core/style.py
+++ b/core/style.py
@@ -16,6 +16,7 @@ class StyleToken(IntEnum):
     CINEMATIC = 2
     CHILL_LOFI_JAM = 3
     UPBEAT_FUNK_GROOVE = 4
+    SYNTHWAVE_RETRO = 7
 
 
 # Mapping of human readable style names to token IDs used by phrase models

--- a/tests/test_synthwave_retro.py
+++ b/tests/test_synthwave_retro.py
@@ -1,0 +1,34 @@
+import numpy as np
+import pytest
+
+from core.style import load_style, StyleToken
+from core.mixer import mix
+
+def test_synthwave_retro_loaded():
+    style = load_style("synthwave_retro")
+    assert StyleToken.SYNTHWAVE_RETRO == 7
+    assert style["swing"] == pytest.approx(0.05)
+    assert style["drums"]["swing"] == pytest.approx(0.03)
+    synth = style["synth_defaults"]
+    assert synth["lpf_cutoff"] == pytest.approx(5000.0)
+    assert synth["chorus"] == pytest.approx(0.5)
+    assert synth["saturation"] == pytest.approx(0.4)
+
+
+def test_synthwave_retro_lpf_between_lofi_and_rock():
+    sr = 44100
+    t = np.arange(sr, dtype=np.float32) / sr
+    tone = np.sin(2 * np.pi * 5000 * t).astype(np.float32)
+    stems = {"keys": tone}
+    style_lofi = load_style("assets/styles/lofi.json")
+    style_rock = load_style("assets/styles/rock.json")
+    style_synth = load_style("assets/styles/synthwave_retro.json")
+    out_lofi = mix(stems, sr, {}, style=style_lofi)
+    out_rock = mix(stems, sr, {}, style=style_rock)
+    out_synth = mix(stems, sr, {}, style=style_synth)
+    n = out_lofi.shape[0]
+    idx = int(5000 * n / sr)
+    amp_lofi = np.abs(np.fft.rfft(out_lofi[:, 0])[idx])
+    amp_rock = np.abs(np.fft.rfft(out_rock[:, 0])[idx])
+    amp_synth = np.abs(np.fft.rfft(out_synth[:, 0])[idx])
+    assert amp_lofi < amp_synth < amp_rock


### PR DESCRIPTION
## Summary
- add Synthwave Retro arrangement preset with defined swing and synth defaults
- expose SYNTHWAVE_RETRO style token
- test style loading and LPF behavior against existing presets

## Testing
- `pytest tests/test_synthwave_retro.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy scipy soundfile discord.py` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68c667458f2c8325b35d6cd48f2365cd