### PR TITLE
feat: use local piper voices

### DIFF
--- a/ui/src/pages/Settings.jsx
+++ b/ui/src/pages/Settings.jsx
@@ -5,11 +5,11 @@ import { open as openDialog, save as saveDialog } from "@tauri-apps/plugin-dialo
 import {
   listWhisper,
   setWhisper as apiSetWhisper,
-  listPiper,
   setPiper as apiSetPiper,
   listLlm,
   setLlm as apiSetLlm,
 } from "../api/models";
+import { listPiperVoices } from "../lib/piperVoices";
 import { listDevices, setDevices as apiSetDevices } from "../api/devices";
 import { listHotwords, setHotword as apiSetHotword } from "../api/hotwords";
 import {
@@ -64,7 +64,14 @@ export default function Settings() {
   useEffect(() => {
     const load = async () => {
       setWhisper(await listWhisper());
-      setPiper(await listPiper());
+      const voices = await listPiperVoices();
+      setPiper((prev) => {
+        const options = voices.map((v) => v.id);
+        const selected = options.includes(prev.selected)
+          ? prev.selected
+          : options[0] || "";
+        return { options, selected };
+      });
       setLlm(await listLlm());
       const devices = await listDevices();
       setInput(devices.input);
@@ -167,7 +174,11 @@ export default function Settings() {
           Piper voice
           <select
             value={piper.selected || ""}
-            onChange={(e) => apiSetPiper(e.target.value)}
+            onChange={(e) => {
+              const value = e.target.value;
+              setPiper((prev) => ({ ...prev, selected: value }));
+              apiSetPiper(value);
+            }}
           >
             {piper.options.map((o) => (
               <option key={o} value={o}>


### PR DESCRIPTION
## Summary
- load piper voice options directly from local assets
- update Settings and DnD pages to use `listPiperVoices`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `(cd ui && npm test)` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c82adfda288325baeae573d7c10855