### PR TITLE
Add piper CLI synthesis helper and integrate into DnD preview

### DIFF
--- a/ui/src/lib/piperSynth.ts
+++ b/ui/src/lib/piperSynth.ts
@@ -1,0 +1,33 @@
+import { Command } from "@tauri-apps/plugin-shell";
+import { createDir, join } from "@tauri-apps/plugin-fs";
+
+/**
+ * Synthesize speech using the `piper` CLI.
+ *
+ * @param text   Text to synthesize.
+ * @param model  Path to the piper model (.onnx).
+ * @param config Path to the model configuration (.json).
+ * @returns The path to the generated WAV file.
+ */
+export async function synthWithPiper(
+  text: string,
+  model: string,
+  config: string,
+): Promise<string> {
+  // Ensure output directory exists
+  const dir = await join("data", "piper_tests");
+  await createDir(dir, { recursive: true });
+  const outPath = await join(dir, `${Date.now()}.wav`);
+
+  const cmd = Command.create("piper", [
+    "--model",
+    model,
+    "--config",
+    config,
+    "--output_file",
+    outPath,
+    text,
+  ]);
+  await cmd.execute();
+  return outPath;
+}

--- a/ui/src/pages/Dnd.jsx
+++ b/ui/src/pages/Dnd.jsx
@@ -1,13 +1,13 @@
 import { useEffect, useState } from "react";
 import { listNpcs, saveNpc, deleteNpc } from "../api/npcs";
 import {
-  testPiper,
   addPiperVoice,
   listPiperProfiles,
   updatePiperProfile,
   removePiperProfile,
 } from "../api/piper";
 import { listPiperVoices } from "../lib/piperVoices";
+import { synthWithPiper } from "../lib/piperSynth";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import BackButton from "../components/BackButton.jsx";
 import Icon from "../components/Icon.jsx";
@@ -312,14 +312,13 @@ export default function Dnd() {
                     return;
                   }
                   try {
-                    const res = await testPiper(piperVoice, piperText);
-                    if (res) {
-                      const path = res.path || res;
-                      const url = res.url ? res.url : convertFileSrc(path);
-                      setPiperPath(path);
-                      setPiperAudio(url);
-                      setPiperError("");
-                    }
+                    const model = `assets/voice_models/${piperVoice}/${piperVoice}.onnx`;
+                    const config = `assets/voice_models/${piperVoice}/${piperVoice}.onnx.json`;
+                    const path = await synthWithPiper(piperText, model, config);
+                    const url = convertFileSrc(path);
+                    setPiperPath(path);
+                    setPiperAudio(url);
+                    setPiperError("");
                   } catch (err) {
                     console.error(err);
                     setPiperError("Failed to generate audio.");
@@ -332,7 +331,7 @@ export default function Dnd() {
                 <div>
                   <audio controls src={piperAudio} />
                   <div>
-                    <a href={piperPath || piperAudio} download="piper.mp3">
+                    <a href={piperPath || piperAudio} download="piper.wav">
                       Download
                     </a>
                   </div>


### PR DESCRIPTION
## Summary
- add `synthWithPiper` utility using the Tauri shell plugin to run the piper CLI and save WAV output
- update DnD page to synthesize preview audio with piper models and expose WAV download

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest` *(fails: ModuleNotFoundError: No module named 'scipy' and other import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c82d3f9330832580cba5369fe39aa9