### PR TITLE
Add default prompt for MusicGen script

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,15 @@ falling back to `localStorage` when the plugin is not available.
 
 ## MusicGen smoke test
 
-Generate a short clip with Meta's pretrained MusicGen model:
+Generate a short clip with Meta's pretrained MusicGen model. The `--prompt`
+argument defaults to "60 bpm, chill, lofi vibe", so the script runs without
+any parameters. Override it by passing your own prompt:
 
 ```bash
+# uses the default prompt
+python main_musicgen.py
+
+# override the prompt
 python main_musicgen.py --prompt "lofi hip hop beat for studying"
 ```
 

--- a/main_musicgen.py
+++ b/main_musicgen.py
@@ -9,7 +9,9 @@ from core.musicgen_backend import generate_music
 
 if __name__ == "__main__":
     ap = argparse.ArgumentParser(description="Generate music from a text prompt using MusicGen")
-    ap.add_argument("--prompt", required=True, help="Text prompt for generation")
+    ap.add_argument("--prompt",
+                    default="60 bpm, chill, lofi vibe",
+                    help="Text prompt for generation (default: %(default)s)")
     ap.add_argument("--duration", type=float, default=10, help="Duration of the clip in seconds")
     ap.add_argument("--model", default="facebook/musicgen-small", help="MusicGen model identifier")
     ap.add_argument("--temperature", type=float, default=1.0, help="Sampling temperature")


### PR DESCRIPTION
## Summary
- allow `main_musicgen.py` to run without a prompt by adding a default
- document the default MusicGen prompt in the README and show how to override it

## Testing
- `pytest` *(fails: No module named 'scipy', 'soundfile', 'discord.ext', attribute errors in sampling)*

------
https://chatgpt.com/codex/tasks/task_e_68c828e1e2388325a2b1b855780c1dbb