### PR TITLE
Add Rain Blocks stylesheet and overlay

### DIFF
--- a/ui/src/pages/RainBlocks.css
+++ b/ui/src/pages/RainBlocks.css
@@ -1,0 +1,113 @@
+.game-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-md);
+  padding: var(--space-lg);
+  margin: 0 auto;
+  width: fit-content;
+  max-width: 100%;
+  background: var(--card-bg);
+  border: 2px solid var(--accent);
+  border-radius: var(--space-md);
+  box-shadow: var(--card-shadow);
+}
+
+.game-container h1 {
+  margin: 0;
+  font-size: 1.75rem;
+  text-align: center;
+  color: var(--text);
+}
+
+.game-board {
+  position: relative;
+  display: inline-block;
+}
+
+.game-canvas {
+  display: block;
+  background: var(--panel-bg);
+  border: 2px solid var(--accent);
+  border-radius: var(--space-sm);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.35);
+}
+
+.game-over-message {
+  margin: 0;
+  font-weight: 600;
+  color: var(--accent);
+  text-align: center;
+}
+
+.game-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-lg);
+  background: var(--overlay-bg);
+  border-radius: var(--space-sm);
+  text-align: center;
+  z-index: 1;
+}
+
+.game-overlay-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-sm);
+  color: var(--text);
+}
+
+.game-overlay-title {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.game-overlay-text {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 500;
+  color: var(--text);
+}
+
+.game-overlay-button {
+  padding: var(--space-sm) var(--space-md);
+  border: 2px solid var(--accent);
+  border-radius: var(--space-xs);
+  background: var(--button-bg);
+  color: var(--text);
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.1s ease;
+}
+
+.game-overlay-button:hover {
+  background: var(--button-hover-bg);
+}
+
+.game-overlay-button:active {
+  transform: translateY(1px);
+}
+
+.game-overlay-hint {
+  margin: 0;
+  font-size: 0.9rem;
+  opacity: 0.8;
+  color: var(--text);
+}
+
+@media (max-width: 600px) {
+  .game-container {
+    padding: var(--space-md);
+  }
+
+  .game-overlay {
+    padding: var(--space-md);
+  }
+}

--- a/ui/src/pages/RainBlocks.jsx
+++ b/ui/src/pages/RainBlocks.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import BackButton from '../components/BackButton.jsx';
+import './RainBlocks.css';
 
 export const CELL_SIZE = 24;
 export const BOARD_COLUMNS = 10;
@@ -47,13 +48,26 @@ export default function RainBlocks() {
 
     if (!isCellFree(0, startColumn)) {
       setGameOverMessage('Game Over');
+      activePieceRef.current = null;
       setActivePiece(null);
       return false;
     }
 
-    setActivePiece({ row: 0, col: startColumn });
+    const nextPiece = { row: 0, col: startColumn };
+    activePieceRef.current = nextPiece;
+    setActivePiece(nextPiece);
     return true;
   }, [isCellFree]);
+
+  const resetGame = useCallback(() => {
+    const freshBoard = createEmptyBoard();
+    boardRef.current = freshBoard;
+    setBoard(freshBoard);
+    activePieceRef.current = null;
+    setActivePiece(null);
+    setGameOverMessage(null);
+    spawnNewPiece();
+  }, [spawnNewPiece]);
 
   const movePieceHorizontally = useCallback(
     (direction) => {
@@ -185,16 +199,35 @@ export default function RainBlocks() {
   return (
     <>
       <BackButton />
-      <h1>Rain Blocks</h1>
-      {gameOverMessage && (
-        <p className="game-over-message">{gameOverMessage}</p>
-      )}
-      <canvas
-        ref={canvasRef}
-        width={CANVAS_WIDTH}
-        height={CANVAS_HEIGHT}
-        className="game-canvas"
-      ></canvas>
+      <div className="game-container">
+        <h1>Rain Blocks</h1>
+        <div className="game-board">
+          <canvas
+            ref={canvasRef}
+            width={CANVAS_WIDTH}
+            height={CANVAS_HEIGHT}
+            className="game-canvas"
+          ></canvas>
+          {gameOverMessage && (
+            <div className="game-overlay">
+              <div className="game-overlay-content">
+                <p className="game-overlay-title">{gameOverMessage}</p>
+                <p className="game-overlay-text">Try again?</p>
+                <button
+                  type="button"
+                  className="game-overlay-button"
+                  onClick={resetGame}
+                >
+                  Restart
+                </button>
+                <p className="game-overlay-hint">
+                  Use A/D or ←/→ to move blocks
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- add a Rain Blocks page stylesheet that mirrors the Snake layout and uses theme tokens for the board, canvas, and overlay elements
- update the Rain Blocks component to import the new styles, wrap the canvas in the shared layout structure, and provide a restart overlay on game over

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c885bf81e88325b25a1056adfdbe6b