### PR TITLE
Handle numeric Piper voice speakers

### DIFF
--- a/ui/src/lib/piperVoices.ts
+++ b/ui/src/lib/piperVoices.ts
@@ -5,7 +5,7 @@ export interface PiperVoice {
   modelPath: string;
   configPath: string;
   lang?: string;
-  speaker?: string;
+  speaker?: number | string;
 }
 
 export async function listPiperVoices(): Promise<PiperVoice[]> {
@@ -26,7 +26,7 @@ export async function listPiperVoices(): Promise<PiperVoice[]> {
     const modelPath = await join(root, id, `${id}.onnx`);
 
     let lang: string | undefined;
-    let speaker: string | undefined;
+    let speaker: number | string | undefined;
 
     try {
       const cfgRaw = await readTextFile(configPath, {
@@ -43,8 +43,9 @@ export async function listPiperVoices(): Promise<PiperVoice[]> {
       if (!lang && typeof cfg?.language === "string") {
         lang = cfg.language;
       }
-      if (typeof cfg?.default_speaker === "string") {
-        speaker = cfg.default_speaker;
+      const defaultSpeaker = cfg?.default_speaker;
+      if (typeof defaultSpeaker === "string" || typeof defaultSpeaker === "number") {
+        speaker = defaultSpeaker;
       }
     } catch {
       // Ignore errors reading or parsing config files.


### PR DESCRIPTION
## Summary
- allow Piper voices to expose numeric default speaker identifiers
- capture either string or number default speakers when parsing config files

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c842bb44808325ac4e106f2974f94a