### PR TITLE
refactor: rename musicgen model param

### DIFF
--- a/ui/src/pages/MusicGen.jsx
+++ b/ui/src/pages/MusicGen.jsx
@@ -25,7 +25,7 @@ export default function MusicGen() {
       const path = await invoke("generate_musicgen", {
         prompt,
         duration: Number(duration),
-        model: modelName,
+        modelName,
         temperature: Number(temperature),
       });
       const src = convertFileSrc(path);


### PR DESCRIPTION
## Summary
- replace MusicGen UI invocation argument `model` with `modelName`

## Testing
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b562ea98832594ca4c602f4ea038