### PR TITLE
Replace alert with inline MusicGen error display

### DIFF
--- a/ui/src/pages/MusicGen.jsx
+++ b/ui/src/pages/MusicGen.jsx
@@ -43,7 +43,6 @@ export default function MusicGen() {
     } catch (err) {
       console.error("music generation failed", err);
       setError(String(err));
-      alert(String(err));
     } finally {
       setGenerating(false);
     }
@@ -146,9 +145,13 @@ export default function MusicGen() {
         </button>
       )}
       {error && (
-        <p className="mt-md" style={{ color: "var(--accent)" }}>
-          {error}
-        </p>
+        <div
+          className="mt-md"
+          role="alert"
+          style={{ color: "var(--accent)", background: "var(--card-bg)", padding: "var(--space-sm)" }}
+        >
+          <strong>Something went wrong:</strong> {error}
+        </div>
       )}
     </>
   );


### PR DESCRIPTION
## Summary
- show MusicGen generation errors inline instead of using the dialog API
- add an accessible, styled error container to highlight failures for the user

## Testing
- npm --prefix ui run build

------
https://chatgpt.com/codex/tasks/task_e_68c895b665348325a36aa34d8ebfbb29