### PR TITLE
Refactor Snake HUD layout

### DIFF
--- a/ui/src/pages/Snake.css
+++ b/ui/src/pages/Snake.css
@@ -19,6 +19,18 @@
   text-align: center;
 }
 
+.game-hud {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  width: 100%;
+}
+
+.game-hud--footer:empty {
+  display: none;
+}
+
 .game-canvas {
   border-radius: var(--space-sm);
   box-shadow: 0 8px 16px rgba(0, 0, 0, 0.35);
@@ -30,9 +42,6 @@
 }
 
 .game-score {
-  position: absolute;
-  top: var(--space-sm);
-  left: var(--space-sm);
   margin: 0;
   padding: 0.25rem 0.5rem;
   border-radius: var(--space-xs);

--- a/ui/src/pages/Snake.jsx
+++ b/ui/src/pages/Snake.jsx
@@ -204,8 +204,10 @@ export default function Snake() {
       <BackButton />
       <div className="game-container">
         <h1>Snake</h1>
-        <div className="game-board">
+        <header className="game-hud">
           <p className="game-score">Score: {score}</p>
+        </header>
+        <div className="game-board">
           <canvas
             ref={canvasRef}
             width={WIDTH}
@@ -231,6 +233,7 @@ export default function Snake() {
             </div>
           )}
         </div>
+        <footer className="game-hud game-hud--footer" aria-hidden="true" />
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
- move the Snake score display into a HUD header outside of the game board and add a footer placeholder for the upcoming high-score
- update the Snake styles to provide flexbox HUD layout while keeping the overlay constrained to the canvas

## Testing
- npm run build
- Manual verification of HUD/overlay behaviour in the Snake page


------
https://chatgpt.com/codex/tasks/task_e_68cc7040f0a0832591929ae3360a06da