### PR TITLE
Add hold mechanic to Rain Blocks

### DIFF
--- a/ui/src/pages/RainBlocks.css
+++ b/ui/src/pages/RainBlocks.css
@@ -66,6 +66,13 @@
   gap: var(--space-xs);
 }
 
+.hold-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
 .preview-title {
   margin: 0;
   font-size: 1rem;
@@ -75,7 +82,24 @@
   color: var(--text);
 }
 
+.hold-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text);
+}
+
 .preview-canvas {
+  display: block;
+  background: rgba(17, 24, 39, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: var(--space-xs);
+  image-rendering: pixelated;
+}
+
+.hold-canvas {
   display: block;
   background: rgba(17, 24, 39, 0.9);
   border: 1px solid rgba(148, 163, 184, 0.25);


### PR DESCRIPTION
## Summary
- add held piece state and track whether hold has been used for the current drop
- implement Shift/C key handler to swap with the hold and render the held piece beside the board
- style the hold preview card and update the overlay instructions to mention the new control

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9c7874d3c832585ce6effc8085f51