### PR TITLE
Add Loop Maker page and routes

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -7,6 +7,7 @@ import Profiles from './pages/Profiles.jsx';
 import MusicGen from './pages/MusicGen.jsx';
 import Tools from './pages/Tools.jsx';
 import Fusion from './pages/Fusion.jsx';
+import LoopMaker from './pages/LoopMaker.jsx';
 
 export default function App() {
   return (
@@ -20,6 +21,7 @@ export default function App() {
         <Route path="/train" element={<Train />} />
         <Route path="/tools" element={<Tools />} />
         <Route path="/fusion" element={<Fusion />} />
+        <Route path="/loopmaker" element={<LoopMaker />} />
       </Routes>
     </>
   );

--- a/ui/src/pages/LoopMaker.jsx
+++ b/ui/src/pages/LoopMaker.jsx
@@ -1,0 +1,12 @@
+import BackButton from '../components/BackButton.jsx';
+
+export default function LoopMaker() {
+  return (
+    <>
+      <BackButton />
+      <h1>Loop Maker</h1>
+      <p>Coming soon...</p>
+    </>
+  );
+}
+

--- a/ui/src/pages/Tools.jsx
+++ b/ui/src/pages/Tools.jsx
@@ -8,7 +8,10 @@ export default function Tools() {
       <h1>Tools</h1>
       <main className="dashboard">
         <Card to="/fusion" icon="Atom" title="Fusion">
-          Loop Maker
+          Concept Combiner
+        </Card>
+        <Card to="/loopmaker" icon="Repeat" title="Loop Maker">
+          Beat Loop Creator
         </Card>
       </main>
     </>


### PR DESCRIPTION
## Summary
- Add Loop Maker card on Tools page
- Register Loop Maker route and component
- Adjust Fusion card caption

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c78aa3a29c83258d61256000ebdc1c