### PR TITLE
Replace createDir with mkdir in piper synth

### DIFF
--- a/ui/src/lib/piperSynth.ts
+++ b/ui/src/lib/piperSynth.ts
@@ -1,6 +1,6 @@
 import { Command } from "@tauri-apps/plugin-shell";
 import { join } from "@tauri-apps/api/path";
-import { createDir } from "@tauri-apps/plugin-fs";
+import { mkdir } from "@tauri-apps/plugin-fs";
 
 interface PiperSynthOptions {
   outDir?: string;
@@ -45,11 +45,11 @@ export async function synthWithPiper(
     outPath = options.outPath;
     const derivedDir = getDirectoryFromPath(options.outPath);
     if (derivedDir) {
-      await createDir(derivedDir, { recursive: true });
+      await mkdir(derivedDir, { recursive: true });
     }
   } else {
     const dir = options.outDir ?? defaultDir;
-    await createDir(dir, { recursive: true });
+    await mkdir(dir, { recursive: true });
     outPath = await join(dir, `${Date.now()}.wav`);
   }
 


### PR DESCRIPTION
## Summary
- update the piperSynth helper to import and call `mkdir` from `@tauri-apps/plugin-fs`

## Testing
- npm run tauri build *(fails: proxy returned 403 while downloading Rust crates)*

------
https://chatgpt.com/codex/tasks/task_e_68c855eabb84832596cf6209bc25cced