### PR TITLE
Add acoustic folk ballad style

### DIFF
--- a/assets/styles/acoustic_folk_ballad.json
+++ b/assets/styles/acoustic_folk_ballad.json
@@ -1,0 +1,5 @@
+{ "swing": 0.02,
+  "drums": { "swing": 0.0 },
+  "synth_defaults": { "lpf_cutoff": 9000.0, "chorus": 0.15, "saturation": 0.05 },
+  "bass": { "tendencies": ["roots","fifths"] },
+  "sections": ["intro","verse","chorus","verse","bridge","chorus","outro"] }

--- a/core/style.py
+++ b/core/style.py
@@ -16,6 +16,7 @@ class StyleToken(IntEnum):
     CINEMATIC = 2
     CHILL_LOFI_JAM = 3
     UPBEAT_FUNK_GROOVE = 4
+    ACOUSTIC_FOLK_BALLAD = 6
     SYNTHWAVE_RETRO = 7
 
 


### PR DESCRIPTION
## Summary
- add `acoustic_folk_ballad` style profile
- register `ACOUSTIC_FOLK_BALLAD` style token

## Testing
- `node -e "const fs=require('fs'); console.log(fs.readdirSync('assets/styles').filter(f=>f.endsWith('.json')).map(f=>f.slice(0,-5)));"`
- `npm --prefix ui run build` *(fails: vite: not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'scipy.signal')*

------
https://chatgpt.com/codex/tasks/task_e_68c6693bf840832598499045a77e0166