### PR TITLE
feat(ui): handle unsupported media types

### DIFF
--- a/ui/src/pages/LoopMaker.jsx
+++ b/ui/src/pages/LoopMaker.jsx
@@ -37,6 +37,13 @@ export default function LoopMaker() {
       const url = URL.createObjectURL(mediaSource);
       mediaSource.addEventListener('sourceopen', async () => {
         try {
+          if (!MediaSource.isTypeSupported(file.type)) {
+            alert(
+              'This video format is not supported for seamless looping; using basic repeat.'
+            );
+            resolve(null);
+            return;
+          }
           const sourceBuffer = mediaSource.addSourceBuffer(file.type);
           const data = await file.arrayBuffer();
           let i = 0;


### PR DESCRIPTION
## Summary
- check `MediaSource.isTypeSupported` before adding source buffer in LoopMaker
- fall back to basic looping when type unsupported and alert user

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: vite not found)
- `node /tmp/test_loopmaker.js`


------
https://chatgpt.com/codex/tasks/task_e_68c7989cb1548325bd2a7fd4a6c29206