### PR TITLE
Enlarge Rain Blocks board and adjust layout spacing

### DIFF
--- a/ui/src/pages/RainBlocks.css
+++ b/ui/src/pages/RainBlocks.css
@@ -3,7 +3,7 @@
   flex-direction: column;
   align-items: center;
   gap: var(--space-md);
-  padding: var(--space-lg);
+  padding: clamp(var(--space-md), 3vw, var(--space-xl));
   margin: 0 auto;
   width: fit-content;
   max-width: 100%;
@@ -40,7 +40,7 @@
 .game-layout {
   display: flex;
   align-items: flex-start;
-  gap: var(--space-lg);
+  gap: clamp(var(--space-md), 4vw, var(--space-lg));
 }
 
 .game-sidebar {
@@ -48,7 +48,7 @@
   flex-direction: column;
   align-items: stretch;
   gap: var(--space-md);
-  min-width: 180px;
+  min-width: 160px;
 }
 
 .sidebar-card {

--- a/ui/src/pages/RainBlocks.jsx
+++ b/ui/src/pages/RainBlocks.jsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import BackButton from '../components/BackButton.jsx';
 import './RainBlocks.css';
 
-export const CELL_SIZE = 24;
+export const CELL_SIZE = 32;
 export const BOARD_COLUMNS = 10;
 export const BOARD_ROWS = 20;
 export const CANVAS_WIDTH = BOARD_COLUMNS * CELL_SIZE;


### PR DESCRIPTION
## Summary
- increase the Rain Blocks cell size so the playfield canvas grows accordingly
- adjust the Rain Blocks container padding, layout gap, and sidebar width to keep the larger board comfortable within the UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9d884cbe48325bfbeba18ea1d86a9