### PR TITLE
Add score tracking to Snake game

### DIFF
--- a/ui/src/pages/Snake.css
+++ b/ui/src/pages/Snake.css
@@ -29,6 +29,19 @@
   display: inline-block;
 }
 
+.game-score {
+  position: absolute;
+  top: var(--space-sm);
+  left: var(--space-sm);
+  margin: 0;
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--space-xs);
+  background: rgba(15, 23, 42, 0.85);
+  color: var(--accent);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
 .game-overlay {
   position: absolute;
   inset: 0;

--- a/ui/src/pages/Snake.jsx
+++ b/ui/src/pages/Snake.jsx
@@ -43,6 +43,7 @@ export default function Snake() {
   const [food, setFood] = useState(() => randomFood(INITIAL_SNAKE));
   const [gameOver, setGameOver] = useState(false);
   const [isRunning, setIsRunning] = useState(false);
+  const [score, setScore] = useState(0);
   const canvasRef = useRef(null);
 
   const resetGameState = useCallback(() => {
@@ -51,6 +52,7 @@ export default function Snake() {
     setDirection({ x: 1, y: 0 });
     setFood(randomFood(startingSnake));
     setGameOver(false);
+    setScore(0);
   }, []);
 
   const startGame = useCallback(() => {
@@ -127,6 +129,7 @@ export default function Snake() {
 
         if (ateFood) {
           const grownSnake = [newHead, ...prevSnake];
+          setScore((prev) => prev + 1);
           setFood(randomFood(grownSnake));
           return grownSnake;
         }
@@ -202,6 +205,7 @@ export default function Snake() {
       <div className="game-container">
         <h1>Snake</h1>
         <div className="game-board">
+          <p className="game-score">Score: {score}</p>
           <canvas
             ref={canvasRef}
             width={WIDTH}


### PR DESCRIPTION
## Summary
- track the Snake game's score in component state and reset when the game restarts
- increment the score whenever the snake eats food
- overlay a styled score indicator on the game board

## Testing
- npm --prefix ui run build

------
https://chatgpt.com/codex/tasks/task_e_68c97d9ff6c48325b56f88a2af47ca69