### PR TITLE
Use Wrench icon for tools card

### DIFF
--- a/ui/src/pages/Dashboard.jsx
+++ b/ui/src/pages/Dashboard.jsx
@@ -10,7 +10,7 @@ export default function Dashboard() {
         <Card to="/musicgen" icon="Music" title="MusicGen" />
         <Card to="/dnd" icon="Dice5" title="Dungeons & Dragons" />
         <Card to="/games" icon="Gamepad2" title="Games" />
-        <Card to="/tools" icon="Tool" title="Tools" />
+        <Card to="/tools" icon="Wrench" title="Tools" />
         <Card to="/settings" icon="Settings" title="Settings" />
         <Card to="/train" icon="Sliders" title="Train Model" />
       </main>


### PR DESCRIPTION
## Summary
- replace the tools dashboard card icon with the Wrench glyph so the Icon component references a known Lucide export

## Testing
- not run (network restrictions prevented installing npm dependencies)

------
https://chatgpt.com/codex/tasks/task_e_68c85ecdd2448325aa511843091500e5