### PR TITLE
Handle missing piper CLI for voice discovery

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,7 +3,7 @@
 use std::{
     collections::HashMap,
     env, fs,
-    io::{BufRead, BufReader},
+    io::{BufRead, BufReader, ErrorKind},
     path::{Path, PathBuf},
     process::{Child, Command, Stdio},
     sync::{
@@ -279,7 +279,13 @@ fn discover_piper_voices() -> Result<Vec<String>, String> {
     let output = Command::new("piper")
         .arg("--list")
         .output()
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| {
+            if e.kind() == ErrorKind::NotFound {
+                "piper binary not found".into()
+            } else {
+                e.to_string()
+            }
+        })?;
     if !output.status.success() {
         return Err(String::from_utf8_lossy(&output.stderr).to_string());
     }

--- a/ui/src/pages/Dnd.jsx
+++ b/ui/src/pages/Dnd.jsx
@@ -28,6 +28,7 @@ export default function Dnd() {
   const [displayName, setDisplayName] = useState("");
   const [voiceTags, setVoiceTags] = useState("");
   const [piperProfiles, setPiperProfiles] = useState([]);
+  const [piperBinaryAvailable, setPiperBinaryAvailable] = useState(true);
 
   const refresh = async () => {
     setNpcs(await listNpcs());
@@ -56,6 +57,15 @@ export default function Dnd() {
         setPiperVoice(v.selected);
       }
     });
+    discoverPiperVoices()
+      .then(() => setPiperBinaryAvailable(true))
+      .catch((err) => {
+        console.error(err);
+        const msg = String(err);
+        if (msg.includes("No such file") || msg.includes("not found")) {
+          setPiperBinaryAvailable(false);
+        }
+      });
   }, []);
 
   useEffect(() => {
@@ -260,8 +270,22 @@ export default function Dnd() {
                     setPiperAvailableVoices(list || []);
                   } catch (err) {
                     console.error(err);
+                    const msg = String(err);
+                    if (
+                      msg.includes("No such file") ||
+                      msg.includes("not found")
+                    ) {
+                      alert(
+                        "Piper CLI not found. Please install the `piper` command line tool."
+                      );
+                    }
                   }
                 }}
+                disabled={!piperBinaryAvailable}
+                title=
+                  {!piperBinaryAvailable
+                    ? "Install the piper CLI to enable voice discovery"
+                    : undefined}
               >
                 Find Voices
               </button>


### PR DESCRIPTION
## Summary
- Detect missing `piper` binary in `discover_piper_voices` and return a clear error
- Pre-check for `piper` CLI in DnD page and disable the **Find Voices** button with tooltip
- Show alert prompting installation of `piper` when discovery fails

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: failed to download config.json; [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*

------
https://chatgpt.com/codex/tasks/task_e_68c7086bff148325a99bfa9bef6f05d4