### PR TITLE
refactor: improve settings page semantics

### DIFF
--- a/ui/src/pages/Settings.jsx
+++ b/ui/src/pages/Settings.jsx
@@ -132,7 +132,7 @@ export default function Settings() {
   };
 
   return (
-    <div>
+    <main>
       <BackButton />
       <h1>Settings</h1>
       <div>
@@ -147,117 +147,123 @@ export default function Settings() {
           Import Settings
         </button>
       </div>
-      <div>
-        <label>
-          Whisper size
-          <select
-            value={whisper.selected || ""}
-            onChange={(e) => apiSetWhisper(e.target.value)}
-          >
-            {whisper.options.map((o) => (
-              <option key={o} value={o}>
-                {o}
-              </option>
-            ))}
-          </select>
-        </label>
-      </div>
-      <div>
-        <label>
-          Piper voice
-          <select
-            value={piper.selected || ""}
-            onChange={(e) => apiSetPiper(e.target.value)}
-          >
-            {piper.options.map((o) => (
-              <option key={o} value={o}>
-                {o}
-              </option>
-            ))}
-          </select>
-        </label>
-      </div>
-      <div>
-        <label>
-          LLM model
-          <select
-            value={llm.selected || ""}
-            onChange={(e) => apiSetLlm(e.target.value)}
-          >
-            {llm.options.map((o) => (
-              <option key={o} value={o}>
-                {o}
-              </option>
-            ))}
-          </select>
-        </label>
-      </div>
-      <div>
-        <label>
-          Input device
-          <select
-            value={input.selected || ""}
-            onChange={(e) =>
-              apiSetDevices({
-                input: Number(e.target.value),
-                output: output.selected,
-              })
-            }
-          >
-            {input.options.map((o) => (
-              <option key={o.id} value={o.id}>
-                {o.name}
-              </option>
-            ))}
-          </select>
-        </label>
-      </div>
-      <div>
-        <label>
-          Output device
-          <select
-            value={output.selected || ""}
-            onChange={(e) =>
-              apiSetDevices({
-                input: input.selected,
-                output: Number(e.target.value),
-              })
-            }
-          >
-            {output.options.map((o) => (
-              <option key={o.id} value={o.id}>
-                {o.name}
-              </option>
-            ))}
-          </select>
-        </label>
-      </div>
-      <div>
-        <h2>Appearance</h2>
-        <div>
-          <label>
-            Theme
+      <section>
+        <fieldset>
+          <legend>Models</legend>
+          <div>
+            <label htmlFor="whisper-select">Whisper size</label>
             <select
+              id="whisper-select"
+              value={whisper.selected || ""}
+              onChange={(e) => apiSetWhisper(e.target.value)}
+            >
+              {whisper.options.map((o) => (
+                <option key={o} value={o}>
+                  {o}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label htmlFor="piper-select">Piper voice</label>
+            <select
+              id="piper-select"
+              value={piper.selected || ""}
+              onChange={(e) => apiSetPiper(e.target.value)}
+            >
+              {piper.options.map((o) => (
+                <option key={o} value={o}>
+                  {o}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label htmlFor="llm-select">LLM model</label>
+            <select
+              id="llm-select"
+              value={llm.selected || ""}
+              onChange={(e) => apiSetLlm(e.target.value)}
+            >
+              {llm.options.map((o) => (
+                <option key={o} value={o}>
+                  {o}
+                </option>
+              ))}
+            </select>
+          </div>
+        </fieldset>
+      </section>
+      <section>
+        <fieldset>
+          <legend>Devices</legend>
+          <div>
+            <label htmlFor="input-device">Input device</label>
+            <select
+              id="input-device"
+              value={input.selected || ""}
+              onChange={(e) =>
+                apiSetDevices({
+                  input: Number(e.target.value),
+                  output: output.selected,
+                })
+              }
+            >
+              {input.options.map((o) => (
+                <option key={o.id} value={o.id}>
+                  {o.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label htmlFor="output-device">Output device</label>
+            <select
+              id="output-device"
+              value={output.selected || ""}
+              onChange={(e) =>
+                apiSetDevices({
+                  input: input.selected,
+                  output: Number(e.target.value),
+                })
+              }
+            >
+              {output.options.map((o) => (
+                <option key={o.id} value={o.id}>
+                  {o.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        </fieldset>
+      </section>
+      <section>
+        <fieldset>
+          <legend>Appearance</legend>
+          <div>
+            <label htmlFor="theme-select">Theme</label>
+            <select
+              id="theme-select"
               value={theme}
               onChange={async (e) => {
                 const newTheme = e.target.value;
                 await setTheme(newTheme);
                 setThemeState(newTheme);
               }}
+              aria-describedby="theme-desc"
             >
               <option value="dark">Dark</option>
               <option value="light">Light</option>
             </select>
-          </label>
-          <p>
-            Dark mode reduces eye strain in low-light environments, while light
-            mode provides better readability in bright settings.
-          </p>
-        </div>
-        <div>
-          <label>
-            Accent color
+            <p id="theme-desc">
+              Dark mode reduces eye strain in low-light environments, while light
+              mode provides better readability in bright settings.
+            </p>
+          </div>
+          <div>
+            <label htmlFor="accent-color">Accent color</label>
             <input
+              id="accent-color"
               type="color"
               value={accent}
               onChange={async (e) => {
@@ -266,50 +272,54 @@ export default function Settings() {
                 setAccentState(color);
               }}
             />
-          </label>
-        </div>
-        <div>
-          <label>
-            Font Size
+          </div>
+          <div>
+            <label htmlFor="font-size">Font Size</label>
             <select
+              id="font-size"
               value={baseFontSize}
               onChange={async (e) => {
                 const size = e.target.value;
                 await setBaseFontSize(size);
                 setBaseFontSizeState(size);
               }}
+              aria-describedby="font-desc"
             >
               <option value="16px">Default</option>
               <option value="18px">Large</option>
             </select>
-          </label>
-          <p>
-            Larger fonts improve readability for visually impaired users.
-          </p>
-        </div>
-      </div>
-      <div>
-        <h2>Hotwords</h2>
-        <ul>
-          {Object.entries(hotwords).map(([name, enabled]) => (
-            <li key={name}>
-              <label>
-                <input
-                  type="checkbox"
-                  checked={enabled}
-                  onChange={(e) => toggleHotword(name, e.target.checked)}
-                />
-                {name}
-              </label>
-            </li>
-          ))}
-        </ul>
-        <button type="button" onClick={addHotword}>
-          Upload Hotword Model
-        </button>
-      </div>
+            <p id="font-desc">
+              Larger fonts improve readability for visually impaired users.
+            </p>
+          </div>
+        </fieldset>
+      </section>
+      <section>
+        <fieldset>
+          <legend>Hotwords</legend>
+          <ul>
+            {Object.entries(hotwords).map(([name, enabled]) => {
+              const id = `hotword-${name}`.replace(/\s+/g, "-");
+              return (
+                <li key={name}>
+                  <input
+                    id={id}
+                    type="checkbox"
+                    checked={enabled}
+                    onChange={(e) => toggleHotword(name, e.target.checked)}
+                  />
+                  <label htmlFor={id}>{name}</label>
+                </li>
+              );
+            })}
+          </ul>
+          <button type="button" onClick={addHotword}>
+            Upload Hotword Model
+          </button>
+        </fieldset>
+      </section>
       <LogPanel />
-    </div>
+    </main>
   );
 }
 


### PR DESCRIPTION
## Summary
- replace Settings page root div with main and group models, devices, appearance and hotwords into sections
- add fieldsets/legends, descriptive aria references and explicit ids for form controls

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: vite: not found)
- `npm install` (hangs, aborted)


------
https://chatgpt.com/codex/tasks/task_e_68c82aebad248325a600c31853d26c39