### PR TITLE
Load Snake high score from storage

### DIFF
--- a/ui/src/pages/Snake.jsx
+++ b/ui/src/pages/Snake.jsx
@@ -44,7 +44,28 @@ export default function Snake() {
   const [gameOver, setGameOver] = useState(false);
   const [isRunning, setIsRunning] = useState(false);
   const [score, setScore] = useState(0);
+  const [highScore, setHighScore] = useState(0);
   const canvasRef = useRef(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      const storedHighScore = window.localStorage.getItem('snakeHighScore');
+      if (!storedHighScore) {
+        return;
+      }
+
+      const parsedHighScore = Number.parseInt(storedHighScore, 10);
+      if (!Number.isNaN(parsedHighScore)) {
+        setHighScore(parsedHighScore);
+      }
+    } catch {
+      // Ignore storage access failures and fall back to the default high score.
+    }
+  }, []);
 
   const resetGameState = useCallback(() => {
     const startingSnake = INITIAL_SNAKE.map((segment) => ({ ...segment }));
@@ -206,6 +227,7 @@ export default function Snake() {
         <h1>Snake</h1>
         <header className="game-hud">
           <p className="game-score">Score: {score}</p>
+          <p className="game-score">High Score: {highScore}</p>
         </header>
         <div className="game-board">
           <canvas


### PR DESCRIPTION
## Summary
- add persisted high score state to the Snake page
- populate the high score from local storage when the component mounts
- surface the stored high score alongside the in-progress score display

## Testing
- npm --prefix ui run build

------
https://chatgpt.com/codex/tasks/task_e_68cc748a84bc8325bfd0d2d539e88350