### PR TITLE
Add persistent Discord token configuration

### DIFF
--- a/brain/voice_orchestrator.py
+++ b/brain/voice_orchestrator.py
@@ -12,12 +12,24 @@ from ears.whisper_service import TranscriptionSegment
 from brain import dialogue
 from mouth.discord_player import DiscordPlayer
 from config.discord_profiles import get_profile
+from config.discord_token import get_token
 
 
 class DiscordOrchestrator:
     """Coordinate speech recognition, dialogue generation and synthesis."""
 
-    def __init__(self, token: str, guild_id: int, channel_id: int, *, debounce: float = 0.3) -> None:
+    def __init__(
+        self,
+        token: Optional[str],
+        guild_id: int,
+        channel_id: int,
+        *,
+        debounce: float = 0.3,
+    ) -> None:
+        token = token or os.getenv("DISCORD_TOKEN") or get_token()
+        if not token:
+            raise RuntimeError("Discord token not provided")
+
         self.token = token
         self.guild_id = guild_id
         self.channel_id = channel_id

--- a/config/discord_token.py
+++ b/config/discord_token.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+"""Utilities for persisting the Discord bot token."""
+
+from pathlib import Path
+
+__all__ = ["get_token", "set_token", "TOKEN_FILE"]
+
+# Location where the Discord token will be stored.
+TOKEN_FILE = Path(__file__).with_name("discord_token.txt")
+
+# Internal cached token value.
+_TOKEN: str | None = None
+
+
+def get_token() -> str | None:
+    """Return the stored Discord token, if available."""
+
+    global _TOKEN
+    if _TOKEN is not None:
+        return _TOKEN
+    if TOKEN_FILE.exists():
+        _TOKEN = TOKEN_FILE.read_text().strip()
+    return _TOKEN
+
+
+def set_token(token: str) -> str:
+    """Persist ``token`` to :data:`TOKEN_FILE`.
+
+    The token is treated as read-only once written. Subsequent attempts to
+    modify it will raise a :class:`RuntimeError`.
+    """
+
+    token = token.strip()
+    existing = get_token()
+    if existing is not None:
+        raise RuntimeError("Token already set")
+
+    TOKEN_FILE.write_text(token)
+    try:
+        # Make the settings file read-only so it cannot be modified by the
+        # running service.
+        TOKEN_FILE.chmod(0o444)
+    except Exception:
+        # Permission change failures are non-fatal.
+        pass
+
+    global _TOKEN
+    _TOKEN = token
+    return token

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -12,6 +12,7 @@ from brain import dialogue
 from mouth.registry import VoiceRegistry
 from config.discord import get_permission_rules
 from config.discord_profiles import get_profile, set_profile
+from config.discord_token import get_token
 import session_export
 
 
@@ -231,6 +232,8 @@ __all__ = ["BlossomBot"]
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution
-    TOKEN = os.environ["DISCORD_TOKEN"]
+    TOKEN = os.getenv("DISCORD_TOKEN") or get_token()
+    if not TOKEN:
+        raise RuntimeError("Discord token not configured")
     bot = BlossomBot()
     bot.run(TOKEN)

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -1,11 +1,18 @@
 # Discord Configuration
 
 Set the bot token in the ``DISCORD_TOKEN`` environment variable before
-starting ``discord_bot.py``:
+starting ``discord_bot.py`` or persist it to ``config/discord_token.txt`` using
+``config.discord_token.set_token``. When the environment variable is not set
+the bot falls back to the stored token.
 
 ```bash
 export DISCORD_TOKEN="your_bot_token"
 python discord_bot.py
+```
+
+```python
+from config.discord_token import set_token
+set_token("your_bot_token")
 ```
 
 The Discord bot reads command permission rules from `config/discord.yaml` on startup.

--- a/mouth/discord_player.py
+++ b/mouth/discord_player.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import math
+import os
 from typing import Optional
 
 import discord
@@ -31,6 +32,7 @@ except Exception:  # pragma: no cover - exercised when resampy missing
 
 from .tts import TTSEngine
 from .registry import VoiceProfile
+from config.discord_token import get_token
 
 
 class DiscordPlayer(discord.Client):
@@ -96,7 +98,7 @@ class DiscordPlayer(discord.Client):
 
 
 async def run_bot(
-    token: str,
+    token: str | None,
     channel_id: int,
     *,
     text: str,
@@ -104,6 +106,10 @@ async def run_bot(
     **engine_kwargs,
 ) -> None:
     """Join a Discord channel and speak ``text`` once."""
+
+    token = token or os.getenv("DISCORD_TOKEN") or get_token()
+    if not token:
+        raise RuntimeError("Discord token not provided")
 
     player = DiscordPlayer(engine=TTSEngine(**engine_kwargs))
 


### PR DESCRIPTION
## Summary
- add `config.discord_token` to persist and retrieve bot token
- allow Discord modules to load token from env or stored file
- document token persistence in Discord setup guide

## Testing
- `pytest` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'random')*
- `pytest tests/test_pipeline_callback.py`

------
https://chatgpt.com/codex/tasks/task_e_68c77ff848e0832582d0ed04d6faf4e6