### PR TITLE
Add progress bar to MusicGen smoke test

### DIFF
--- a/scripts/test_musicgen.py
+++ b/scripts/test_musicgen.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from scipy.io.wavfile import write as write_wav
 from transformers import pipeline
+from tqdm import tqdm
 
 
 DEFAULT_PROMPT = "lofi hip hop beat for studying"
@@ -17,13 +18,24 @@ DEFAULT_PROMPT = "lofi hip hop beat for studying"
 def main(prompt: str = DEFAULT_PROMPT) -> Path:
     """Generate a short audio clip from ``prompt`` and return the output path."""
 
-    pipe = pipeline("text-to-audio", model="facebook/musicgen-small")
-    result = pipe(prompt)
-    audio = result[0]["audio"]
-    sample_rate = result[0]["sampling_rate"]
-    out_path = Path("out") / "musicgen_sample.wav"
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    write_wav(out_path, sample_rate, audio)
+    with tqdm(total=3, leave=False) as progress:
+        progress.set_description("Loading model")
+        pipe = pipeline("text-to-audio", model="facebook/musicgen-small")
+        progress.update()
+
+        progress.set_description("Generating audio")
+        result = pipe(prompt)
+        progress.update()
+
+        audio = result[0]["audio"]
+        sample_rate = result[0]["sampling_rate"]
+        out_path = Path("out") / "musicgen_sample.wav"
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+
+        progress.set_description("Writing file")
+        write_wav(out_path, sample_rate, audio)
+        progress.update()
+
     print(f"Saved {out_path}")
     return out_path
 


### PR DESCRIPTION
## Summary
- add `tqdm` progress bar to `scripts/test_musicgen.py`
- show progress through model loading, audio generation, and file writing steps

## Testing
- `python -m pytest tests/test_utils.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `python scripts/test_musicgen.py` *(fails: ModuleNotFoundError: No module named 'scipy')*

------
https://chatgpt.com/codex/tasks/task_e_68c7885a54b483259d42991285b82d7d