### PR TITLE
Add MusicGen command-line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,16 @@ falling back to `localStorage` when the plugin is not available.
 Generate a short clip with Meta's pretrained MusicGen model:
 
 ```bash
-python scripts/test_musicgen.py
+python main_musicgen.py --prompt "lofi hip hop beat for studying"
 ```
 
-The first run downloads the `facebook/musicgen-small` weights (about 3 GB).
-Expect roughly 3 GB of GPU memory or 6 GB of system RAM for inference.
-Producing a four‑second clip typically finishes in under 10 seconds on a
-recent GPU and in roughly one to two minutes on a modern CPU.
+This writes the output WAV file under `out/musicgen/`. The first run downloads
+the `facebook/musicgen-small` weights (about 3 GB).
+
+The legacy `scripts/test_musicgen.py` helper remains available for a minimal
+smoke test. Expect roughly 3 GB of GPU memory or 6 GB of system RAM for
+inference. Producing a four‑second clip typically finishes in under 10 seconds
+on a recent GPU and in roughly one to two minutes on a modern CPU.
 
 ## Prerequisites
 

--- a/main_musicgen.py
+++ b/main_musicgen.py
@@ -1,0 +1,26 @@
+import sys
+if sys.version_info[:2] != (3, 10):
+    raise RuntimeError("Blossom requires Python 3.10")
+
+import argparse
+
+from core.musicgen_backend import generate_music
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description="Generate music from a text prompt using MusicGen")
+    ap.add_argument("--prompt", required=True, help="Text prompt for generation")
+    ap.add_argument("--duration", type=float, default=10, help="Duration of the clip in seconds")
+    ap.add_argument("--model", default="facebook/musicgen-small", help="MusicGen model identifier")
+    ap.add_argument("--temperature", type=float, default=1.0, help="Sampling temperature")
+    ap.add_argument("--output-dir", default="out", help="Directory to write output audio")
+    args = ap.parse_args()
+
+    out_path = generate_music(
+        prompt=args.prompt,
+        duration=args.duration,
+        model_name=args.model,
+        temperature=args.temperature,
+        output_dir=args.output_dir,
+    )
+    print(out_path)


### PR DESCRIPTION
## Summary
- add `main_musicgen.py` CLI for generating music with MusicGen
- document the new MusicGen CLI in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'scipy.signal'; 'scipy' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a3f7fac0832582adcdc1f0473572