### PR TITLE
Fix voice model resource handling

### DIFF
--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashSet, fs, path::Path};
 
-pub fn list_from_dir(dir: &Path) -> Result<Vec<String>, String> {
+pub fn list_from_dir<P: AsRef<Path>>(dir: P) -> Result<Vec<String>, String> {
+    let dir = dir.as_ref();
     let mut items = HashSet::new();
     for entry in fs::read_dir(dir).map_err(|e| e.to_string())? {
         let entry = entry.map_err(|e| e.to_string())?;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,7 +31,7 @@
               "identifier": "fs:scope",
               "allow": [
                 { "path": "$APPDATA/*" },
-                { "path": "D:/Blossom/Blossom_Music/assets/voice_models/**" }
+                { "path": "$RESOURCE/assets/voice_models/**" }
               ]
             }
           ]
@@ -50,6 +50,9 @@
         }
       ]
     }
+  },
+  "bundle": {
+    "resources": ["assets/voice_models/**"]
   },
   "plugins": {
     "shell": {


### PR DESCRIPTION
## Summary
- allow the fs plugin to read voice models from the bundled resource directory and add the folder to the packaged resources
- update the Rust helper to accept more path types and have `list_piper` fall back to the resource directory when discovering voices

## Testing
- npm --prefix ui run build
- npm run tauri build *(fails: crate downloads blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c863cc3058832597b61ae1072ef2a1