### PR TITLE
Add accessible styling for DnD section navigation

### DIFF
--- a/ui/src/pages/Dnd.css
+++ b/ui/src/pages/Dnd.css
@@ -1,0 +1,57 @@
+.dnd-section-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  margin: 2rem 0;
+  padding: 0.5rem 0;
+}
+
+.dnd-section-btn {
+  align-items: center;
+  background-color: #1f2933;
+  border: 2px solid transparent;
+  border-radius: 12px;
+  color: #f9fafb;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  font-weight: 600;
+  gap: 0.75rem;
+  min-width: 8rem;
+  padding: 1.25rem 1.5rem;
+  text-align: center;
+  transition: transform 0.15s ease, box-shadow 0.15s ease,
+    border-color 0.15s ease, background-color 0.15s ease;
+}
+
+.dnd-section-btn span {
+  font-size: 1.1rem;
+  letter-spacing: 0.02em;
+}
+
+.dnd-section-btn:hover {
+  background-color: #111827;
+  border-color: #f59e0b;
+  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.25);
+  transform: translateY(-2px);
+}
+
+.dnd-section-btn:focus-visible {
+  background-color: #111827;
+  border-color: #f59e0b;
+  box-shadow: 0 0 0 4px rgba(245, 158, 11, 0.25);
+  outline: 3px solid #fbbf24;
+  outline-offset: 4px;
+}
+
+.dnd-section-btn:active {
+  background-color: #1c2230;
+  transform: translateY(0);
+}
+
+.dnd-section-btn:disabled {
+  background-color: #4b5563;
+  color: #e5e7eb;
+  cursor: not-allowed;
+  opacity: 0.75;
+}

--- a/ui/src/pages/Dnd.jsx
+++ b/ui/src/pages/Dnd.jsx
@@ -11,6 +11,7 @@ import { synthWithPiper } from "../lib/piperSynth";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import BackButton from "../components/BackButton.jsx";
 import Icon from "../components/Icon.jsx";
+import "./Dnd.css";
 
 export default function Dnd() {
   const emptyNpc = { name: "", description: "", prompt: "", voice: "" };


### PR DESCRIPTION
## Summary
- add a dedicated stylesheet for the DnD page to improve navigation spacing and contrast
- provide hover, focus, and disabled states that meet WCAG guidelines for the DnD section buttons
- import the stylesheet in the DnD page so the new styles are applied

## Testing
- not run (frontend styles only)


------
https://chatgpt.com/codex/tasks/task_e_68c85ed1596c8325a3d405c4fc52a0dc