### PR TITLE
Display current and high score together in Snake HUD

### DIFF
--- a/ui/src/pages/Snake.css
+++ b/ui/src/pages/Snake.css
@@ -41,14 +41,26 @@
   display: inline-block;
 }
 
-.game-score {
-  margin: 0;
-  padding: 0.25rem 0.5rem;
+.game-scoreboard {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 0.25rem;
+  margin: 0 auto;
+  padding: 0.4rem 0.75rem;
   border-radius: var(--space-xs);
   background: rgba(15, 23, 42, 0.85);
   color: var(--accent);
   font-weight: 700;
   letter-spacing: 0.02em;
+  line-height: 1.2;
+}
+
+.game-scoreboard-line {
+  margin: 0;
+  font-size: 1rem;
+  white-space: nowrap;
 }
 
 .game-overlay {

--- a/ui/src/pages/Snake.jsx
+++ b/ui/src/pages/Snake.jsx
@@ -256,8 +256,10 @@ export default function Snake() {
       <div className="game-container">
         <h1>Snake</h1>
         <header className="game-hud">
-          <p className="game-score">Score: {score}</p>
-          <p className="game-score">High Score: {highScore}</p>
+          <div className="game-scoreboard">
+            <p className="game-scoreboard-line">Score: {score}</p>
+            <p className="game-scoreboard-line">High Score: {highScore}</p>
+          </div>
         </header>
         <div className="game-board">
           <canvas


### PR DESCRIPTION
## Summary
- wrap the Snake HUD score display in a dedicated container that lists both the current and high scores
- style the new score container so the stacked values retain the original badge look and spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc7d67780c8325b92078308a132520