### PR TITLE
Add configurable output format for loop maker downloads

### DIFF
--- a/ui/src/lib/sharedState.jsx
+++ b/ui/src/lib/sharedState.jsx
@@ -22,6 +22,7 @@ export const DEFAULT_MUSICGEN_FORM = Object.freeze({
 export const DEFAULT_LOOPMAKER_FORM = Object.freeze({
   targetSeconds: 3600,
   targetInput: '3600',
+  outputFormat: 'video/webm;codecs=vp9,opus',
 });
 
 export const DEFAULT_BEATMAKER_FORM = Object.freeze({


### PR DESCRIPTION
## Summary
- add an output format default to the shared loop maker form state
- expose recorder MIME/extension choices in LoopMaker and persist the selection
- update recording, messaging, and job metadata to respect the selected format

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccdce9259483258a94790b3d473ee6