### PR TITLE
Add Tauri fs plugin dependency to UI

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@tauri-apps/api": "^2.8.0",
     "@tauri-apps/plugin-dialog": "^2.4.0",
+    "@tauri-apps/plugin-fs": "^2.x",
     "blossom-music-gen": "file:..",
     "lucide-react": "^0.379.0",
     "react": "^18",

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -21,6 +21,7 @@ export default defineConfig({
     exclude: [
       '@tauri-apps/api',
       '@tauri-apps/plugin-dialog',
+      '@tauri-apps/plugin-fs',
       '@tauri-apps/plugin-shell',
       '@tauri-apps/plugin-store',
       '@tauri-apps/plugin-opener',


### PR DESCRIPTION
## Summary
- add the @tauri-apps/plugin-fs runtime dependency to the UI package
- exclude the new plugin from Vite dependency optimization to match other Tauri plugins

## Testing
- npm --prefix ui install *(fails: npm error 403 Forbidden - GET https://registry.npmjs.org/@tauri-apps%2fplugin-fs)*
- npm run tauri dev *(fails: tauri command not found because CLI deps are unavailable after the failed install)*

------
https://chatgpt.com/codex/tasks/task_e_68c8434a09f8832590ad9ef70e164769