### PR TITLE
Update PyTorch dependencies to 2.6

### DIFF
--- a/core/musicgen_backend.py
+++ b/core/musicgen_backend.py
@@ -57,7 +57,7 @@ def _get_pipeline(model_name: str):
             "To enable MusicGen, install:\n"
             "  pip install --upgrade transformers accelerate\n"
             "And install PyTorch (CPU-only example):\n"
-            "  pip install --index-url https://download.pytorch.org/whl/cpu torch torchaudio\n"
+            "  pip install --index-url https://download.pytorch.org/whl/cpu \"torch>=2.6\" \"torchaudio>=2.6\"\n"
             "Also ensure scipy is installed for writing WAV files."
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,8 +20,8 @@ discord.py[voice]==2.3.2
 # Optional: phrase models and MIDI support
 # CPU builds by default from PyPI. For NVIDIA GPU builds see
 # requirements-gpu-cu121.txt or requirements-gpu-cu118.txt.
-torch>=2.3
-torchaudio>=2.3  # for decoding and saving audio
+torch>=2.6
+torchaudio>=2.6  # for decoding and saving audio
 onnxruntime
 mido
 transformers>=4.39


### PR DESCRIPTION
## Summary
- raise the torch and torchaudio minimum versions in requirements.txt to 2.6
- update the MusicGen backend installation guidance to reference the new minimum versions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8f17e95c48325ad74754d9a3e6bae