### PR TITLE
Use readFile for Piper audio blob

### DIFF
--- a/ui/src/pages/Dnd.jsx
+++ b/ui/src/pages/Dnd.jsx
@@ -9,7 +9,7 @@ import {
 import { listPiperVoices } from "../lib/piperVoices";
 import { synthWithPiper } from "../lib/piperSynth";
 import { convertFileSrc } from "@tauri-apps/api/core";
-import { readBinaryFile, BaseDirectory } from "@tauri-apps/plugin-fs";
+import { readFile, BaseDirectory } from "@tauri-apps/plugin-fs";
 import { appDataDir } from "@tauri-apps/api/path";
 import BackButton from "../components/BackButton.jsx";
 import Icon from "../components/Icon.jsx";
@@ -331,7 +331,7 @@ export default function Dnd() {
                     let blobUrl = "";
                     try {
                       // First try reading the absolute path directly.
-                      const data = await readBinaryFile(path);
+                      const data = await readFile(path);
                       const blob = new Blob([data], { type: "audio/wav" });
                       blobUrl = URL.createObjectURL(blob);
                     } catch (e1) {
@@ -342,7 +342,7 @@ export default function Dnd() {
                         const nPath = norm(path);
                         if (nPath.startsWith(nBase)) {
                           const rel = nPath.substring(nBase.length);
-                          const data = await readBinaryFile(rel, { baseDir: BaseDirectory.AppData });
+                          const data = await readFile(rel, { baseDir: BaseDirectory.AppData });
                           const blob = new Blob([data], { type: "audio/wav" });
                           blobUrl = URL.createObjectURL(blob);
                         }


### PR DESCRIPTION
## Summary
- switch the Piper audio handling to use `readFile` from the Tauri FS plugin
- keep the Blob creation flow intact for both absolute and app data paths

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c894790acc8325826a1ccd57f59d4b