### PR TITLE
Enable React Router future flags

### DIFF
--- a/ui/src/main.jsx
+++ b/ui/src/main.jsx
@@ -8,7 +8,7 @@ import '../theme.js';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <HashRouter>
+    <HashRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
       <App />
     </HashRouter>
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- enable React Router v7 experimental flags on HashRouter to remove development warnings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite not found; dependency install hung and was killed)*

------
https://chatgpt.com/codex/tasks/task_e_68c78c5f13008325b63832faf435f85b