### PR TITLE
Add games card to dashboard

### DIFF
--- a/ui/src/pages/Dashboard.jsx
+++ b/ui/src/pages/Dashboard.jsx
@@ -9,6 +9,7 @@ export default function Dashboard() {
       <main className="dashboard">
         <Card to="/musicgen" icon="Music" title="MusicGen" />
         <Card to="/dnd" icon="Dice5" title="Dungeons & Dragons" />
+        <Card to="/games" icon="Gamepad2" title="Games" />
         <Card to="/tools" icon="Tool" title="Tools" />
         <Card to="/settings" icon="Settings" title="Settings" />
         <Card to="/train" icon="Sliders" title="Train Model" />


### PR DESCRIPTION
## Summary
- add Games card link to dashboard navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite not found, dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a4c5a9ac83259dc461df2958d2c5