### PR TITLE
feat(ui): add train model tool

### DIFF
--- a/ui/src/pages/Tools.jsx
+++ b/ui/src/pages/Tools.jsx
@@ -13,6 +13,9 @@ export default function Tools() {
         <Card to="/loopmaker" icon="Repeat" title="Loop Maker">
           Beat Loop Creator
         </Card>
+        <Card to="/train" icon="Sliders" title="Train Model">
+          Custom Model Trainer
+        </Card>
       </main>
     </>
   );


### PR DESCRIPTION
## Summary
- add train model card to Tools page for quick access

## Testing
- `npm --prefix ui test` *(fails: Missing script "test")*
- `pytest tests/test_drum_round_robin.py` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68c7a3d094e4832587341bd05e1c18ad