### PR TITLE
fix: update shell plugin config

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -26,6 +26,6 @@
     }
   },
   "plugins": {
-    "shell": { "scope": [{ "name": "piper", "cmd": "piper" }] }
+    "shell": { "open": [{ "name": "piper", "cmd": "piper" }] }
   }
 }


### PR DESCRIPTION
## Summary
- replace deprecated `scope` key with `open` for shell plugin

## Testing
- `npm run tauri dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c82e5d0cac832582f1128e6009a2d5