### PR TITLE
Fix Rain Blocks line clear timing

### DIFF
--- a/ui/src/pages/RainBlocks.jsx
+++ b/ui/src/pages/RainBlocks.jsx
@@ -301,26 +301,20 @@ export default function RainBlocks() {
 
         const runFlashCycle = () => {
           flashTimerRef.current = setTimeout(() => {
-            flashToggleCountRef.current += 1;
-            setFlashPhase((prevPhase) => !prevPhase);
-            if (flashToggleCountRef.current >= 2) {
-              const rows = clearingRowsRef.current;
-              const rowsSet = new Set(rows);
-              clearFlashTimer();
-              setBoard((prevBoard) => {
-                const remaining = prevBoard.filter((_, idx) => !rowsSet.has(idx));
-                while (remaining.length < BOARD_ROWS) {
-                  remaining.unshift(Array(BOARD_COLUMNS).fill(0));
-                }
-                return remaining;
-              });
-              clearingRowsRef.current = [];
-              setClearingRows([]);
-              setFlashPhase(false);
-              flashToggleCountRef.current = 0;
-              return;
-            }
-            runFlashCycle();
+            const rows = clearingRowsRef.current;
+            const rowsSet = new Set(rows);
+            flashTimerRef.current = null;
+            setBoard((prevBoard) => {
+              const remaining = prevBoard.filter((_, idx) => !rowsSet.has(idx));
+              while (remaining.length < BOARD_ROWS) {
+                remaining.unshift(Array(BOARD_COLUMNS).fill(0));
+              }
+              return remaining;
+            });
+            clearingRowsRef.current = [];
+            setClearingRows([]);
+            setFlashPhase(false);
+            flashToggleCountRef.current = 0;
           }, LINE_CLEAR_FLASH_DELAY);
         };
 


### PR DESCRIPTION
## Summary
- clear filled Rain Blocks rows right after the first flash delay instead of waiting for an extra toggle
- reset the flash state immediately after clearing so the next piece can spawn without the sluggish pause

## Testing
- npm install *(fails: 403 Forbidden fetching @fontsource/urbanist)*

------
https://chatgpt.com/codex/tasks/task_e_68cccbf9e7e08325b3575d59dc417145