### PR TITLE
Add soundfile to TTS optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.10,<3.11"
 [project.optional-dependencies]
 midi = ["mido"]
 diarization = ["pyannote.audio"]
-tts = ["piper-tts"]
+tts = ["piper-tts", "soundfile"]
 
 [build-system]
 requires = ["setuptools>=61"]


### PR DESCRIPTION
## Summary
- include `soundfile` alongside `piper-tts` in the `tts` optional dependencies

## Testing
- `pip install --no-cache-dir --index-url https://pypi.org/simple .[tts]` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'scipy' and others during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a692c60883259e5eaa3589d9f1d2