### PR TITLE
Add Rain Blocks next-piece preview

### DIFF
--- a/ui/src/pages/RainBlocks.css
+++ b/ui/src/pages/RainBlocks.css
@@ -22,12 +22,65 @@
 
 .scoreboard {
   display: flex;
-  justify-content: space-between;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: var(--space-xs);
   width: 100%;
   font-weight: 600;
   color: var(--text);
+}
+
+.scoreboard span {
+  display: block;
+  padding: var(--space-xs) var(--space-sm);
+  border-radius: var(--space-xs);
+  background: rgba(255, 255, 255, 0.05);
+  text-align: center;
+}
+
+.game-layout {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-lg);
+}
+
+.game-sidebar {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--space-md);
+  min-width: 180px;
+}
+
+.sidebar-card {
+  padding: var(--space-sm);
+  background: var(--panel-bg);
+  border: 2px solid var(--accent);
+  border-radius: var(--space-sm);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.35);
+}
+
+.preview-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
+.preview-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text);
+}
+
+.preview-canvas {
+  display: block;
+  background: rgba(17, 24, 39, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: var(--space-xs);
+  image-rendering: pixelated;
 }
 
 .game-board {
@@ -115,6 +168,22 @@
 @media (max-width: 600px) {
   .game-container {
     padding: var(--space-md);
+  }
+
+  .game-layout {
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-md);
+  }
+
+  .game-sidebar {
+    width: 100%;
+    max-width: 320px;
+    align-items: center;
+  }
+
+  .sidebar-card {
+    width: 100%;
   }
 
   .game-overlay {


### PR DESCRIPTION
## Summary
- cache the upcoming tetromino and update the spawn logic to consume the queued shape before creating the replacement
- render the upcoming tetromino on a dedicated preview canvas and reorganize the layout into a board/sidebar split
- style the sidebar, scoreboard, and preview so the panel matches the game presentation

## Testing
- npm --prefix ui run build

------
https://chatgpt.com/codex/tasks/task_e_68c9c35627dc8325b31fce4882f7649b