### PR TITLE
Scan Piper voices from models directory

### DIFF
--- a/ui/src/api/models.js
+++ b/ui/src/api/models.js
@@ -3,7 +3,6 @@ import { invoke } from "@tauri-apps/api/core";
 export const listWhisper = () => invoke("list_whisper");
 export const setWhisper = (model) => invoke("set_whisper", { model });
 
-export const listPiper = () => invoke("list_piper");
 export const setPiper = (voice) => invoke("set_piper", { voice });
 
 export const listLlm = () => invoke("list_llm");


### PR DESCRIPTION
## Summary
- derive Piper voice options by scanning `assets/voice_models` before falling back to legacy data
- remove the unused `listPiper` front-end API export

## Testing
- cargo fmt --manifest-path src-tauri/Cargo.toml

------
https://chatgpt.com/codex/tasks/task_e_68c8410b06388325ac64db9811060fac