### PR TITLE
Write MusicGen test output to out directory

### DIFF
--- a/scripts/test_musicgen.py
+++ b/scripts/test_musicgen.py
@@ -2,7 +2,7 @@
 
 This script downloads the pre-trained ``facebook/musicgen-small`` model on
 first use and generates a short audio clip from a text prompt.  The output is
-saved to ``musicgen_sample.wav`` in the current directory.
+saved to ``out/musicgen_sample.wav`` in the current directory.
 """
 
 from pathlib import Path
@@ -21,7 +21,8 @@ def main(prompt: str = DEFAULT_PROMPT) -> Path:
     result = pipe(prompt)
     audio = result[0]["audio"]
     sample_rate = result[0]["sampling_rate"]
-    out_path = Path("musicgen_sample.wav")
+    out_path = Path("out") / "musicgen_sample.wav"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
     write_wav(out_path, sample_rate, audio)
     print(f"Saved {out_path}")
     return out_path


### PR DESCRIPTION
## Summary
- write MusicGen sample output to `out/musicgen_sample.wav`
- create the `out` directory before writing

## Testing
- `python -m py_compile scripts/test_musicgen.py`
- `TRANSFORMERS_OFFLINE=1 python scripts/test_musicgen.py` *(fails: No module named 'scipy')*
- `pip install scipy -q` *(fails: Could not find a version that satisfies the requirement scipy)*

------
https://chatgpt.com/codex/tasks/task_e_68c7876af7808325813014b94a1a9f77