### PR TITLE
Persist Snake high score state

### DIFF
--- a/ui/src/pages/Snake.jsx
+++ b/ui/src/pages/Snake.jsx
@@ -67,6 +67,36 @@ export default function Snake() {
     }
   }, []);
 
+  useEffect(() => {
+    if (score <= highScore) {
+      return;
+    }
+
+    setHighScore(score);
+  }, [score, highScore]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    if (!Number.isFinite(highScore) || highScore <= 0) {
+      return;
+    }
+
+    try {
+      const serializedHighScore = String(highScore);
+      const storedHighScore = window.localStorage.getItem('snakeHighScore');
+      if (storedHighScore === serializedHighScore) {
+        return;
+      }
+
+      window.localStorage.setItem('snakeHighScore', serializedHighScore);
+    } catch {
+      // Ignore storage access failures and fall back to the default high score.
+    }
+  }, [highScore]);
+
   const resetGameState = useCallback(() => {
     const startingSnake = INITIAL_SNAKE.map((segment) => ({ ...segment }));
     setSnake(startingSnake);


### PR DESCRIPTION
## Summary
- update the Snake page to raise the high score state whenever the current score exceeds it
- sync high score changes back to localStorage to persist improvements between sessions

## Testing
- npm --prefix ui run build

------
https://chatgpt.com/codex/tasks/task_e_68cc7cc0a09c83259f7e52389f8354a9