### PR TITLE
Add MusicGen generation interface

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -4,23 +4,14 @@ import Dnd from './pages/Dnd.jsx';
 import Settings from './pages/Settings.jsx';
 import Train from './pages/Train.jsx';
 import Profiles from './pages/Profiles.jsx';
-import AlgorithmicGenerator from './pages/Generate.jsx';
-import MusicGenerator from './pages/MusicGenerator.jsx';
-import MusicLang from './pages/MusicLang.jsx';
 import MusicGen from './pages/MusicGen.jsx';
-import PhraseModel from './pages/PhraseModel.jsx';
 
 export default function App() {
   return (
     <>
       <Routes>
         <Route path="/" element={<Dashboard />} />
-        <Route path="/music-generator" element={<MusicGenerator />} />
-        <Route path="/music-generator/algorithmic" element={<AlgorithmicGenerator />} />
-        <Route path="/music-generator/phrase" element={<PhraseModel />} />
-        <Route path="/music-generator/musiclang" element={<MusicLang />} />
-        <Route path="/music-generator/musicgen" element={<MusicGen />} />
-        <Route path="/generate" element={<AlgorithmicGenerator />} />
+        <Route path="/musicgen" element={<MusicGen />} />
         <Route path="/dnd" element={<Dnd />} />
         <Route path="/settings" element={<Settings />} />
         <Route path="/profiles" element={<Profiles />} />

--- a/ui/src/pages/Dashboard.jsx
+++ b/ui/src/pages/Dashboard.jsx
@@ -7,7 +7,7 @@ export default function Dashboard() {
         <h1>Blossom Music Generation</h1>
       </header>
       <main className="dashboard">
-        <Card to="/music-generator" icon="Music" title="Music Generator" />
+        <Card to="/musicgen" icon="Music" title="MusicGen" />
         <Card to="/dnd" icon="Dice5" title="Dungeons & Dragons" />
         <Card to="/settings" icon="Settings" title="Settings" />
         <Card to="/train" icon="Sliders" title="Train Model" />

--- a/ui/src/pages/MusicGen.jsx
+++ b/ui/src/pages/MusicGen.jsx
@@ -1,10 +1,85 @@
+import { useState } from "react";
 import BackButton from "../components/BackButton.jsx";
 
 export default function MusicGen() {
+  const [prompt, setPrompt] = useState("");
+  const [duration, setDuration] = useState(10);
+  const [temperature, setTemperature] = useState(1);
+  const [topK, setTopK] = useState(250);
+  const [audioUrl, setAudioUrl] = useState(null);
+  const [generating, setGenerating] = useState(false);
+
+  const generate = async () => {
+    setGenerating(true);
+    setAudioUrl(null);
+    try {
+      const resp = await fetch("/musicgen", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          prompt,
+          duration: Number(duration),
+          temperature: Number(temperature),
+          top_k: Number(topK),
+        }),
+      });
+      const blob = await resp.blob();
+      setAudioUrl(URL.createObjectURL(blob));
+    } catch (err) {
+      console.error("music generation failed", err);
+    } finally {
+      setGenerating(false);
+    }
+  };
+
   return (
     <>
       <BackButton />
-      <h1>Coming Soon</h1>
+      <h1>MusicGen</h1>
+      <div className="musicgen-controls">
+        <label>
+          Prompt
+          <input
+            type="text"
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+          />
+        </label>
+        <label>
+          Duration (s)
+          <input
+            type="number"
+            min="1"
+            value={duration}
+            onChange={(e) => setDuration(e.target.value)}
+          />
+        </label>
+        <label>
+          Temperature
+          <input
+            type="number"
+            step="0.1"
+            value={temperature}
+            onChange={(e) => setTemperature(e.target.value)}
+          />
+        </label>
+        <label>
+          Top-k
+          <input
+            type="number"
+            value={topK}
+            onChange={(e) => setTopK(e.target.value)}
+          />
+        </label>
+        <button type="button" onClick={generate} disabled={generating}>
+          {generating ? "Generating..." : "Generate"}
+        </button>
+      </div>
+      {audioUrl && (
+        <div style={{ marginTop: "1rem" }}>
+          <audio controls src={audioUrl} />
+        </div>
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- add prompt and parameter controls to MusicGen page with audio playback
- replace Music Generator card with dedicated MusicGen card
- simplify routes so MusicGen page is only generator entry point

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c704e9d2948325a0444cfe7465f428