### PR TITLE
Add transformers, accelerate, and torchaudio dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,6 @@ discord.py[voice] @ git+https://github.com/jg-l/discord.py
 torch
 onnxruntime
 mido
+transformers
+accelerate
+torchaudio  # for decoding and saving audio


### PR DESCRIPTION
## Summary
- add transformers, accelerate, and torchaudio dependencies to requirements file

## Testing
- `pytest`
- `pip install transformers accelerate` *(fails: Could not find a version that satisfies the requirement transformers)*
- `pip install torchaudio` *(fails: Could not find a version that satisfies the requirement torchaudio)*

------
https://chatgpt.com/codex/tasks/task_e_68c66c01baec8325be0cf81b3c452514