### PR TITLE
Adjust Rain Blocks hold preview layout

### DIFF
--- a/ui/src/pages/RainBlocks.css
+++ b/ui/src/pages/RainBlocks.css
@@ -67,10 +67,21 @@
 }
 
 .hold-container {
+  position: absolute;
+  top: var(--space-sm);
+  right: var(--space-sm);
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: var(--space-xs);
+  padding: var(--space-xs) var(--space-sm);
+  background: rgba(15, 23, 42, 0.92);
+  border: 2px solid var(--accent);
+  border-radius: var(--space-xs);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.4);
+  transform: translateY(-100%);
+  pointer-events: none;
+  z-index: 2;
 }
 
 .preview-title {
@@ -137,7 +148,7 @@
   background: var(--overlay-bg);
   border-radius: var(--space-sm);
   text-align: center;
-  z-index: 1;
+  z-index: 5;
 }
 
 .game-overlay-content {

--- a/ui/src/pages/RainBlocks.jsx
+++ b/ui/src/pages/RainBlocks.jsx
@@ -10,6 +10,9 @@ export const CANVAS_HEIGHT = BOARD_ROWS * CELL_SIZE;
 const PREVIEW_GRID_SIZE = 4;
 const PREVIEW_CELL_SIZE = 20;
 const PREVIEW_CANVAS_SIZE = PREVIEW_GRID_SIZE * PREVIEW_CELL_SIZE;
+const HOLD_GRID_SIZE = 4;
+const HOLD_CELL_SIZE = 16;
+const HOLD_CANVAS_SIZE = HOLD_GRID_SIZE * HOLD_CELL_SIZE;
 const LOCK_DELAY_MS = 300;
 const HARD_DROP_POINTS_PER_ROW = 2;
 
@@ -566,9 +569,9 @@ export default function RainBlocks() {
     const holdCanvas = heldCanvasRef.current;
     if (!holdCanvas) return;
     const context = holdCanvas.getContext('2d');
-    context.clearRect(0, 0, PREVIEW_CANVAS_SIZE, PREVIEW_CANVAS_SIZE);
+    context.clearRect(0, 0, HOLD_CANVAS_SIZE, HOLD_CANVAS_SIZE);
     context.fillStyle = '#111827';
-    context.fillRect(0, 0, PREVIEW_CANVAS_SIZE, PREVIEW_CANVAS_SIZE);
+    context.fillRect(0, 0, HOLD_CANVAS_SIZE, HOLD_CANVAS_SIZE);
 
     if (!heldPiece) {
       return;
@@ -577,18 +580,18 @@ export default function RainBlocks() {
     const { matrix, color } = heldPiece;
     const rows = matrix.length;
     const cols = matrix[0].length;
-    const offsetRow = Math.floor((PREVIEW_GRID_SIZE - rows) / 2);
-    const offsetCol = Math.floor((PREVIEW_GRID_SIZE - cols) / 2);
+    const offsetRow = Math.floor((HOLD_GRID_SIZE - rows) / 2);
+    const offsetCol = Math.floor((HOLD_GRID_SIZE - cols) / 2);
 
     context.fillStyle = color;
     matrix.forEach((rowArr, r) => {
       rowArr.forEach((cell, c) => {
         if (cell) {
           context.fillRect(
-            (offsetCol + c) * PREVIEW_CELL_SIZE,
-            (offsetRow + r) * PREVIEW_CELL_SIZE,
-            PREVIEW_CELL_SIZE,
-            PREVIEW_CELL_SIZE,
+            (offsetCol + c) * HOLD_CELL_SIZE,
+            (offsetRow + r) * HOLD_CELL_SIZE,
+            HOLD_CELL_SIZE,
+            HOLD_CELL_SIZE,
           );
         }
       });
@@ -612,6 +615,15 @@ export default function RainBlocks() {
         <h1>Rain Blocks</h1>
         <div className="game-layout">
           <div className="game-board">
+            <div className="hold-container">
+              <p className="hold-title">Hold</p>
+              <canvas
+                ref={heldCanvasRef}
+                width={HOLD_CANVAS_SIZE}
+                height={HOLD_CANVAS_SIZE}
+                className="hold-canvas"
+              ></canvas>
+            </div>
             <canvas
               ref={canvasRef}
               width={CANVAS_WIDTH}
@@ -648,15 +660,6 @@ export default function RainBlocks() {
               <span>High Score: {highScore}</span>
               <span>Lines: {linesCleared}</span>
               <span>Level: {level}</span>
-            </div>
-            <div className="hold-container sidebar-card">
-              <p className="hold-title">Hold</p>
-              <canvas
-                ref={heldCanvasRef}
-                width={PREVIEW_CANVAS_SIZE}
-                height={PREVIEW_CANVAS_SIZE}
-                className="hold-canvas"
-              ></canvas>
             </div>
             <div className="preview-container sidebar-card">
               <p className="preview-title">Next</p>


### PR DESCRIPTION
## Summary
- move the hold preview into the game board and introduce hold-specific sizing constants
- shrink the hold canvas, render it in the board's top-right corner, and update styling to keep it visible without obstructing play
- ensure the game-over overlay still appears above the hold preview while preserving the sidebar layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9d9cabb4c83259bcd435eb86203e5