### PR TITLE
Refactor sanitizeName helper in LoopMaker

### DIFF
--- a/ui/src/pages/LoopMaker.jsx
+++ b/ui/src/pages/LoopMaker.jsx
@@ -59,6 +59,16 @@ const extensionFromMime = (mimeType, fallbackMimeType) => {
   return 'webm';
 };
 
+function sanitizeName(s) {
+  if (typeof s !== 'string') return '';
+  let out = '';
+  for (const ch of s) {
+    if (/^[a-zA-Z0-9 _-]$/.test(ch)) out += ch;
+    else out += '_';
+  }
+  return out.trim().replace(/\.+$/g, '').substring(0, 120) || 'loop';
+}
+
 const MAX_CONCAT_DURATION_SECONDS = 60 * 60 * 3; // 3 hours of video
 const MAX_CONCAT_FALLBACK_LOOPS = 2048;
 
@@ -1556,12 +1566,3 @@ export default function LoopMaker() {
     </div>
   );
 }
-  const sanitizeName = useCallback((s) => {
-    if (typeof s !== 'string') return '';
-    let out = '';
-    for (const ch of s) {
-      if (/^[a-zA-Z0-9 _-]$/.test(ch)) out += ch;
-      else out += '_';
-    }
-    return out.trim().replace(/\.+$/g, '').substring(0, 120) || 'loop';
-  }, []);


### PR DESCRIPTION
## Summary
- convert the sanitizeName logic into a regular helper so it no longer relies on React hooks
- keep LoopMaker using the updated helper to avoid the invalid hook call at runtime

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd764dd5988325b7f4746464302e25