### PR TITLE
Add dialog open capability

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -63,6 +63,14 @@
               ]
             }
           ]
+        },
+        {
+          "identifier": "allow-dialog-open",
+          "windows": ["*"],
+          "permissions": [
+            "dialog:allow-open",
+            "dialog:default"
+          ]
         }
       ]
     }


### PR DESCRIPTION
## Summary
- add a dedicated Tauri capability that grants dialog open permissions to every window

## Testing
- `npm --prefix ui run build`
- `npm run tauri build` *(fails: missing system libraries `glib-2.0` / `gobject-2.0` required by `pkg-config`)*

------
https://chatgpt.com/codex/tasks/task_e_68c97ddb973c8325b10cb8d845dfae27