### PR TITLE
Add Rain Blocks canvas layout

### DIFF
--- a/ui/src/pages/RainBlocks.jsx
+++ b/ui/src/pages/RainBlocks.jsx
@@ -1,18 +1,42 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import BackButton from '../components/BackButton.jsx';
 
+export const CELL_SIZE = 24;
+export const BOARD_COLUMNS = 10;
+export const BOARD_ROWS = 20;
+export const CANVAS_WIDTH = BOARD_COLUMNS * CELL_SIZE;
+export const CANVAS_HEIGHT = BOARD_ROWS * CELL_SIZE;
+
 export default function RainBlocks() {
-  const gameRef = useRef(null);
+  const canvasRef = useRef(null);
+  const [gameOverMessage, setGameOverMessage] = useState(null);
 
   useEffect(() => {
-    // TODO: Implement Rain Blocks game logic
-  }, []);
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return;
+    }
+
+    const context = canvas.getContext('2d');
+    context.fillStyle = '#111827';
+    context.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+
+    setGameOverMessage(null);
+  }, [canvasRef, setGameOverMessage]);
 
   return (
     <>
       <BackButton />
       <h1>Rain Blocks</h1>
-      <div ref={gameRef} className="game-container"></div>
+      {gameOverMessage && (
+        <p className="game-over-message">{gameOverMessage}</p>
+      )}
+      <canvas
+        ref={canvasRef}
+        width={CANVAS_WIDTH}
+        height={CANVAS_HEIGHT}
+        className="game-canvas"
+      ></canvas>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- set up the Rain Blocks page with exported board sizing constants
- render the back button, heading, optional game over message, and the canvas element
- initialize the canvas via a ref so drawing code can target it

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68c856360e508325b95c59f013aa1e23