### PR TITLE
Add validation for unsupported MusicGen models

### DIFF
--- a/core/musicgen_backend.py
+++ b/core/musicgen_backend.py
@@ -57,6 +57,13 @@ def _get_pipeline(model_name: str):
 
     normalized_name = MODEL_NAME_ALIASES.get(model_name, model_name)
 
+    if normalized_name not in MODEL_NAME_ALIASES.values():
+        valid_options = ", ".join(MODEL_NAME_ALIASES)
+        raise ValueError(
+            f"Unsupported MusicGen model '{model_name}'. "
+            f"Please choose one of: {valid_options}, or provide a valid Hugging Face identifier."
+        )
+
     with _CACHE_LOCK:
         if normalized_name in _PIPELINE_CACHE:
             return _PIPELINE_CACHE[normalized_name]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -10,8 +10,14 @@ pub async fn generate_musicgen(
     temperature: f32,
 ) -> Result<String, String> {
     let code = format!(
-        "import core.musicgen_backend as m; \
-         print(m.generate_music({prompt:?}, {duration}, {model_name:?}, {temperature}, 'out'))",
+        r#"import sys
+import core.musicgen_backend as m
+try:
+    print(m.generate_music({prompt:?}, {duration}, {model_name:?}, {temperature}, 'out'))
+except Exception as exc:
+    sys.stderr.write(str(exc))
+    sys.exit(1)
+"#,
         prompt = prompt,
         duration = duration,
         model_name = model_name,


### PR DESCRIPTION
## Summary
- validate the requested MusicGen model name and raise a helpful ValueError when it is unsupported
- surface only the friendly error message back to the UI by catching exceptions in the Tauri command

## Testing
- python - <<'PY'
import core.musicgen_backend as m
m.pipeline = object()
try:
    m._get_pipeline("invalid")
except Exception as exc:
    print(repr(str(exc)))
PY


------
https://chatgpt.com/codex/tasks/task_e_68c8705d3cd08325a37ac27e8b821b7d