### PR TITLE
Use tauri path resolve for musicgen test script

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -465,8 +465,8 @@ sf.write({wav:?}, audio, 22050)
 fn musicgen_test(app_handle: AppHandle) -> Result<Vec<u8>, String> {
     let script = app_handle
         .path()
-        .resolve_resource("scripts/test_musicgen.py")
-        .map_err(|_| "failed to resolve test script".to_string())?;
+        .resolve("scripts/test_musicgen.py")
+        .ok_or("failed to resolve test script")?;
     let output = Command::new("python")
         .arg(script)
         .output()


### PR DESCRIPTION
## Summary
- Use AppHandle.path().resolve for musicgen test script path
- Simplify error handling with ok_or when resolving test script

## Testing
- `cargo build --manifest-path src-tauri/Cargo.toml` *(fails: [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*

------
https://chatgpt.com/codex/tasks/task_e_68c7a476db488325a2211b0dc98d7a63