### PR TITLE
Ensure chunk queries handle empty databases

### DIFF
--- a/notes/search.py
+++ b/notes/search.py
@@ -9,6 +9,7 @@ from typing import List, Tuple
 import numpy as np
 
 from .embedding import embed_texts, DEFAULT_MODEL, DEFAULT_INDEX_PATH
+from .chunker import ensure_chunk_tables
 
 
 def search_chunks(
@@ -51,6 +52,10 @@ def search_chunks(
 
     conn = sqlite3.connect(db_path)
     try:
+        ensure_chunk_tables(conn)
+        cols = [row[1] for row in conn.execute("PRAGMA table_info(chunks)")]
+        if "vector_id" not in cols:
+            return []
         if tags:
             placeholders = ",".join("?" * len(tags))
             sql = (

--- a/service_api.py
+++ b/service_api.py
@@ -17,6 +17,7 @@ from config.obsidian import get_vault
 from notes.embedding import DEFAULT_INDEX_PATH
 from notes.watchdog import DEFAULT_DB_PATH
 from notes.search import search_chunks
+from notes.chunker import ensure_chunk_tables
 from notes.parser import parse_note, NoteParseError
 
 
@@ -65,6 +66,7 @@ def search(query: str, tags: List[str] | None = None) -> List[Dict[str, Any]]:
     placeholders = ",".join("?" * len(chunk_ids))
     conn = sqlite3.connect(db_path)
     try:
+        ensure_chunk_tables(conn)
         rows = conn.execute(
             f"SELECT id, path, heading, content FROM chunks WHERE id IN ({placeholders})",
             chunk_ids,
@@ -164,6 +166,7 @@ def list_npcs() -> List[Dict[str, Any]]:
     vault, db_path, _ = _paths()
     conn = sqlite3.connect(db_path)
     try:
+        ensure_chunk_tables(conn)
         rows = conn.execute(
             """
             SELECT DISTINCT c.path FROM chunks c
@@ -204,6 +207,7 @@ def list_lore() -> List[Dict[str, Any]]:
     vault, db_path, _ = _paths()
     conn = sqlite3.connect(db_path)
     try:
+        ensure_chunk_tables(conn)
         rows = conn.execute(
             """
             SELECT DISTINCT c.path FROM chunks c

--- a/tests/test_empty_database.py
+++ b/tests/test_empty_database.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import sys
+import types
+
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import numpy as np
+
+import service_api
+from notes import search as note_search
+
+
+def _fake_embed_texts(texts, model_name=note_search.DEFAULT_MODEL):
+    items = list(texts)
+    if not items:
+        return np.zeros((0, 1), dtype="float32")
+    return np.zeros((len(items), 1), dtype="float32")
+
+
+class _FakeFaissIndex:
+    def reconstruct(self, vector_id: int) -> np.ndarray:  # pragma: no cover - defensive
+        return np.zeros(1, dtype="float32")
+
+
+def test_empty_database_returns_no_results(tmp_path: Path, monkeypatch) -> None:
+    """APIs backed by an empty database should yield empty results."""
+
+    db_path = tmp_path / "chunks.sqlite"
+    db_path.touch()
+
+    # Avoid loading heavy models or native dependencies during the test.
+    monkeypatch.setattr(note_search, "embed_texts", _fake_embed_texts)
+    fake_faiss = types.SimpleNamespace(read_index=lambda path: _FakeFaissIndex())
+    monkeypatch.setitem(sys.modules, "faiss", fake_faiss)
+
+    # Point the service API at the temporary vault directory.
+    monkeypatch.setattr(service_api, "get_vault", lambda: tmp_path)
+
+    assert service_api.search("anything") == []
+    assert service_api.list_npcs() == []
+    assert service_api.list_lore() == []
+    assert (
+        note_search.search_chunks(
+            "anything", db_path, tmp_path / note_search.DEFAULT_INDEX_PATH
+        )
+        == []
+    )


### PR DESCRIPTION
## Summary
- add a shared helper that ensures the chunk and tag tables exist
- invoke the helper before read queries in the service API and search module
- add a regression test confirming empty databases return empty results

## Testing
- pytest tests/test_empty_database.py

------
https://chatgpt.com/codex/tasks/task_e_68c9e6718cd08325a8e6bf9990c461aa