### PR TITLE
refactor: map spawn errors

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -18,10 +18,11 @@ pub async fn generate_musicgen(
         temperature = temperature,
     );
 
-    let output =
-        async_runtime::spawn_blocking(move || Command::new("python").args(["-c", &code]).output())
-            .await
-            .map_err(|e| e.to_string())??;
+    let output = async_runtime
+        ::spawn_blocking(move || Command::new("python").args(["-c", &code]).output())
+        .await
+        .map_err(|e| e.to_string())?
+        .map_err(|e| e.to_string())?;
 
     if !output.status.success() {
         return Err(String::from_utf8_lossy(&output.stderr).to_string());


### PR DESCRIPTION
## Summary
- map blocking musicgen command execution errors with explicit conversions

## Testing
- `cargo check` *(fails: failed to download crates `futures-sink` due to 403 CONNECT tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b1c44f8c83258616c93c58c30016