### PR TITLE
Remove unused Duration import

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -10,7 +10,6 @@ use std::{
         atomic::{AtomicU64, Ordering},
         Arc, Mutex,
     },
-    time::Duration,
 };
 
 use regex::Regex;


### PR DESCRIPTION
## Summary
- remove unused `time::Duration` import

## Testing
- `cargo fmt`
- `cargo build` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68c79b544c448325bdec22c11f188bd8