### PR TITLE
Add games route

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -8,6 +8,7 @@ import MusicGen from './pages/MusicGen.jsx';
 import Tools from './pages/Tools.jsx';
 import Fusion from './pages/Fusion.jsx';
 import LoopMaker from './pages/LoopMaker.jsx';
+import Games from './pages/Games.jsx';
 
 export default function App() {
   return (
@@ -22,6 +23,7 @@ export default function App() {
         <Route path="/tools" element={<Tools />} />
         <Route path="/fusion" element={<Fusion />} />
         <Route path="/loopmaker" element={<LoopMaker />} />
+        <Route path="/games" element={<Games />} />
       </Routes>
     </>
   );


### PR DESCRIPTION
## Summary
- expose existing Games page in routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a849a230832585329c6e35035d07