### PR TITLE
Add scaffolding for Rain Blocks and Snake game pages

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -9,6 +9,8 @@ import Tools from './pages/Tools.jsx';
 import Fusion from './pages/Fusion.jsx';
 import LoopMaker from './pages/LoopMaker.jsx';
 import Games from './pages/Games.jsx';
+import RainBlocks from './pages/RainBlocks.jsx';
+import Snake from './pages/Snake.jsx';
 
 export default function App() {
   return (
@@ -24,6 +26,8 @@ export default function App() {
         <Route path="/fusion" element={<Fusion />} />
         <Route path="/loopmaker" element={<LoopMaker />} />
         <Route path="/games" element={<Games />} />
+        <Route path="/games/rain-blocks" element={<RainBlocks />} />
+        <Route path="/games/snake" element={<Snake />} />
       </Routes>
     </>
   );

--- a/ui/src/pages/RainBlocks.jsx
+++ b/ui/src/pages/RainBlocks.jsx
@@ -1,0 +1,18 @@
+import { useEffect, useRef } from 'react';
+import BackButton from '../components/BackButton.jsx';
+
+export default function RainBlocks() {
+  const gameRef = useRef(null);
+
+  useEffect(() => {
+    // TODO: Implement Rain Blocks game logic
+  }, []);
+
+  return (
+    <>
+      <BackButton />
+      <h1>Rain Blocks</h1>
+      <div ref={gameRef} className="game-container"></div>
+    </>
+  );
+}

--- a/ui/src/pages/Snake.jsx
+++ b/ui/src/pages/Snake.jsx
@@ -1,0 +1,18 @@
+import { useEffect, useRef } from 'react';
+import BackButton from '../components/BackButton.jsx';
+
+export default function Snake() {
+  const gameRef = useRef(null);
+
+  useEffect(() => {
+    // TODO: Implement Snake game logic
+  }, []);
+
+  return (
+    <>
+      <BackButton />
+      <h1>Snake</h1>
+      <div ref={gameRef} className="game-container"></div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add placeholder RainBlocks and Snake pages with BackButton and headings
- wire up routes for rain-blocks and snake games
- ensure Games page links to new game routes

## Testing
- `npm test` (fails: Missing script)
- `npm run build` (fails: vite not found)


------
https://chatgpt.com/codex/tasks/task_e_68c7a988d09083258102faf453e678be