### PR TITLE
Add Rain Blocks and Snake game scaffolds with routing

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -8,6 +8,9 @@ import MusicGen from './pages/MusicGen.jsx';
 import Tools from './pages/Tools.jsx';
 import Fusion from './pages/Fusion.jsx';
 import LoopMaker from './pages/LoopMaker.jsx';
+import Games from './pages/Games.jsx';
+import RainBlocks from './pages/RainBlocks.jsx';
+import Snake from './pages/Snake.jsx';
 
 export default function App() {
   return (
@@ -22,6 +25,9 @@ export default function App() {
         <Route path="/tools" element={<Tools />} />
         <Route path="/fusion" element={<Fusion />} />
         <Route path="/loopmaker" element={<LoopMaker />} />
+        <Route path="/games" element={<Games />} />
+        <Route path="/games/rain-blocks" element={<RainBlocks />} />
+        <Route path="/games/snake" element={<Snake />} />
       </Routes>
     </>
   );

--- a/ui/src/pages/RainBlocks.jsx
+++ b/ui/src/pages/RainBlocks.jsx
@@ -1,0 +1,13 @@
+import BackButton from '../components/BackButton.jsx';
+
+export default function RainBlocks() {
+  return (
+    <>
+      <BackButton />
+      <h1>Rain Blocks</h1>
+      <div className="game-container">
+        {/* Game logic coming soon */}
+      </div>
+    </>
+  );
+}

--- a/ui/src/pages/Snake.jsx
+++ b/ui/src/pages/Snake.jsx
@@ -1,0 +1,13 @@
+import BackButton from '../components/BackButton.jsx';
+
+export default function Snake() {
+  return (
+    <>
+      <BackButton />
+      <h1>Snake</h1>
+      <div className="game-container">
+        {/* Game logic coming soon */}
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add Rain Blocks game page scaffold with BackButton and placeholder container
- add Snake game page scaffold with BackButton and placeholder container
- wire new game routes into App router

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a84b71e48325b9b519ad61c053ff