### PR TITLE
Fix discord.py dependency source

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ faiss-cpu
 sentence-transformers
 watchfiles
 
-discord.py[voice] @ git+https://github.com/jg-l/discord.py
+discord.py[voice]==2.3.2
 
 # Optional: phrase models and MIDI support
 torch


### PR DESCRIPTION
## Summary
- replace the broken discord.py git dependency with the published 2.3.2 release to allow pip installs to succeed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c859ddfd5c83258d9e8b553a46a57c