### PR TITLE
Propagate MusicGen test errors to UI

### DIFF
--- a/ui/src/pages/MusicGen.jsx
+++ b/ui/src/pages/MusicGen.jsx
@@ -9,6 +9,7 @@ export default function MusicGen() {
   const [topK, setTopK] = useState(250);
   const [audioUrl, setAudioUrl] = useState(null);
   const [generating, setGenerating] = useState(false);
+  const [error, setError] = useState(null);
 
   const generate = async () => {
     setGenerating(true);
@@ -36,12 +37,14 @@ export default function MusicGen() {
   const runTest = async () => {
     setGenerating(true);
     setAudioUrl(null);
+    setError(null);
     try {
       const bytes = await invoke("musicgen_test");
       const blob = new Blob([new Uint8Array(bytes)]);
       setAudioUrl(URL.createObjectURL(blob));
     } catch (err) {
       console.error("musicgen test failed", err);
+      setError(String(err));
     } finally {
       setGenerating(false);
     }
@@ -97,6 +100,9 @@ export default function MusicGen() {
         <div style={{ marginTop: "1rem" }}>
           <audio controls src={audioUrl} />
         </div>
+      )}
+      {error && (
+        <p style={{ color: "red", marginTop: "1rem" }}>{error}</p>
       )}
     </>
   );


### PR DESCRIPTION
## Summary
- run MusicGen smoke test with path-resolved script and capture stdout/stderr
- bubble up stderr on failure and surface errors in MusicGen UI

## Testing
- `cargo test` *(fails: failed to download from https://index.crates.io/config.json - [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c7914d24b083259b2390ef1ee3351c