### PR TITLE
chore: ignore piper voice models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ src-tauri/target
 # Environment variables
 .env
 *.env.local
+
+# Piper voices (big files)
+assets/voice_models/**


### PR DESCRIPTION
## Summary
- ignore large piper voice model files to avoid committing big assets

## Testing
- `pytest` *(fails: No module named 'scipy')*

------
https://chatgpt.com/codex/tasks/task_e_68c82458d9288325a6719af4a9162642