### PR TITLE
feat: add icon navigation for DnD sections

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -107,3 +107,38 @@ header {
   width: 3rem;
   height: 3rem;
 }
+
+.dnd-section-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+  margin-bottom: var(--space-lg);
+}
+
+.dnd-section-btn {
+  background: var(--card-bg);
+  border-radius: 8px;
+  padding: var(--space-md);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-sm);
+  border: 2px solid transparent;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease,
+    border-color 0.2s ease, color 0.2s ease;
+}
+
+.dnd-section-btn:hover,
+.dnd-section-btn:focus {
+  background: var(--card-hover-bg);
+  box-shadow: var(--card-shadow);
+  transform: translateY(-4px) scale(1.02);
+}
+
+.dnd-section-btn svg {
+  color: var(--icon);
+  width: 3rem;
+  height: 3rem;
+}

--- a/ui/src/pages/Dnd.jsx
+++ b/ui/src/pages/Dnd.jsx
@@ -114,14 +114,28 @@ export default function Dnd() {
     }
   };
 
+  const sections = [
+    { name: "Lore", icon: "BookOpen" },
+    { name: "NPCs", icon: "Users" },
+    { name: "Piper", icon: "Mic2" },
+    { name: "Discord", icon: "MessageCircle" },
+    { name: "Chat", icon: "MessageSquare" },
+  ];
+
   return (
     <div>
       <BackButton />
       <h1>Dungeons & Dragons</h1>
-      <div style={{ display: "flex", gap: "0.5rem", marginBottom: "1rem" }}>
-        {["Lore", "NPCs", "Piper", "Discord", "Chat"].map((name) => (
-          <button key={name} type="button" onClick={() => setSection(name)}>
-            {name}
+      <div className="dnd-section-nav">
+        {sections.map(({ name, icon }) => (
+          <button
+            key={name}
+            type="button"
+            className="dnd-section-btn"
+            onClick={() => setSection(name)}
+          >
+            <Icon name={icon} size={48} />
+            <span>{name}</span>
           </button>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- add icon-based section nav buttons on DnD page
- style DnD section navigation and buttons

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c7888fa1b88325b56095e7321cd538