### PR TITLE
Handle NPC API errors in DnD page

### DIFF
--- a/ui/src/pages/Dnd.jsx
+++ b/ui/src/pages/Dnd.jsx
@@ -80,13 +80,25 @@ export default function Dnd() {
   const edit = (npc) => setCurrent(npc);
   const newNpc = () => setCurrent(emptyNpc);
   const save = async () => {
-    await saveNpc(current);
-    setCurrent(emptyNpc);
-    refresh();
+    try {
+      await saveNpc(current);
+      setCurrent(emptyNpc);
+    } catch (err) {
+      console.error(err);
+      alert("Failed to save NPC: " + String(err));
+    } finally {
+      refresh();
+    }
   };
   const remove = async (name) => {
-    await deleteNpc(name);
-    refresh();
+    try {
+      await deleteNpc(name);
+    } catch (err) {
+      console.error(err);
+      alert("Failed to delete NPC: " + String(err));
+    } finally {
+      refresh();
+    }
   };
 
   const handleProfileChange = (idx, field, value) => {


### PR DESCRIPTION
## Summary
- Wrap NPC save and delete API calls with try/catch to surface errors
- Alert users on failure and refresh NPC list to keep UI responsive

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: vite: not found)

------
https://chatgpt.com/codex/tasks/task_e_68c798921d8c8325a249509235e4ca39