### PR TITLE
refactor: simplify musicgen command formatting

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -9,10 +9,14 @@ pub async fn generate_musicgen(
     model_name: String,
     temperature: f32,
 ) -> Result<String, String> {
-    let code = format!(concat!(
-        "import core.musicgen_backend as m; ",
-        "print(m.generate_music({prompt:?}, {duration}, {model_name:?}, {temperature}, 'out'))",
-    ));
+    let code = format!(
+        "import core.musicgen_backend as m; \
+         print(m.generate_music({prompt:?}, {duration}, {model_name:?}, {temperature}, 'out'))",
+        prompt = prompt,
+        duration = duration,
+        model_name = model_name,
+        temperature = temperature,
+    );
 
     let output =
         async_runtime::spawn_blocking(move || Command::new("python").args(["-c", &code]).output())


### PR DESCRIPTION
## Summary
- refactor generate_musicgen Python snippet to use a single `format!` string with named parameters

## Testing
- `cargo check` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68c7af9f3ec48325b9af5a552082cac6