### PR TITLE
Add MusicGen command to Tauri backend

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,0 +1,28 @@
+use std::process::Command;
+
+use tauri::async_runtime;
+
+#[tauri::command]
+pub async fn generate_musicgen(
+    prompt: String,
+    duration: f32,
+    model_name: String,
+    temperature: f32,
+) -> Result<String, String> {
+    let code = format!(concat!(
+        "import core.musicgen_backend as m; ",
+        "print(m.generate_music({prompt:?}, {duration}, {model_name:?}, {temperature}, 'out'))",
+    ));
+
+    let output =
+        async_runtime::spawn_blocking(move || Command::new("python").args(["-c", &code]).output())
+            .await
+            .map_err(|e| e.to_string())??;
+
+    if !output.status.success() {
+        return Err(String::from_utf8_lossy(&output.stderr).to_string());
+    }
+
+    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Ok(path)
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -22,10 +22,12 @@ use tauri_plugin_opener::OpenerExt;
 use tauri_plugin_store::{Builder, Store, StoreBuilder};
 use tempfile::NamedTempFile;
 use url::Url;
+mod commands;
 mod config;
 mod musiclang;
 mod util;
 use crate::util::list_from_dir;
+use commands::generate_musicgen;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone)]
 struct Npc {
@@ -1036,6 +1038,7 @@ fn main() {
             remove_piper_profile,
             piper_test,
             musicgen_test,
+            generate_musicgen,
             list_llm,
             set_llm,
             npc_list,


### PR DESCRIPTION
## Summary
- support generating music via Python backend using new `generate_musicgen` command
- wire command into Tauri main module for frontend access

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: failed to download from https://index.crates.io/config.json, 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a3f213d48325bac8416665d7c533