### PR TITLE
Add Tools page and Fusion Loop Maker icon

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -5,6 +5,8 @@ import Settings from './pages/Settings.jsx';
 import Train from './pages/Train.jsx';
 import Profiles from './pages/Profiles.jsx';
 import MusicGen from './pages/MusicGen.jsx';
+import Tools from './pages/Tools.jsx';
+import Fusion from './pages/Fusion.jsx';
 
 export default function App() {
   return (
@@ -16,6 +18,8 @@ export default function App() {
         <Route path="/settings" element={<Settings />} />
         <Route path="/profiles" element={<Profiles />} />
         <Route path="/train" element={<Train />} />
+        <Route path="/tools" element={<Tools />} />
+        <Route path="/fusion" element={<Fusion />} />
       </Routes>
     </>
   );

--- a/ui/src/pages/Dashboard.jsx
+++ b/ui/src/pages/Dashboard.jsx
@@ -9,6 +9,7 @@ export default function Dashboard() {
       <main className="dashboard">
         <Card to="/musicgen" icon="Music" title="MusicGen" />
         <Card to="/dnd" icon="Dice5" title="Dungeons & Dragons" />
+        <Card to="/tools" icon="Tool" title="Tools" />
         <Card to="/settings" icon="Settings" title="Settings" />
         <Card to="/train" icon="Sliders" title="Train Model" />
       </main>

--- a/ui/src/pages/Fusion.jsx
+++ b/ui/src/pages/Fusion.jsx
@@ -1,0 +1,12 @@
+import BackButton from '../components/BackButton.jsx';
+
+export default function Fusion() {
+  return (
+    <>
+      <BackButton />
+      <h1>Fusion Loop Maker</h1>
+      <p>Coming soon...</p>
+    </>
+  );
+}
+

--- a/ui/src/pages/Tools.jsx
+++ b/ui/src/pages/Tools.jsx
@@ -1,0 +1,17 @@
+import BackButton from '../components/BackButton.jsx';
+import Card from '../components/Card.jsx';
+
+export default function Tools() {
+  return (
+    <>
+      <BackButton />
+      <h1>Tools</h1>
+      <main className="dashboard">
+        <Card to="/fusion" icon="Atom" title="Fusion">
+          Loop Maker
+        </Card>
+      </main>
+    </>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add Tools section to home page
- provide Fusion Loop Maker icon within new Tools page
- wire up routes for new Tools and Fusion pages

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'scipy')*

------
https://chatgpt.com/codex/tasks/task_e_68c785f6cabc83258f3af9c8dc1c3679