### PR TITLE
feat: add musicgen test handler

### DIFF
--- a/ui/src/pages/MusicGen.jsx
+++ b/ui/src/pages/MusicGen.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { invoke } from "@tauri-apps/api/tauri";
 import BackButton from "../components/BackButton.jsx";
 
 export default function MusicGen() {
@@ -27,6 +28,20 @@ export default function MusicGen() {
       setAudioUrl(URL.createObjectURL(blob));
     } catch (err) {
       console.error("music generation failed", err);
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  const runTest = async () => {
+    setGenerating(true);
+    setAudioUrl(null);
+    try {
+      const bytes = await invoke("musicgen_test");
+      const blob = new Blob([new Uint8Array(bytes)]);
+      setAudioUrl(URL.createObjectURL(blob));
+    } catch (err) {
+      console.error("musicgen test failed", err);
     } finally {
       setGenerating(false);
     }
@@ -73,6 +88,9 @@ export default function MusicGen() {
         </label>
         <button type="button" onClick={generate} disabled={generating}>
           {generating ? "Generating..." : "Generate"}
+        </button>
+        <button type="button" onClick={runTest} disabled={generating}>
+          {generating ? "Testing..." : "Run Test"}
         </button>
       </div>
       {audioUrl && (


### PR DESCRIPTION
## Summary
- add runTest handler to MusicGen page that invokes `musicgen_test`
- expose Run Test button for triggering test audio generation

## Testing
- `npm test` (fails: Missing script: "test")
- `pytest` (fails: ModuleNotFoundError: No module named 'scipy')

------
https://chatgpt.com/codex/tasks/task_e_68c7821490dc8325a14c1abbb1c03cec