### PR TITLE
Style settings page with theme-based layout

### DIFF
--- a/ui/src/pages/Settings.css
+++ b/ui/src/pages/Settings.css
@@ -1,0 +1,42 @@
+.settings {
+  max-width: 60rem;
+  margin: 0 auto;
+  padding: var(--space-lg);
+}
+
+.settings-section {
+  margin-top: var(--space-lg);
+  padding: var(--space-md);
+  background: var(--card-bg);
+  border-radius: var(--space-sm);
+  box-shadow: var(--card-shadow);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.settings label {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.settings button + button {
+  margin-left: var(--space-sm);
+}
+
+.settings .button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
+
+.settings-section ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+.settings-section ul li + li {
+  margin-top: var(--space-xs);
+}
+

--- a/ui/src/pages/Settings.jsx
+++ b/ui/src/pages/Settings.jsx
@@ -28,6 +28,7 @@ import {
   setBaseFontSize,
   getBaseFontSize,
 } from "../../theme.js";
+import "./Settings.css";
 
 export default function Settings() {
   const VAULT_KEY = "vaultPath";
@@ -132,22 +133,24 @@ export default function Settings() {
   };
 
   return (
-    <div>
+    <main className="settings">
       <BackButton />
       <h1>Settings</h1>
-      <div>
+      <section className="settings-section">
         <p>Vault path: {vault || "(none)"}</p>
-        <button type="button" onClick={chooseVault}>
-          Choose Vault
-        </button>
-        <button type="button" onClick={exportSettings}>
-          Export Settings
-        </button>
-        <button type="button" onClick={importSettings}>
-          Import Settings
-        </button>
-      </div>
-      <div>
+        <div className="button-row">
+          <button type="button" onClick={chooseVault}>
+            Choose Vault
+          </button>
+          <button type="button" onClick={exportSettings}>
+            Export Settings
+          </button>
+          <button type="button" onClick={importSettings}>
+            Import Settings
+          </button>
+        </div>
+      </section>
+      <section className="settings-section">
         <label>
           Whisper size
           <select
@@ -161,8 +164,8 @@ export default function Settings() {
             ))}
           </select>
         </label>
-      </div>
-      <div>
+      </section>
+      <section className="settings-section">
         <label>
           Piper voice
           <select
@@ -176,8 +179,8 @@ export default function Settings() {
             ))}
           </select>
         </label>
-      </div>
-      <div>
+      </section>
+      <section className="settings-section">
         <label>
           LLM model
           <select
@@ -191,8 +194,8 @@ export default function Settings() {
             ))}
           </select>
         </label>
-      </div>
-      <div>
+      </section>
+      <section className="settings-section">
         <label>
           Input device
           <select
@@ -211,8 +214,8 @@ export default function Settings() {
             ))}
           </select>
         </label>
-      </div>
-      <div>
+      </section>
+      <section className="settings-section">
         <label>
           Output device
           <select
@@ -231,8 +234,8 @@ export default function Settings() {
             ))}
           </select>
         </label>
-      </div>
-      <div>
+      </section>
+      <section className="settings-section">
         <h2>Appearance</h2>
         <div>
           <label>
@@ -287,8 +290,8 @@ export default function Settings() {
             Larger fonts improve readability for visually impaired users.
           </p>
         </div>
-      </div>
-      <div>
+      </section>
+      <section className="settings-section">
         <h2>Hotwords</h2>
         <ul>
           {Object.entries(hotwords).map(([name, enabled]) => (
@@ -307,9 +310,11 @@ export default function Settings() {
         <button type="button" onClick={addHotword}>
           Upload Hotword Model
         </button>
-      </div>
-      <LogPanel />
-    </div>
+      </section>
+      <section className="settings-section">
+        <LogPanel />
+      </section>
+    </main>
   );
 }
 


### PR DESCRIPTION
## Summary
- Add `Settings.css` for a centered settings layout with themed card sections and consistent control spacing
- Import new styles and structure Settings page with `<main>` and `<section>` wrappers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c82969aa6c8325a9b685a791437cb4