### PR TITLE
Add lore listing support

### DIFF
--- a/ui/src/api/lore.js
+++ b/ui/src/api/lore.js
@@ -1,0 +1,4 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export const listLore = () => invoke("lore_list");
+


### PR DESCRIPTION
## Summary
- add a service_api.list_lore helper that collects lore notes with parsed metadata
- expose a new Tauri lore_list command and UI API for fetching lore entries
- update the D&D page to load and display lore items with refresh/error handling

## Testing
- cargo fmt

------
https://chatgpt.com/codex/tasks/task_e_68c9d892f6ec8325becc92ac5ef12b14