### PR TITLE
Handle MusicGen pipeline TypeError fallback

### DIFF
--- a/core/musicgen_backend.py
+++ b/core/musicgen_backend.py
@@ -129,12 +129,24 @@ def generate_music(
     )
 
     try:
-        result = pipe(
-            prompt,
-            max_new_tokens=max_new_tokens,
-            do_sample=True,
-            temperature=temperature,
-        )
+        try:
+            logger.debug("Calling MusicGen pipeline with max_new_tokens")
+            result = pipe(
+                prompt,
+                max_new_tokens=max_new_tokens,
+                do_sample=True,
+                temperature=temperature,
+            )
+        except TypeError:
+            logger.info(
+                "MusicGen pipeline rejected max_new_tokens; retrying with max_length"
+            )
+            result = pipe(
+                prompt,
+                max_length=max_new_tokens,
+                do_sample=True,
+                temperature=temperature,
+            )
         audio = result[0]["audio"]
         sample_rate = result[0]["sampling_rate"]
     except Exception as exc:  # pragma: no cover - depends on HF pipeline


### PR DESCRIPTION
## Summary
- retry the MusicGen pipeline call with max_length if max_new_tokens raises a TypeError
- add logging to clarify which invocation path is used

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c8898e5ae08325a749a134c0075db6