### PR TITLE
feat: add musicgen test command

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -451,6 +451,20 @@ sf.write({wav:?}, audio, 22050)
 }
 
 #[tauri::command]
+fn musicgen_test() -> Result<Vec<u8>, String> {
+    let status = Command::new("python")
+        .arg("scripts/test_musicgen.py")
+        .status()
+        .map_err(|e| e.to_string())?;
+    if !status.success() {
+        return Err("musicgen test failed".into());
+    }
+    let out_path = Path::new("out/musicgen_sample.wav");
+    let bytes = fs::read(out_path).map_err(|e| e.to_string())?;
+    Ok(bytes)
+}
+
+#[tauri::command]
 fn hotword_get() -> Result<Value, String> {
     let output = Command::new("python")
         .args(["-m", "ears.hotword", "list"])
@@ -1006,6 +1020,7 @@ fn main() {
             update_piper_profile,
             remove_piper_profile,
             piper_test,
+            musicgen_test,
             list_llm,
             set_llm,
             npc_list,


### PR DESCRIPTION
## Summary
- add `musicgen_test` Tauri command to generate a sample via MusicGen and return bytes
- expose `musicgen_test` through Tauri's invoke handler for frontend use

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: failed to get `futures-sink` as a dependency, download config.json failed)*
- `npm test` *(fails: Missing script "test")*
- `npm --prefix ui test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c78936eae083258e6a15753358e720