### PR TITLE
Add interactive calendar tool

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -22,6 +22,7 @@ import RainBlocks from './pages/RainBlocks.jsx';
 import Snake from './pages/Snake.jsx';
 import BrickBreaker from './pages/BrickBreaker.jsx';
 import AlbumMaker from './pages/AlbumMaker.jsx';
+import Calendar from './pages/Calendar.jsx';
 
 export default function App() {
   return (
@@ -42,6 +43,7 @@ export default function App() {
         <Route path="/profiles" element={<Profiles />} />
         <Route path="/train" element={<Train />} />
         <Route path="/tools" element={<Tools />} />
+        <Route path="/calendar" element={<Calendar />} />
         <Route path="/queue" element={<Queue />} />
         <Route path="/fusion" element={<Fusion />} />
         <Route path="/loopmaker" element={<LoopMaker />} />

--- a/ui/src/pages/Calendar.css
+++ b/ui/src/pages/Calendar.css
@@ -1,0 +1,309 @@
+.calendar-page {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto var(--space-xl);
+  padding: 0 var(--space-xl) var(--space-xl);
+  display: grid;
+  grid-template-columns: minmax(0, 2.25fr) minmax(0, 1fr);
+  gap: var(--space-xl);
+  box-sizing: border-box;
+}
+
+.calendar-main,
+.calendar-sidebar {
+  background: var(--card-bg);
+  border-radius: 18px;
+  box-shadow: var(--card-shadow);
+  padding: var(--space-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.calendar-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+  flex-wrap: wrap;
+}
+
+.calendar-nav {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.calendar-icon-button {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: none;
+  background: color-mix(in srgb, var(--card-hover-bg), transparent 25%);
+  color: var(--text);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.calendar-icon-button:hover,
+.calendar-icon-button:focus-visible {
+  background: color-mix(in srgb, var(--accent), transparent 75%);
+  color: var(--accent);
+  transform: translateY(-2px);
+  box-shadow: var(--card-shadow);
+}
+
+.calendar-current-month {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-xs);
+  min-width: 160px;
+}
+
+.calendar-month-label {
+  font-size: clamp(1.4rem, 3vw, 2.3rem);
+  font-weight: 800;
+}
+
+.calendar-month-summary {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--text), transparent 45%);
+}
+
+.calendar-toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.calendar-action-button {
+  border: none;
+  border-radius: 999px;
+  background: var(--button-bg);
+  color: var(--text);
+  font-weight: 700;
+  padding: 0.45rem 1.2rem;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.calendar-action-button:hover,
+.calendar-action-button:focus-visible {
+  background: var(--button-hover-bg);
+  transform: translateY(-1px);
+  box-shadow: var(--card-shadow);
+}
+
+.calendar-week-start {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  font-size: 0.9rem;
+  color: color-mix(in srgb, var(--text), transparent 30%);
+}
+
+.calendar-select {
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--card-hover-bg), var(--text) 18%);
+  background: color-mix(in srgb, var(--card-bg), transparent 10%);
+  color: var(--text);
+  font-weight: 600;
+  padding: 0.35rem 0.9rem;
+  cursor: pointer;
+  appearance: none;
+}
+
+.calendar-select:hover,
+.calendar-select:focus-visible {
+  border-color: color-mix(in srgb, var(--accent), transparent 60%);
+}
+
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: var(--space-xs);
+  width: 100%;
+}
+
+.calendar-grid-header,
+.calendar-week {
+  display: contents;
+}
+
+.calendar-weekday {
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: color-mix(in srgb, var(--text), transparent 45%);
+  text-align: center;
+  padding-bottom: var(--space-xs);
+}
+
+.calendar-cell {
+  background: color-mix(in srgb, var(--card-bg), transparent 0%);
+  border: 1px solid color-mix(in srgb, var(--card-hover-bg), var(--text) 14%);
+  border-radius: 14px;
+  padding: var(--space-sm);
+  min-height: 90px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: var(--space-xs);
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  color: var(--text);
+  transition: transform 0.18s ease, box-shadow 0.18s ease,
+    border-color 0.18s ease, background 0.18s ease;
+  position: relative;
+}
+
+.calendar-cell:focus {
+  outline: none;
+}
+
+.calendar-cell:hover,
+.calendar-cell:focus-visible {
+  transform: translateY(-2px);
+  border-color: color-mix(in srgb, var(--accent), transparent 55%);
+  box-shadow: var(--card-shadow);
+  background: color-mix(in srgb, var(--card-hover-bg), transparent 20%);
+}
+
+.calendar-cell--outside {
+  color: color-mix(in srgb, var(--text), transparent 55%);
+  background: color-mix(in srgb, var(--card-bg), transparent 55%);
+}
+
+.calendar-cell--outside:hover,
+.calendar-cell--outside:focus-visible {
+  background: color-mix(in srgb, var(--card-hover-bg), transparent 55%);
+}
+
+.calendar-cell--today {
+  border-color: color-mix(in srgb, var(--accent), transparent 35%);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent), transparent 40%);
+}
+
+.calendar-cell--selected {
+  background: color-mix(in srgb, var(--accent), var(--card-bg) 45%);
+  border-color: color-mix(in srgb, var(--accent), transparent 25%);
+  color: #ffffff;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.4);
+}
+
+[data-theme='light'] .calendar-cell--selected {
+  color: #ffffff;
+}
+
+.calendar-cell-day {
+  font-size: 1.3rem;
+  font-weight: 800;
+}
+
+.calendar-cell-badge {
+  margin-top: auto;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent), transparent 75%);
+  color: color-mix(in srgb, var(--accent), transparent 10%);
+}
+
+.calendar-cell--selected .calendar-cell-badge {
+  background: rgba(255, 255, 255, 0.22);
+  color: #ffffff;
+}
+
+.calendar-sidebar-title {
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.calendar-selected-label {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.calendar-detail-list {
+  display: grid;
+  gap: var(--space-sm);
+}
+
+.calendar-detail-item {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.calendar-detail-term {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: color-mix(in srgb, var(--text), transparent 45%);
+}
+
+.calendar-detail-value {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.calendar-empty-state {
+  font-size: 0.95rem;
+  color: color-mix(in srgb, var(--text), transparent 35%);
+}
+
+@media (max-width: 1100px) {
+  .calendar-page {
+    grid-template-columns: 1fr;
+  }
+
+  .calendar-main,
+  .calendar-sidebar {
+    padding: var(--space-md);
+  }
+
+  .calendar-toolbar {
+    align-items: stretch;
+  }
+
+  .calendar-current-month {
+    flex-direction: row;
+    justify-content: center;
+    text-align: center;
+  }
+}
+
+@media (max-width: 720px) {
+  .calendar-page {
+    padding: 0 var(--space-md) var(--space-lg);
+    gap: var(--space-lg);
+  }
+
+  .calendar-cell {
+    min-height: 72px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .calendar-icon-button,
+  .calendar-action-button,
+  .calendar-cell {
+    transition: none;
+  }
+}

--- a/ui/src/pages/Calendar.jsx
+++ b/ui/src/pages/Calendar.jsx
@@ -1,0 +1,388 @@
+import { useMemo, useState, useCallback } from 'react';
+import BackButton from '../components/BackButton.jsx';
+import Icon from '../components/Icon.jsx';
+import './Calendar.css';
+
+const WEEK_START_OPTIONS = [
+  { value: 0, label: 'Sunday' },
+  { value: 1, label: 'Monday' },
+];
+
+const MS_IN_DAY = 24 * 60 * 60 * 1000;
+
+function startOfDay(date) {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function startOfMonth(date) {
+  return new Date(date.getFullYear(), date.getMonth(), 1);
+}
+
+function isSameDay(a, b) {
+  if (!a || !b) return false;
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+function formatDateKey(date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function buildCalendarWeeks(monthDate, weekStart) {
+  const year = monthDate.getFullYear();
+  const month = monthDate.getMonth();
+  const firstOfMonth = new Date(year, month, 1);
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const offset = (firstOfMonth.getDay() - weekStart + 7) % 7;
+  const totalCells = Math.ceil((offset + daysInMonth) / 7) * 7;
+  const startDate = new Date(year, month, 1 - offset);
+  const baseDay = startDate.getDate();
+
+  return Array.from({ length: totalCells / 7 }, (_, weekIndex) =>
+    Array.from({ length: 7 }, (_, dayIndex) => {
+      const cellDate = new Date(startDate);
+      cellDate.setDate(baseDay + weekIndex * 7 + dayIndex);
+      return cellDate;
+    })
+  );
+}
+
+function getStartOfWeek(date, weekStart) {
+  const result = startOfDay(date);
+  const diff = (result.getDay() - weekStart + 7) % 7;
+  result.setDate(result.getDate() - diff);
+  return result;
+}
+
+function getDayOfYear(date) {
+  const start = new Date(date.getFullYear(), 0, 0);
+  const diff = startOfDay(date) - start;
+  return Math.floor(diff / MS_IN_DAY);
+}
+
+function isLeapYear(year) {
+  if (year % 4 !== 0) return false;
+  if (year % 100 !== 0) return true;
+  return year % 400 === 0;
+}
+
+export default function Calendar() {
+  const today = useMemo(() => startOfDay(new Date()), []);
+  const [visibleMonth, setVisibleMonth] = useState(() => startOfMonth(today));
+  const [selectedDate, setSelectedDate] = useState(() => today);
+  const [weekStart, setWeekStart] = useState(WEEK_START_OPTIONS[0].value);
+
+  const weeks = useMemo(
+    () => buildCalendarWeeks(visibleMonth, weekStart),
+    [visibleMonth, weekStart]
+  );
+
+  const monthFormatter = useMemo(
+    () => new Intl.DateTimeFormat(undefined, { month: 'long', year: 'numeric' }),
+    []
+  );
+  const fullDateFormatter = useMemo(
+    () => new Intl.DateTimeFormat(undefined, { dateStyle: 'full' }),
+    []
+  );
+  const shortWeekdayFormatter = useMemo(
+    () => new Intl.DateTimeFormat(undefined, { weekday: 'short' }),
+    []
+  );
+  const longWeekdayFormatter = useMemo(
+    () => new Intl.DateTimeFormat(undefined, { weekday: 'long' }),
+    []
+  );
+  const rangeFormatter = useMemo(
+    () => new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' }),
+    []
+  );
+  const rangeFormatterWithYear = useMemo(
+    () =>
+      new Intl.DateTimeFormat(undefined, {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      }),
+    []
+  );
+
+  const weekdayLabels = useMemo(() => {
+    return Array.from({ length: 7 }, (_, index) => {
+      const date = new Date(Date.UTC(2021, 7, 1 + weekStart + index));
+      return {
+        short: shortWeekdayFormatter.format(date),
+        long: longWeekdayFormatter.format(date),
+      };
+    });
+  }, [weekStart, shortWeekdayFormatter, longWeekdayFormatter]);
+
+  const monthLabel = useMemo(
+    () => monthFormatter.format(visibleMonth),
+    [monthFormatter, visibleMonth]
+  );
+  const selectedLabel = useMemo(
+    () => (selectedDate ? fullDateFormatter.format(selectedDate) : ''),
+    [selectedDate, fullDateFormatter]
+  );
+  const daysInVisibleMonth = useMemo(
+    () => new Date(visibleMonth.getFullYear(), visibleMonth.getMonth() + 1, 0).getDate(),
+    [visibleMonth]
+  );
+
+  const weekRange = useMemo(() => {
+    if (!selectedDate) return null;
+    const start = getStartOfWeek(selectedDate, weekStart);
+    const end = new Date(start);
+    end.setDate(start.getDate() + 6);
+    return { start, end };
+  }, [selectedDate, weekStart]);
+
+  const weekRangeLabel = useMemo(() => {
+    if (!weekRange) return '—';
+    const sameYear =
+      weekRange.start.getFullYear() === weekRange.end.getFullYear();
+    if (sameYear) {
+      const startLabel = rangeFormatter.format(weekRange.start);
+      const endLabel = rangeFormatter.format(weekRange.end);
+      return `${startLabel} – ${endLabel}, ${weekRange.start.getFullYear()}`;
+    }
+    const startLabel = rangeFormatterWithYear.format(weekRange.start);
+    const endLabel = rangeFormatterWithYear.format(weekRange.end);
+    return `${startLabel} – ${endLabel}`;
+  }, [weekRange, rangeFormatter, rangeFormatterWithYear]);
+
+  const relativeLabel = useMemo(() => {
+    if (!selectedDate) return '—';
+    const diff = Math.round((selectedDate.getTime() - today.getTime()) / MS_IN_DAY);
+    if (diff === 0) return 'Today';
+    const abs = Math.abs(diff);
+    const unit = abs === 1 ? 'day' : 'days';
+    return diff > 0 ? `${abs} ${unit} from now` : `${abs} ${unit} ago`;
+  }, [selectedDate, today]);
+
+  const dayOfYear = useMemo(
+    () => (selectedDate ? getDayOfYear(selectedDate) : null),
+    [selectedDate]
+  );
+  const totalDaysInYear = useMemo(() => {
+    if (!selectedDate) return null;
+    return isLeapYear(selectedDate.getFullYear()) ? 366 : 365;
+  }, [selectedDate]);
+  const quarter = useMemo(
+    () =>
+      selectedDate != null
+        ? Math.floor(selectedDate.getMonth() / 3) + 1
+        : null,
+    [selectedDate]
+  );
+  const isoValue = useMemo(() => {
+    if (!selectedDate) return '—';
+    const year = selectedDate.getFullYear();
+    const month = String(selectedDate.getMonth() + 1).padStart(2, '0');
+    const day = String(selectedDate.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }, [selectedDate]);
+
+  const handleMonthChange = useCallback(
+    (direction) => {
+      setVisibleMonth((prev) => {
+        const next = new Date(prev.getFullYear(), prev.getMonth() + direction, 1);
+        return next;
+      });
+    },
+    [setVisibleMonth]
+  );
+
+  const handleToday = useCallback(() => {
+    setVisibleMonth(startOfMonth(today));
+    setSelectedDate(today);
+  }, [today]);
+
+  const handleSelectDate = useCallback(
+    (date) => {
+      const normalized = startOfDay(date);
+      setSelectedDate(normalized);
+      setVisibleMonth((prev) => {
+        if (
+          prev.getFullYear() === normalized.getFullYear() &&
+          prev.getMonth() === normalized.getMonth()
+        ) {
+          return prev;
+        }
+        return startOfMonth(normalized);
+      });
+    },
+    [setSelectedDate, setVisibleMonth]
+  );
+
+  const handleWeekStartChange = useCallback((event) => {
+    setWeekStart(Number(event.target.value));
+  }, []);
+
+  return (
+    <>
+      <BackButton />
+      <h1>Calendar</h1>
+      <main className="calendar-page">
+        <section className="calendar-main">
+          <header className="calendar-toolbar">
+            <div className="calendar-nav">
+              <button
+                type="button"
+                className="calendar-icon-button"
+                aria-label="Go to previous month"
+                onClick={() => handleMonthChange(-1)}
+              >
+                <Icon name="ChevronLeft" size={20} />
+              </button>
+              <div className="calendar-current-month" aria-live="polite">
+                <span className="calendar-month-label">{monthLabel}</span>
+                <span className="calendar-month-summary">
+                  {daysInVisibleMonth} days
+                </span>
+              </div>
+              <button
+                type="button"
+                className="calendar-icon-button"
+                aria-label="Go to next month"
+                onClick={() => handleMonthChange(1)}
+              >
+                <Icon name="ChevronRight" size={20} />
+              </button>
+            </div>
+            <div className="calendar-toolbar-actions">
+              <button
+                type="button"
+                className="calendar-action-button"
+                onClick={handleToday}
+              >
+                Today
+              </button>
+              <label className="calendar-week-start">
+                Week starts on
+                <select
+                  className="calendar-select"
+                  value={weekStart}
+                  onChange={handleWeekStartChange}
+                >
+                  {WEEK_START_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+          </header>
+          <div
+            className="calendar-grid"
+            role="grid"
+            aria-label={`Calendar for ${monthLabel}`}
+          >
+            <div className="calendar-grid-header" role="row">
+              {weekdayLabels.map((weekday) => (
+                <div
+                  key={weekday.long}
+                  className="calendar-weekday"
+                  role="columnheader"
+                  aria-label={weekday.long}
+                >
+                  {weekday.short}
+                </div>
+              ))}
+            </div>
+            {weeks.map((week, weekIndex) => (
+              <div key={weekIndex} className="calendar-week" role="row">
+                {week.map((date) => {
+                  const key = formatDateKey(date);
+                  const inCurrentMonth =
+                    date.getMonth() === visibleMonth.getMonth() &&
+                    date.getFullYear() === visibleMonth.getFullYear();
+                  const isToday = isSameDay(date, today);
+                  const isSelected =
+                    selectedDate != null && isSameDay(date, selectedDate);
+
+                  const cellClassNames = [
+                    'calendar-cell',
+                    !inCurrentMonth && 'calendar-cell--outside',
+                    isToday && 'calendar-cell--today',
+                    isSelected && 'calendar-cell--selected',
+                  ]
+                    .filter(Boolean)
+                    .join(' ');
+
+                  const label = `${fullDateFormatter.format(
+                    date
+                  )}${isToday ? ' (Today)' : ''}`;
+
+                  return (
+                    <button
+                      key={key}
+                      type="button"
+                      className={cellClassNames}
+                      aria-pressed={isSelected}
+                      aria-current={isToday ? 'date' : undefined}
+                      aria-label={label}
+                      onClick={() => handleSelectDate(date)}
+                      data-date={key}
+                    >
+                      <span className="calendar-cell-day">{date.getDate()}</span>
+                      {isToday && <span className="calendar-cell-badge">Today</span>}
+                    </button>
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+        </section>
+        <aside className="calendar-sidebar">
+          <h2 className="calendar-sidebar-title">Date details</h2>
+          {selectedDate ? (
+            <>
+              <p className="calendar-selected-label">{selectedLabel}</p>
+              <dl className="calendar-detail-list">
+                <div className="calendar-detail-item">
+                  <dt className="calendar-detail-term">Relative</dt>
+                  <dd className="calendar-detail-value">{relativeLabel}</dd>
+                </div>
+                <div className="calendar-detail-item">
+                  <dt className="calendar-detail-term">Week range</dt>
+                  <dd className="calendar-detail-value">{weekRangeLabel}</dd>
+                </div>
+                <div className="calendar-detail-item">
+                  <dt className="calendar-detail-term">Day of year</dt>
+                  <dd className="calendar-detail-value">
+                    {dayOfYear != null && totalDaysInYear != null
+                      ? `${dayOfYear} of ${totalDaysInYear}`
+                      : '—'}
+                  </dd>
+                </div>
+                <div className="calendar-detail-item">
+                  <dt className="calendar-detail-term">Quarter</dt>
+                  <dd className="calendar-detail-value">
+                    {quarter != null ? `Q${quarter}` : '—'}
+                  </dd>
+                </div>
+                <div className="calendar-detail-item">
+                  <dt className="calendar-detail-term">ISO date</dt>
+                  <dd className="calendar-detail-value">{isoValue}</dd>
+                </div>
+              </dl>
+            </>
+          ) : (
+            <p className="calendar-empty-state">
+              Select any day in the grid to see more information.
+            </p>
+          )}
+        </aside>
+      </main>
+    </>
+  );
+}

--- a/ui/src/pages/Tools.jsx
+++ b/ui/src/pages/Tools.jsx
@@ -22,6 +22,9 @@ export default function Tools() {
         <Card to="/album" icon="Disc3" title="Album Maker">
           Cover + Tracklist Generator
         </Card>
+        <Card to="/calendar" icon="CalendarDays" title="Calendar">
+          Visual Schedule Planner
+        </Card>
         <Card to="/train" icon="Sliders" title="Train Model">
           Custom Model Trainer
         </Card>


### PR DESCRIPTION
## Summary
- add a dedicated Calendar page with month navigation, week-start selection, and contextual date details
- style the calendar layout with a responsive grid and sidebar details panel
- register the Calendar route and expose it on the tools dashboard

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68cd86484bcc8325a48aa500a47ef8f5