### PR TITLE
Add job registry persistence and expose job history in UI

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -329,6 +329,7 @@ dependencies = [
 name = "blossom_tauri"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "futures-sink",
  "regex",
  "reqwest 0.11.27",
@@ -516,8 +517,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link 0.2.0",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -9,6 +9,7 @@ regex = "1"
 tempfile = "3"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
+chrono = { version = "0.4", features = ["serde"] }
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 tauri-plugin-dialog = { version = "2.0.0-rc.8" }
 tauri-plugin-opener = { version = "2.0.0-rc.8" }

--- a/src-tauri/src/musiclang.rs
+++ b/src-tauri/src/musiclang.rs
@@ -43,7 +43,10 @@ pub fn list_musiclang_models() -> Result<Vec<ModelInfo>, String> {
                                 sibs.iter().find_map(|sib| {
                                     let name = sib.get("rfilename").and_then(|v| v.as_str())?;
                                     if name.ends_with(".onnx") {
-                                        Some((name.to_string(), sib.get("size").and_then(|v| v.as_u64())))
+                                        Some((
+                                            name.to_string(),
+                                            sib.get("size").and_then(|v| v.as_u64()),
+                                        ))
                                     } else {
                                         None
                                     }
@@ -97,10 +100,7 @@ pub fn download_model(
         return list_from_dir(path.parent().unwrap());
     }
 
-    let url = format!(
-        "https://huggingface.co/{}/resolve/main/{}",
-        name, onnx_path
-    );
+    let url = format!("https://huggingface.co/{}/resolve/main/{}", name, onnx_path);
     let mut response = blocking::get(&url)
         .and_then(|res| res.error_for_status())
         .map_err(|e| {

--- a/ui/src/pages/PhraseModel.jsx
+++ b/ui/src/pages/PhraseModel.jsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
+import { invoke, convertFileSrc } from "@tauri-apps/api/core";
 import BackButton from "../components/BackButton.jsx";
 
 export default function PhraseModel() {
@@ -45,6 +46,16 @@ export default function PhraseModel() {
   const [summary, setSummary] = useState([]);
   const [metrics, setMetrics] = useState("");
   const [showResults, setShowResults] = useState(false);
+  const [completedJobs, setCompletedJobs] = useState([]);
+
+  const formatTimestamp = useCallback((value) => {
+    if (!value) return "—";
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return value;
+    }
+    return date.toLocaleString();
+  }, []);
 
   useEffect(() => {
     async function loadOptions() {
@@ -66,6 +77,23 @@ export default function PhraseModel() {
     loadOptions();
   }, []);
 
+  const refreshJobs = useCallback(async () => {
+    try {
+      const jobs = await invoke("list_completed_jobs");
+      if (Array.isArray(jobs)) {
+        setCompletedJobs(jobs);
+      }
+    } catch (err) {
+      console.error("failed to load jobs", err);
+    }
+  }, []);
+
+  useEffect(() => {
+    refreshJobs();
+    const timer = setInterval(refreshJobs, 5000);
+    return () => clearInterval(timer);
+  }, [refreshJobs]);
+
   const chooseOutdir = () => {
     if (outdirPicker.current) outdirPicker.current.click();
   };
@@ -80,80 +108,113 @@ export default function PhraseModel() {
   };
 
   const start = async () => {
-    const fd = new FormData();
-    fd.append("preset", preset);
-    fd.append("style", style);
-    if (minutes) fd.append("minutes", minutes);
-    if (sections) fd.append("sections", sections);
-    fd.append("seed", seed);
-    if (samplerSeed) fd.append("sampler_seed", samplerSeed);
-    if (mixPreset) fd.append("mix_preset", mixPreset);
-    fd.append("name", name);
-    if (mixConfig) fd.append("mix_config", mixConfig);
-    if (arrangeConfig) fd.append("arrange_config", arrangeConfig);
-    if (bundleStems) fd.append("bundle_stems", "true");
-    if (evalOnly) fd.append("eval_only", "true");
-    if (dryRun) fd.append("dry_run", "true");
-    if (keysSfz) fd.append("keys_sfz", keysSfz);
-    if (padsSfz) fd.append("pads_sfz", padsSfz);
-    if (bassSfz) fd.append("bass_sfz", bassSfz);
-    if (drumsSfz) fd.append("drums_sfz", drumsSfz);
-    if (melodyMidi) fd.append("melody_midi", melodyMidi);
-    fd.append("phrase", "true");
-    if (drumsModel) fd.append("drums_model", drumsModel);
-    if (bassModel) fd.append("bass_model", bassModel);
-    if (keysModel) fd.append("keys_model", keysModel);
-    if (arrange) fd.append("arrange", arrange);
-    if (outro) fd.append("outro", outro);
-    if (preview) fd.append("preview", preview);
-    if (outdir) fd.append("outdir", outdir);
+    const mixConfigText = mixConfig ? await mixConfig.text() : undefined;
+    const arrangeConfigText = arrangeConfig ? await arrangeConfig.text() : undefined;
+    const options = {
+      preset: preset || undefined,
+      style: style || undefined,
+      minutes: minutes ? Number(minutes) : undefined,
+      sections: sections ? Number(sections) : undefined,
+      seed: Number(seed),
+      samplerSeed: samplerSeed ? Number(samplerSeed) : undefined,
+      mixPreset: mixPreset || undefined,
+      name: name || undefined,
+      mixConfig: mixConfigText,
+      arrangeConfig: arrangeConfigText,
+      bundleStems,
+      evalOnly,
+      dryRun,
+      keysSfz: keysSfz?.path || undefined,
+      padsSfz: padsSfz?.path || undefined,
+      bassSfz: bassSfz?.path || undefined,
+      drumsSfz: drumsSfz?.path || undefined,
+      melodyMidi: melodyMidi?.path || undefined,
+      drumsModel: drumsModel || undefined,
+      bassModel: bassModel || undefined,
+      keysModel: keysModel || undefined,
+      arrange: arrange || undefined,
+      outro: outro || undefined,
+      preview: preview ? Number(preview) : undefined,
+      outdir: outdir || undefined,
+      phrase: true,
+    };
 
     setRunning(true);
     setLog("");
     setShowResults(false);
-    const resp = await fetch("/render", { method: "POST", body: fd });
-    const data = await resp.json();
-    setJobId(data.job_id);
-    poll(data.job_id);
+    setSummary([]);
+    setMetrics("");
+    setLinks([]);
+    try {
+      const id = await invoke("queue_render_job", { options });
+      setJobId(id);
+      poll(id);
+    } catch (err) {
+      console.error("failed to start job", err);
+      setRunning(false);
+      setLog(err instanceof Error ? err.message : String(err));
+    }
   };
 
   const cancel = async () => {
     if (!jobId) return;
-    await fetch(`/jobs/${jobId}/cancel`, { method: "POST" });
+    try {
+      await invoke("cancel_render", { jobId });
+    } catch (err) {
+      console.error("failed to cancel job", err);
+    }
   };
 
   const poll = async (id) => {
     if (!id) return;
-    const resp = await fetch(`/jobs/${id}`);
-    if (!resp.ok) return;
-    const data = await resp.json();
-    setProgress(data.progress || 0);
-    setEta(data.eta || "");
-    setStage(data.stage || "");
-    setLog(data.log.join(""));
-    if (data.status === "running") {
-      setTimeout(() => poll(id), 1000);
-    } else {
-      setRunning(false);
-      if (data.status === "completed") {
-        const names = ["mix.wav", "stems.mid", "bundle.zip"];
-        setLinks(names.map((n) => ({ name: n, href: `/jobs/${id}/artifact/${n}` })));
-        const m = data.metrics || {};
-        const sum = [];
-        if (m.hash) sum.push(`Hash: ${m.hash}`);
-        if (typeof m.duration === "number")
-          sum.push(`Duration: ${m.duration.toFixed(2)}s`);
-        if (m.section_counts)
-          sum.push(
-            "Sections: " +
-              Object.entries(m.section_counts)
-                .map(([k, v]) => `${k}: ${v}`)
-                .join(", ")
+    try {
+      const data = await invoke("job_status", { jobId: id });
+      const progressInfo = data?.progress || {};
+      setProgress(progressInfo.percent || 0);
+      setEta(progressInfo.eta || "");
+      setStage(progressInfo.stage || "");
+      const stdoutLines = Array.isArray(data.stdout) ? data.stdout : [];
+      const stderrLines = Array.isArray(data.stderr) ? data.stderr : [];
+      const combined = [...stdoutLines, ...stderrLines];
+      setLog(combined.join("\n"));
+      if (data.status === "running") {
+        setTimeout(() => poll(id), 1000);
+      } else {
+        setRunning(false);
+        if (data.status === "completed") {
+          const artifacts = Array.isArray(data.artifacts) ? data.artifacts : [];
+          setLinks(
+            artifacts.map((artifact) => {
+              const path = artifact.path || "";
+              let href = "";
+              try {
+                href = path ? convertFileSrc(path) : "";
+              } catch (err) {
+                console.warn("Unable to convert artifact path", err);
+              }
+              return {
+                name: artifact.name || path || "artifact",
+                href,
+                path,
+              };
+            })
           );
-        setSummary(sum);
-        setMetrics(JSON.stringify(m, null, 2));
-        setShowResults(true);
+          setSummary([]);
+          setMetrics("");
+          setShowResults(true);
+        } else if (data.status === "error") {
+          setSummary([]);
+          setMetrics("");
+          if (data.message) {
+            setLog((prev) =>
+              prev ? `${prev}\n${data.message}` : data.message
+            );
+          }
+        }
+        refreshJobs();
       }
+    } catch (err) {
+      console.error("failed to fetch job status", err);
     }
   };
 
@@ -385,6 +446,11 @@ export default function PhraseModel() {
         <progress value={progress} max="100" />
         <span>{stage}</span>
         <span>{eta ? `ETA: ${eta}` : ""}</span>
+        {jobId && (
+          <div style={{ marginTop: "0.5rem" }}>
+            Current job ID: <strong>{jobId}</strong>
+          </div>
+        )}
       </div>
 
       <pre
@@ -404,8 +470,19 @@ export default function PhraseModel() {
           <h3>Results</h3>
           <ul>
             {links.map((l) => (
-              <li key={l.name}>
-                <a href={l.href}>{l.name}</a>
+              <li key={`${l.name}-${l.path || l.href}`}>
+                {l.href ? (
+                  <a href={l.href} target="_blank" rel="noreferrer">
+                    {l.name}
+                  </a>
+                ) : (
+                  <span>{l.name}</span>
+                )}
+                {l.path && (
+                  <small style={{ marginLeft: "0.5rem", color: "#6b7280" }}>
+                    {l.path}
+                  </small>
+                )}
               </li>
             ))}
           </ul>
@@ -417,6 +494,38 @@ export default function PhraseModel() {
           <pre>{metrics}</pre>
         </div>
       )}
+
+      <section style={{ marginTop: "2rem" }}>
+        <h2>Completed Jobs</h2>
+        {completedJobs.length ? (
+          <div style={{ overflowX: "auto" }}>
+            <table className="job-table">
+              <thead>
+                <tr>
+                  <th>ID</th>
+                  <th>Status</th>
+                  <th>Label</th>
+                  <th>Created</th>
+                  <th>Finished</th>
+                </tr>
+              </thead>
+              <tbody>
+                {completedJobs.map((job) => (
+                  <tr key={job.id}>
+                    <td>{job.id}</td>
+                    <td>{job.status}</td>
+                    <td>{job.label || job.args?.[0] || ""}</td>
+                    <td>{formatTimestamp(job.created_at || job.createdAt)}</td>
+                    <td>{formatTimestamp(job.finished_at || job.finishedAt)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <p>No completed jobs yet.</p>
+        )}
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- expand the Tauri job registry to capture metadata, persist completed jobs, and expose commands for listing, inspection, artifact registration, manual logging, and pruning
- point MusicGen, PhraseModel, LoopMaker, and BeatMaker pages at the shared job API, surfacing job IDs, artifacts, and a completed jobs table

## Testing
- cargo fmt --manifest-path src-tauri/Cargo.toml
- npm run build
- cargo test --manifest-path src-tauri/Cargo.toml *(fails: requires system glib-2.0 library)*

------
https://chatgpt.com/codex/tasks/task_e_68ccb523ec4c8325927cf69ecab21956