### PR TITLE
Add Sound Lab landing page and nested generator routes

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -5,6 +5,8 @@ import Settings from './pages/Settings.jsx';
 import Train from './pages/Train.jsx';
 import Profiles from './pages/Profiles.jsx';
 import MusicGen from './pages/MusicGen.jsx';
+import AlgorithmicGenerator from './pages/Generate.jsx';
+import SoundLab from './pages/SoundLab.jsx';
 import Queue from './pages/Queue.jsx';
 import Tools from './pages/Tools.jsx';
 import Fusion from './pages/Fusion.jsx';
@@ -21,7 +23,10 @@ export default function App() {
     <>
       <Routes>
         <Route path="/" element={<Dashboard />} />
-        <Route path="/musicgen" element={<MusicGen />} />
+        <Route path="/musicgen" element={<SoundLab />}>
+          <Route path="musicgen" element={<MusicGen />} />
+          <Route path="algorithmic" element={<AlgorithmicGenerator />} />
+        </Route>
         <Route path="/dnd" element={<Dnd />} />
         <Route path="/settings" element={<Settings />} />
         <Route path="/profiles" element={<Profiles />} />

--- a/ui/src/pages/SoundLab.jsx
+++ b/ui/src/pages/SoundLab.jsx
@@ -1,0 +1,34 @@
+import { useOutlet } from 'react-router-dom';
+import BackButton from '../components/BackButton.jsx';
+import Card from '../components/Card.jsx';
+
+export default function SoundLab() {
+  const outlet = useOutlet();
+
+  if (outlet) {
+    return outlet;
+  }
+
+  return (
+    <>
+      <BackButton />
+      <h1>Sound Lab</h1>
+      <main className="dashboard">
+        <Card
+          to="/musicgen/musicgen"
+          icon="Waveform"
+          title="MusicGen"
+        >
+          Launch the classic prompt-to-music workflow.
+        </Card>
+        <Card
+          to="/musicgen/algorithmic"
+          icon="Cpu"
+          title="Algorithmic Generator"
+        >
+          Explore algorithmic arranging and rendering tools.
+        </Card>
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add a Sound Lab landing page with navigation cards for the MusicGen and algorithmic generators
- nest the music generation routes so the landing page sits at `/musicgen` with children for each generator

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd7f8b2c8883258133752179a38f08