### PR TITLE
fix: update Tauri shell plugin configuration

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,12 +20,21 @@
       "capabilities": [
         {
           "identifier": "allow-internal-toggle-devtools",
-          "permissions": ["core:webview:allow-internal-toggle-devtools"]
+          "permissions": [
+            "core:webview:allow-internal-toggle-devtools"
+          ]
         }
       ]
     }
   },
   "plugins": {
-    "shell": { "open": [{ "name": "piper", "cmd": "piper" }] }
+    "shell": {
+      "scope": [
+        {
+          "name": "piper",
+          "cmd": "piper"
+        }
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- replace deprecated `open` entry with scoped shell command in `tauri.conf.json`

## Testing
- ⚠️ `cargo build --manifest-path src-tauri/Cargo.toml` *(failed: failed to download from crates.io: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c834e66d788325b92d7ccd2f1b093b