### PR TITLE
feat: enable shell plugin

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,6 +13,7 @@ reqwest = { version = "0.11", default-features = false, features = ["blocking", 
 tauri-plugin-dialog = { version = "2.0.0-rc.8" }
 tauri-plugin-opener = { version = "2.0.0-rc.8" }
 tauri-plugin-store = { version = "2.0.0-rc.8" }
+tauri-plugin-shell = "2"
 url = "2"
 futures-sink = "0.3.31"
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -21,6 +21,7 @@ use tauri::{async_runtime, AppHandle, Runtime, State};
 use tauri_plugin_dialog::DialogExt;
 use tauri_plugin_opener::OpenerExt;
 use tauri_plugin_store::{Builder, Store, StoreBuilder};
+use tauri_plugin_shell::init as shell_init;
 use tempfile::NamedTempFile;
 use url::Url;
 mod commands;
@@ -952,6 +953,7 @@ fn main() {
     if let Err(e) = tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
+        .plugin(shell_init())
         .plugin(Builder::new().build())
         .setup(|app| -> Result<(), Box<dyn std::error::Error>> {
             // Prefer a repo-root virtualenv (../.venv) when running from src-tauri

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -26,5 +26,6 @@
     }
   },
   "plugins": {
+    "shell": { "scope": [{ "name": "piper", "cmd": "piper" }] }
   }
 }


### PR DESCRIPTION
## Summary
- add tauri-plugin-shell dependency
- initialize shell plugin in Tauri builder
- configure shell plugin scope for piper command

## Testing
- `cargo check` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68c82753d2c88325bfb8c72a766065f7