### PR TITLE
Add fusion inputs and state management in Fusion page

### DIFF
--- a/ui/src/pages/Fusion.jsx
+++ b/ui/src/pages/Fusion.jsx
@@ -1,11 +1,40 @@
+import { useState } from 'react';
 import BackButton from '../components/BackButton.jsx';
 
 export default function Fusion() {
+  const [conceptA, setConceptA] = useState('');
+  const [conceptB, setConceptB] = useState('');
+  const [notes, setNotes] = useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    // TODO: implement fusion logic
+  };
+
   return (
     <>
       <BackButton />
       <h1>Fusion Loop Maker</h1>
-      <p>Coming soon...</p>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="text"
+          placeholder="First concept"
+          value={conceptA}
+          onChange={(e) => setConceptA(e.target.value)}
+        />
+        <input
+          type="text"
+          placeholder="Second concept"
+          value={conceptB}
+          onChange={(e) => setConceptB(e.target.value)}
+        />
+        <textarea
+          placeholder="Notes or description"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+        />
+        <button type="submit">Fuse Concepts</button>
+      </form>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Add form to Fusion page with concept inputs, notes textarea, and fuse button
- Manage form data with React useState and stub submit handler

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68c78fcf5af4832596fc54109503b71b