### PR TITLE
Add start overlay and running state to Snake

### DIFF
--- a/ui/src/pages/Snake.css
+++ b/ui/src/pages/Snake.css
@@ -23,3 +23,67 @@
   border-radius: var(--space-sm);
   box-shadow: 0 8px 16px rgba(0, 0, 0, 0.35);
 }
+
+.game-board {
+  position: relative;
+  display: inline-block;
+}
+
+.game-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-lg);
+  background: var(--overlay-bg);
+  border-radius: var(--space-sm);
+  text-align: center;
+  z-index: 1;
+}
+
+.game-overlay-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-sm);
+  color: var(--text);
+}
+
+.game-overlay-title {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.game-overlay-text {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.game-overlay-button {
+  padding: var(--space-sm) var(--space-md);
+  border: 2px solid var(--accent);
+  border-radius: var(--space-xs);
+  background: var(--button-bg);
+  color: var(--text);
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.1s ease;
+}
+
+.game-overlay-button:hover {
+  background: var(--button-hover-bg);
+}
+
+.game-overlay-button:active {
+  transform: translateY(1px);
+}
+
+.game-overlay-hint {
+  margin: 0;
+  font-size: 0.9rem;
+  opacity: 0.8;
+}


### PR DESCRIPTION
## Summary
- add an `isRunning` state to control when the Snake loop executes
- reset game state on demand and expose a keyboard/button driven start flow
- render and style a start overlay prompting players to press start when the game is idle

## Testing
- npm run build *(fails: vite executable not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c85ed2ebd48325bbb64b6b64a648ae