### PR TITLE
Fix pipeline kwargs name in MusicGen backend

### DIFF
--- a/core/musicgen_backend.py
+++ b/core/musicgen_backend.py
@@ -168,13 +168,13 @@ def _get_pipeline(model_name: str, device_override: Optional[int] = None):
                 if torch_dtype is not None and device == 0:
                     model_kwargs["torch_dtype"] = torch_dtype
 
-                base_kwargs = {
+                pipeline_kwargs = {
                     "model": normalized_name,
                     "device": device,
                     "trust_remote_code": True,
                     "model_kwargs": model_kwargs,
                 }
-                return pipeline("text-to-audio", **base_kwargs)
+                return pipeline("text-to-audio", **pipeline_kwargs)
 
             def _should_retry_without_safetensors(exc: Exception) -> bool:
                 text = f"{exc.__class__.__name__}: {exc}".lower()


### PR DESCRIPTION
## Summary
- ensure the text-to-audio pipeline initialization unpacks the correct kwargs dictionary

## Testing
- pytest tests/test_musicgen_backend.py

------
https://chatgpt.com/codex/tasks/task_e_68cc6b47a0d483259852e4032af97871