### PR TITLE
Allow internal devtools toggling

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -15,7 +15,15 @@
         "width": 800,
         "height": 600
       }
-    ]
+    ],
+    "security": {
+      "capabilities": [
+        {
+          "identifier": "allow-internal-toggle-devtools",
+          "permissions": ["core:webview:allow-internal-toggle-devtools"]
+        }
+      ]
+    }
   },
   "plugins": {
   }


### PR DESCRIPTION
## Summary
- add security capability to permit internal toggle of devtools in the Tauri webview

## Testing
- `npm run tauri build` *(fails: failed to download from crates.io 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c706a265a083258472ab3ed9d2dbfc