### PR TITLE
Add progress bar to MusicGen test script

### DIFF
--- a/scripts/test_musicgen.py
+++ b/scripts/test_musicgen.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from scipy.io.wavfile import write as write_wav
 from transformers import pipeline
+from tqdm.auto import tqdm
 
 
 DEFAULT_PROMPT = "lofi hip hop beat for studying"
@@ -17,12 +18,22 @@ DEFAULT_PROMPT = "lofi hip hop beat for studying"
 def main(prompt: str = DEFAULT_PROMPT) -> Path:
     """Generate a short audio clip from ``prompt`` and return the output path."""
 
-    pipe = pipeline("text-to-audio", model="facebook/musicgen-small")
-    result = pipe(prompt)
-    audio = result[0]["audio"]
-    sample_rate = result[0]["sampling_rate"]
-    out_path = Path("musicgen_sample.wav")
-    write_wav(out_path, sample_rate, audio)
+    with tqdm(total=3, unit="step", leave=False) as pbar:
+        pbar.set_description("Loading model")
+        pipe = pipeline("text-to-audio", model="facebook/musicgen-small")
+        pbar.update()
+
+        pbar.set_description("Generating audio")
+        result = pipe(prompt)
+        pbar.update()
+
+        pbar.set_description("Saving file")
+        audio = result[0]["audio"]
+        sample_rate = result[0]["sampling_rate"]
+        out_path = Path("musicgen_sample.wav")
+        write_wav(out_path, sample_rate, audio)
+        pbar.update()
+
     print(f"Saved {out_path}")
     return out_path
 


### PR DESCRIPTION
## Summary
- use `tqdm` to show progress for model loading, audio generation, and file saving in `test_musicgen.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'scipy')*

------
https://chatgpt.com/codex/tasks/task_e_68c78773bebc8325b36f9b417bbf32d9