### PR TITLE
Revamp Fusion page layout

### DIFF
--- a/ui/src/pages/Fusion.css
+++ b/ui/src/pages/Fusion.css
@@ -1,0 +1,93 @@
+.fusion {
+  max-width: 60rem;
+  margin: 0 auto;
+  padding: var(--space-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.fusion h1 {
+  margin: 0;
+  font-size: clamp(2rem, 3vw, 2.75rem);
+}
+
+.fusion-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.fusion-controls {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: center;
+  gap: var(--space-md);
+}
+
+.fusion-input {
+  width: 100%;
+  padding: var(--space-sm);
+  font-size: 1rem;
+  border-radius: var(--space-xs);
+  border: 1px solid color-mix(in srgb, var(--text) 18%, transparent);
+  background: var(--card-bg);
+  color: var(--text);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.fusion-input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 25%, transparent);
+}
+
+.fusion-button {
+  align-self: stretch;
+  padding: var(--space-sm) var(--space-lg);
+  border-radius: 999px;
+  border: none;
+  background: var(--button-bg);
+  color: var(--text);
+  font-weight: 600;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+  min-width: 7rem;
+}
+
+.fusion-button:hover,
+.fusion-button:focus-visible {
+  background: var(--button-hover-bg);
+  transform: translateY(-1px);
+  box-shadow: var(--card-shadow);
+}
+
+.fusion-output {
+  min-height: 14rem;
+  padding: var(--space-lg);
+  background: var(--card-bg);
+  border-radius: var(--space-sm);
+  border: 1px solid color-mix(in srgb, var(--text) 12%, transparent);
+  box-shadow: var(--card-shadow);
+  font-size: 1.05rem;
+  line-height: 1.6;
+  white-space: pre-wrap;
+}
+
+@media (max-width: 700px) {
+  .fusion {
+    padding: var(--space-md);
+  }
+
+  .fusion-controls {
+    grid-template-columns: 1fr;
+  }
+
+  .fusion-button {
+    width: 100%;
+  }
+}

--- a/ui/src/pages/Fusion.jsx
+++ b/ui/src/pages/Fusion.jsx
@@ -1,41 +1,64 @@
 import { useState } from 'react';
 import BackButton from '../components/BackButton.jsx';
+import './Fusion.css';
 
 export default function Fusion() {
   const [conceptA, setConceptA] = useState('');
   const [conceptB, setConceptB] = useState('');
-  const [notes, setNotes] = useState('');
+  const [fusionResult, setFusionResult] = useState('');
 
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    // TODO: implement fusion logic
+  const handleSubmit = (event) => {
+    event.preventDefault();
+
+    const trimmedA = conceptA.trim();
+    const trimmedB = conceptB.trim();
+
+    if (!trimmedA && !trimmedB) {
+      setFusionResult('Enter concepts to explore their fusion.');
+      return;
+    }
+
+    if (!trimmedA || !trimmedB) {
+      setFusionResult('Add a second concept to complete the fusion.');
+      return;
+    }
+
+    setFusionResult(`Fusion of ${trimmedA} and ${trimmedB} coming soon.`);
   };
 
   return (
-    <>
+    <div className="fusion">
       <BackButton />
-      <h1>Fusion Loop Maker</h1>
-      <form onSubmit={handleSubmit}>
-        <input
-          type="text"
-          placeholder="First concept"
-          value={conceptA}
-          onChange={(e) => setConceptA(e.target.value)}
-        />
-        <input
-          type="text"
-          placeholder="Second concept"
-          value={conceptB}
-          onChange={(e) => setConceptB(e.target.value)}
-        />
-        <textarea
-          placeholder="Notes or description"
-          value={notes}
-          onChange={(e) => setNotes(e.target.value)}
-        />
-        <button type="submit">Fuse Concepts</button>
+      <h1>Fusion</h1>
+      <form className="fusion-form" onSubmit={handleSubmit}>
+        <div className="fusion-controls">
+          <input
+            className="fusion-input"
+            type="text"
+            placeholder="First concept"
+            value={conceptA}
+            onChange={(event) => setConceptA(event.target.value)}
+          />
+          <button className="fusion-button" type="submit">
+            FUSE
+          </button>
+          <input
+            className="fusion-input"
+            type="text"
+            placeholder="Second concept"
+            value={conceptB}
+            onChange={(event) => setConceptB(event.target.value)}
+          />
+        </div>
       </form>
-    </>
+      <div
+        className="fusion-output"
+        role="status"
+        aria-live="polite"
+      >
+        {fusionResult || 'Fusion results will appear here.'}
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- rename the Fusion page heading and restructure the form controls into a horizontal layout with a centered FUSE action
- replace the free-form textarea with a styled output panel that surfaces placeholder fusion results and guides the user
- add dedicated page styles to support the new layout, spacing, and responsive behavior

## Testing
- npm run build *(fails: Vite CLI is unavailable because dev dependencies could not be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c85ed786288325bb47cfc697b8aa18