### PR TITLE
Reorganize settings backup controls

### DIFF
--- a/ui/src/pages/Settings.jsx
+++ b/ui/src/pages/Settings.jsx
@@ -250,12 +250,6 @@ export default function Settings() {
           <button type="button" onClick={chooseVault}>
             Choose Vault
           </button>
-          <button type="button" onClick={exportSettings}>
-            Export Settings
-          </button>
-          <button type="button" onClick={importSettings}>
-            Import Settings
-          </button>
         </div>
       </section>
       <section className="settings-section">
@@ -453,6 +447,20 @@ export default function Settings() {
       </section>
       <section className="settings-section">
         <LogPanel />
+      </section>
+      <section className="settings-section">
+        <fieldset>
+          <legend>Settings Backup</legend>
+          <p>Export or import all Blossom preferences for safekeeping.</p>
+          <div className="button-row">
+            <button type="button" onClick={exportSettings}>
+              Export Settings
+            </button>
+            <button type="button" onClick={importSettings}>
+              Import Settings
+            </button>
+          </div>
+        </fieldset>
       </section>
       <section className="settings-section">
         <fieldset>


### PR DESCRIPTION
## Summary
- keep the vault controls focused on the path display and chooser button
- add a dedicated "Settings Backup" panel with helper text plus export/import buttons using the shared button-row layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ccd38296108325be52132a0b2a76df