### PR TITLE
Handle piper command failures

### DIFF
--- a/ui/src/lib/piperSynth.ts
+++ b/ui/src/lib/piperSynth.ts
@@ -28,6 +28,11 @@ export async function synthWithPiper(
     outPath,
     text,
   ]);
-  await cmd.execute();
+  const res = await cmd.execute();
+  if (res.code !== 0) {
+    const message = res.stderr?.trim() || `Piper command failed with code ${res.code}`;
+    throw new Error(message);
+  }
+
   return outPath;
 }


### PR DESCRIPTION
## Summary
- capture the Piper CLI execution result in `synthWithPiper`
- throw an error with stderr output when the command exits with a failure code
- return the generated path only when the command succeeds

## Testing
- `npm --prefix ui install --no-progress` *(hangs in this environment, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68c83f1190348325a2ad7025146cff2d