### PR TITLE
refactor: rename algorithmic generator component

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -6,7 +6,7 @@ import Train from './pages/Train.jsx';
 import OnnxCrafter from './pages/OnnxCrafter.jsx';
 import Profiles from './pages/Profiles.jsx';
 import Models from './pages/Models.jsx';
-import Generate from './pages/Generate.jsx';
+import AlgorithmicGenerator from './pages/Generate.jsx';
 import MusicGenerator from './pages/MusicGenerator.jsx';
 import MusicLang from './pages/MusicLang.jsx';
 import MusicGen from './pages/MusicGen.jsx';
@@ -18,11 +18,11 @@ export default function App() {
       <Routes>
         <Route path="/" element={<Dashboard />} />
         <Route path="/music-generator" element={<MusicGenerator />} />
-        <Route path="/music-generator/algorithmic" element={<Generate />} />
+        <Route path="/music-generator/algorithmic" element={<AlgorithmicGenerator />} />
         <Route path="/music-generator/phrase" element={<PhraseModel />} />
         <Route path="/music-generator/musiclang" element={<MusicLang />} />
         <Route path="/music-generator/musicgen" element={<MusicGen />} />
-        <Route path="/generate" element={<Generate />} />
+        <Route path="/generate" element={<AlgorithmicGenerator />} />
         <Route path="/dnd" element={<Dnd />} />
         <Route path="/settings" element={<Settings />} />
         <Route path="/profiles" element={<Profiles />} />

--- a/ui/src/pages/Generate.jsx
+++ b/ui/src/pages/Generate.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import BackButton from "../components/BackButton.jsx";
 
-export default function Generate() {
+export default function AlgorithmicGenerator() {
   const [preset, setPreset] = useState("");
   const [presets, setPresets] = useState([]);
   const [style, setStyle] = useState("");
@@ -15,7 +15,6 @@ export default function Generate() {
   const [outdir, setOutdir] = useState("");
   const [mixConfig, setMixConfig] = useState(null);
   const [arrangeConfig, setArrangeConfig] = useState(null);
-  const [phrase, setPhrase] = useState(false);
   const [drumsModel, setDrumsModel] = useState("");
   const [bassModel, setBassModel] = useState("");
   const [keysModel, setKeysModel] = useState("");
@@ -101,7 +100,6 @@ export default function Generate() {
     if (bassSfz) fd.append("bass_sfz", bassSfz);
     if (drumsSfz) fd.append("drums_sfz", drumsSfz);
     if (melodyMidi) fd.append("melody_midi", melodyMidi);
-    if (phrase) fd.append("phrase", "true");
     if (drumsModel) fd.append("drums_model", drumsModel);
     if (bassModel) fd.append("bass_model", bassModel);
     if (keysModel) fd.append("keys_model", keysModel);
@@ -267,14 +265,6 @@ export default function Generate() {
             type="file"
             onChange={(e) => setArrangeConfig(e.target.files[0] || null)}
           />
-        </label>
-        <label>
-          <input
-            type="checkbox"
-            checked={phrase}
-            onChange={(e) => setPhrase(e.target.checked)}
-          />
-          Phrase backend
         </label>
         <label>
           Drums model


### PR DESCRIPTION
## Summary
- rename `Generate` component to `AlgorithmicGenerator`
- drop obsolete phrase state, form-data, and checkbox
- update routes and imports for new component name

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: sh: 1: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c666ee870083259755a66be62c6aee