### PR TITLE
feat: import tauri manager trait

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -15,6 +15,7 @@ use std::{
 use regex::Regex;
 use serde_json::{json, Value};
 use tauri::Emitter;
+use tauri::Manager;
 use tauri::{async_runtime, AppHandle, Runtime, State};
 use tauri_plugin_dialog::DialogExt;
 use tauri_plugin_opener::OpenerExt;


### PR DESCRIPTION
## Summary
- add Manager trait import in Tauri backend

## Testing
- `npm run tauri dev` *(fails: `vite` not found)*
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a34eee9483258e4d51f5a446aebe