### PR TITLE
Adjust Rain Blocks hold panel alignment

### DIFF
--- a/ui/src/pages/RainBlocks.css
+++ b/ui/src/pages/RainBlocks.css
@@ -68,8 +68,9 @@
 
 .hold-container {
   position: absolute;
-  top: var(--space-sm);
-  right: var(--space-sm);
+  top: 0;
+  left: 100%;
+  margin-left: var(--space-sm);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -79,7 +80,6 @@
   border: 2px solid var(--accent);
   border-radius: var(--space-xs);
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.4);
-  transform: translateY(-100%);
   pointer-events: none;
   z-index: 2;
 }
@@ -121,6 +121,7 @@
 .game-board {
   position: relative;
   display: inline-block;
+  margin-right: calc(4rem + (3 * var(--space-sm)) + 4px);
 }
 
 .game-canvas {


### PR DESCRIPTION
## Summary
- anchor the Rain Blocks hold container to the board's right edge without translating it above the playfield
- reserve horizontal spacing so the hold preview clears the title and sidebar layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ccdbb476c8832588e70ae03834d827