### PR TITLE
Remove train card from dashboard

### DIFF
--- a/ui/src/pages/Dashboard.jsx
+++ b/ui/src/pages/Dashboard.jsx
@@ -12,7 +12,6 @@ export default function Dashboard() {
         <Card to="/games" icon="Gamepad2" title="Games" />
         <Card to="/tools" icon="Wrench" title="Tools" />
         <Card to="/settings" icon="Settings" title="Settings" />
-        <Card to="/train" icon="Sliders" title="Train Model" />
       </main>
     </>
   );


### PR DESCRIPTION
## Summary
- remove the Train Model navigation card from the dashboard home page

## Testing
- npm run build *(fails: vite: not found in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c861a5e43c8325a6f2d9fa3fca3574