### PR TITLE
Use Tauri path join helper in Piper utilities

### DIFF
--- a/ui/src/lib/piperSynth.ts
+++ b/ui/src/lib/piperSynth.ts
@@ -1,5 +1,6 @@
 import { Command } from "@tauri-apps/plugin-shell";
-import { createDir, join } from "@tauri-apps/plugin-fs";
+import { join } from "@tauri-apps/api/path";
+import { createDir } from "@tauri-apps/plugin-fs";
 
 interface PiperSynthOptions {
   outDir?: string;

--- a/ui/src/lib/piperVoices.ts
+++ b/ui/src/lib/piperVoices.ts
@@ -1,4 +1,5 @@
-import { BaseDirectory, readDir, readTextFile, join } from "@tauri-apps/plugin-fs";
+import { join } from "@tauri-apps/api/path";
+import { BaseDirectory, readDir, readTextFile } from "@tauri-apps/plugin-fs";
 
 export interface PiperVoice {
   id: string;


### PR DESCRIPTION
## Summary
- adjust the Piper voices and synth helpers to source `join` from `@tauri-apps/api/path`
- keep filesystem helpers (`readDir`, `readTextFile`, `createDir`) imported from `@tauri-apps/plugin-fs`

## Testing
- npm run build *(fails: local `vite` binary is not available in the environment)*
- npx --yes vite@5 build *(fails: registry access returns HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c8514c9b2c83259e19b4db027819ec