### PR TITLE
Add persistent high score HUD to Snake mini-game

### DIFF
--- a/ui/src/pages/Snake.css
+++ b/ui/src/pages/Snake.css
@@ -29,17 +29,27 @@
   display: inline-block;
 }
 
-.game-score {
+.game-scoreboard {
   position: absolute;
   top: var(--space-sm);
-  left: var(--space-sm);
-  margin: 0;
-  padding: 0.25rem 0.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  padding: 0.35rem 0.75rem;
   border-radius: var(--space-xs);
   background: rgba(15, 23, 42, 0.85);
   color: var(--accent);
   font-weight: 700;
   letter-spacing: 0.02em;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+}
+
+.game-score-label {
+  margin: 0;
+  line-height: 1;
+  white-space: nowrap;
 }
 
 .game-overlay {


### PR DESCRIPTION
## Summary
- load and persist a Snake high score using localStorage
- update gameplay scoring to promote new records without resetting them on restart
- restyle the score HUD to show both current and high scores together

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc7045073083259d9a4eff66e1ae2e