### PR TITLE
Set Python working directory for musicgen command

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -18,11 +18,16 @@ pub async fn generate_musicgen(
         temperature = temperature,
     );
 
-    let output = async_runtime
-        ::spawn_blocking(move || Command::new("python").args(["-c", &code]).output())
-        .await
-        .map_err(|e| e.to_string())?
-        .map_err(|e| e.to_string())?;
+    let output = async_runtime::spawn_blocking(move || {
+        Command::new("python")
+            .current_dir("..")
+            .env("PYTHONPATH", "..")
+            .args(["-c", &code])
+            .output()
+    })
+    .await
+    .map_err(|e| e.to_string())?
+    .map_err(|e| e.to_string())?;
 
     if !output.status.success() {
         return Err(String::from_utf8_lossy(&output.stderr).to_string());


### PR DESCRIPTION
## Summary
- ensure generate_musicgen spawns python from project root and sets PYTHONPATH so core.musicgen_backend imports

## Testing
- `cargo build` *(fails: failed to download dependencies - 403)*
- `pip install numpy` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c821891ab88325ab9b1298d86903ac