### PR TITLE
refactor: trim unused argument from cancel_render

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -738,7 +738,7 @@ fn train_model(
 }
 
 #[tauri::command]
-fn cancel_render(app: AppHandle, registry: State<JobRegistry>, job_id: u64) -> Result<(), String> {
+fn cancel_render(registry: State<JobRegistry>, job_id: u64) -> Result<(), String> {
     let mut jobs = registry.jobs.lock().map_err(|e| e.to_string())?;
     match jobs.get_mut(&job_id) {
         Some(job) => {


### PR DESCRIPTION
## Summary
- remove unused AppHandle parameter from cancel_render

## Testing
- `cargo check` *(fails: failed to download from https://index.crates.io/config.json [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*

------
https://chatgpt.com/codex/tasks/task_e_68c79b58f71c83258686af76fb759e1e