### PR TITLE
feat: manage piper profiles

### DIFF
--- a/ui/src/api/piper.js
+++ b/ui/src/api/piper.js
@@ -8,3 +8,12 @@ export const discoverPiperVoices = () =>
 export const addPiperVoice = (voice, name, tags) =>
     invoke("add_piper_voice", { voice, name, tags });
 
+export const listPiperProfiles = () =>
+    invoke("list_piper_profiles");
+
+export const updatePiperProfile = (original, name, tags) =>
+    invoke("update_piper_profile", { original, name, tags });
+
+export const removePiperProfile = (name) =>
+    invoke("remove_piper_profile", { name });
+


### PR DESCRIPTION
## Summary
- add backend commands to list, update, and remove Piper voice profiles
- expose new Piper profile APIs and enable editing/removal in the DnD page

## Testing
- `npm test --prefix ui` *(fails: Missing script: "test")*
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: failed to download from https://index.crates.io/config.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6691629588325bf290e8fefd45e24