### PR TITLE
Adjust dashboard ambient glow masks

### DIFF
--- a/ui/src/pages/Dashboard.css
+++ b/ui/src/pages/Dashboard.css
@@ -89,6 +89,32 @@
   position: relative;
   display: block;
   width: 100%;
+  z-index: 0;
+}
+
+.screen-ambient-wrap::after {
+  content: "";
+  position: absolute;
+  inset: -18% -12% -20%;
+  border-radius: 36px;
+  background:
+    radial-gradient(125% 120% at 50% 50%, rgba(94, 163, 255, 0.24) 0%, rgba(94, 163, 255, 0.12) 44%, rgba(94, 163, 255, 0) 84%),
+    radial-gradient(110% 90% at 20% 30%, rgba(255, 173, 208, 0.22) 0%, rgba(255, 173, 208, 0.1) 40%, rgba(255, 173, 208, 0) 82%),
+    radial-gradient(130% 100% at 82% 78%, rgba(130, 255, 221, 0.2) 0%, rgba(130, 255, 221, 0.08) 46%, rgba(130, 255, 221, 0) 88%);
+  filter: blur(68px);
+  opacity: 0.58;
+  pointer-events: none;
+  z-index: -2;
+  -webkit-mask-image:
+    radial-gradient(170% 150% at 50% 52%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 38%, rgba(0,0,0,0.75) 64%, rgba(0,0,0,0.25) 84%, rgba(0,0,0,0) 100%),
+    radial-gradient(210% 170% at 18% 18%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 40%, rgba(0,0,0,0.55) 70%, rgba(0,0,0,0.12) 88%, rgba(0,0,0,0) 100%),
+    radial-gradient(210% 170% at 84% 86%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 42%, rgba(0,0,0,0.5) 72%, rgba(0,0,0,0.12) 90%, rgba(0,0,0,0) 100%);
+  -webkit-mask-composite: source-in, source-in;
+  mask-image:
+    radial-gradient(170% 150% at 50% 52%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 38%, rgba(0,0,0,0.75) 64%, rgba(0,0,0,0.25) 84%, rgba(0,0,0,0) 100%),
+    radial-gradient(210% 170% at 18% 18%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 40%, rgba(0,0,0,0.55) 70%, rgba(0,0,0,0.12) 88%, rgba(0,0,0,0) 100%),
+    radial-gradient(210% 170% at 84% 86%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 42%, rgba(0,0,0,0.5) 72%, rgba(0,0,0,0.12) 90%, rgba(0,0,0,0) 100%);
+  mask-composite: intersect, intersect;
 }
 
 .screen-ambient-video {
@@ -104,8 +130,17 @@
   mix-blend-mode: screen;
   pointer-events: none;
   z-index: 0;
-  /* centered thicker edge halo */
-  mask-image: radial-gradient(90% 90% at 50% 50%, transparent 56%, rgba(255,255,255,0.9) 64%, transparent 78%);
+  /* layered masks to keep the core opaque while easing asymmetrical falloff */
+  -webkit-mask-image:
+    radial-gradient(120% 96% at 50% 48%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 44%, rgba(0,0,0,0.85) 64%, rgba(0,0,0,0.35) 80%, rgba(0,0,0,0) 96%),
+    radial-gradient(140% 120% at 18% 26%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 42%, rgba(0,0,0,0.68) 68%, rgba(0,0,0,0.18) 86%, rgba(0,0,0,0) 98%),
+    radial-gradient(140% 120% at 82% 80%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 44%, rgba(0,0,0,0.66) 70%, rgba(0,0,0,0.2) 88%, rgba(0,0,0,0) 100%);
+  -webkit-mask-composite: source-in, source-in;
+  mask-image:
+    radial-gradient(120% 96% at 50% 48%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 44%, rgba(0,0,0,0.85) 64%, rgba(0,0,0,0.35) 80%, rgba(0,0,0,0) 96%),
+    radial-gradient(140% 120% at 18% 26%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 42%, rgba(0,0,0,0.68) 68%, rgba(0,0,0,0.18) 86%, rgba(0,0,0,0) 98%),
+    radial-gradient(140% 120% at 82% 80%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 44%, rgba(0,0,0,0.66) 70%, rgba(0,0,0,0.2) 88%, rgba(0,0,0,0) 100%);
+  mask-composite: intersect, intersect;
 }
 
 .screen {


### PR DESCRIPTION
## Summary
- rework the dashboard ambient video mask with layered radial gradients and composite rules for uneven falloff
- add an asymmetrical masked glow on the ambient wrapper pseudo-element while keeping the screen core opaque

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cd84e14f608325b7bb992d7e84256f