### PR TITLE
Align MusicGen pipeline kwargs usage

### DIFF
--- a/core/musicgen_backend.py
+++ b/core/musicgen_backend.py
@@ -158,21 +158,23 @@ def _get_pipeline(model_name: str, device_override: Optional[int] = None):
 
             def _build_pipe(use_safetensors: bool):
                 model_kwargs = {
+                    # The pipeline now expects safetensor preferences within model_kwargs.
                     "use_safetensors": use_safetensors,
                     # Avoid FlashAttention-related CUDA issues on some builds
                     "attn_implementation": "eager",
-                    **({"local_files_only": True} if offline else {}),
                 }
+                if offline:
+                    model_kwargs["local_files_only"] = True
                 if torch_dtype is not None and device == 0:
                     model_kwargs["torch_dtype"] = torch_dtype
 
-                base_kwargs = {
+                pipeline_kwargs = {
                     "model": normalized_name,
                     "device": device,
                     "trust_remote_code": True,
                     "model_kwargs": model_kwargs,
                 }
-                return pipeline("text-to-audio", **base_kwargs)
+                return pipeline("text-to-audio", **pipeline_kwargs)
 
             if normalized_name in BIN_ONLY_MODELS:
                 pipe = _build_pipe(use_safetensors=False)

--- a/tests/test_musicgen_backend.py
+++ b/tests/test_musicgen_backend.py
@@ -212,14 +212,12 @@ def test_get_pipeline_retries_without_safetensors(monkeypatch):
 
     assert pipe is not None
     assert len(calls) == 2
-    assert "use_safetensors" not in calls[0]
-    assert "dtype" not in calls[0]
-    assert "torch_dtype" not in calls[0]
-    assert calls[0]["model_kwargs"]["use_safetensors"] is True
-    assert "use_safetensors" not in calls[1]
-    assert "dtype" not in calls[1]
-    assert "torch_dtype" not in calls[1]
-    assert calls[1]["model_kwargs"]["use_safetensors"] is False
+
+    disallowed = {"use_safetensors", "dtype", "torch_dtype"}
+    for call, expected in zip(calls, [True, False]):
+        assert disallowed.isdisjoint(call)
+        assert "model_kwargs" in call
+        assert call["model_kwargs"]["use_safetensors"] is expected
 
 
 def test_bin_only_models_skip_safetensors(monkeypatch):
@@ -248,10 +246,12 @@ def test_bin_only_models_skip_safetensors(monkeypatch):
 
     assert pipe is not None
     assert len(calls) == 1
-    assert "use_safetensors" not in calls[0]
-    assert "dtype" not in calls[0]
-    assert "torch_dtype" not in calls[0]
-    assert calls[0]["model_kwargs"]["use_safetensors"] is False
+
+    disallowed = {"use_safetensors", "dtype", "torch_dtype"}
+    call = calls[0]
+    assert disallowed.isdisjoint(call)
+    assert "model_kwargs" in call
+    assert call["model_kwargs"]["use_safetensors"] is False
 
 
 def test_get_pipeline_gpu_dtype_passed_via_model_kwargs(monkeypatch):
@@ -285,9 +285,9 @@ def test_get_pipeline_gpu_dtype_passed_via_model_kwargs(monkeypatch):
     assert pipe is not None
     assert len(calls) == 1
     call = calls[0]
-    assert "use_safetensors" not in call
-    assert "dtype" not in call
-    assert "torch_dtype" not in call
+    disallowed = {"use_safetensors", "dtype", "torch_dtype"}
+    assert disallowed.isdisjoint(call)
+    assert "model_kwargs" in call
     assert call["model_kwargs"]["use_safetensors"] is True
     assert call["model_kwargs"]["torch_dtype"] is torch_float32
 


### PR DESCRIPTION
## Summary
- ensure the MusicGen pipeline forwards safetensor selection through `model_kwargs` alongside other model hints
- keep CUDA dtype hints scoped to `model_kwargs` and clarify the helper structure
- refresh backend tests to assert no top-level `use_safetensors`/`dtype` kwargs are leaked

## Testing
- pytest tests/test_musicgen_backend.py

------
https://chatgpt.com/codex/tasks/task_e_68cc605a7c508325b66b43bc5e99e4c2