### PR TITLE
Add core event capability to Tauri config

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -71,6 +71,14 @@
             "dialog:allow-open",
             "dialog:default"
           ]
+        },
+        {
+          "identifier": "allow-core-event",
+          "windows": ["*"],
+          "permissions": [
+            "core:event:allow-listen",
+            "core:event:default"
+          ]
         }
       ]
     }


### PR DESCRIPTION
## Summary
- add an `allow-core-event` capability so all windows can listen to core events

## Testing
- npm --prefix ui run build
- npm run tauri build *(fails: missing system dependency `glib-2.0` in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c998bd08688325a5c9486a4557e9e5