### PR TITLE
Add leveling and line tracking to Rain Blocks

### DIFF
--- a/ui/src/pages/RainBlocks.css
+++ b/ui/src/pages/RainBlocks.css
@@ -23,6 +23,8 @@
 .scoreboard {
   display: flex;
   justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
   width: 100%;
   font-weight: 600;
   color: var(--text);


### PR DESCRIPTION
## Summary
- add level 1-20 system with line clearing to progress
- track lines cleared and level in UI
- scale drop speed and scoring by level

## Testing
- `npm test` (fails: Missing script "test")
- `pytest` (fails: ModuleNotFoundError: No module named 'discord.ext')

------
https://chatgpt.com/codex/tasks/task_e_68c97d20876c8325940822004f24a5a3