### PR TITLE
Align dashboard glow gradients

### DIFF
--- a/ui/src/pages/Dashboard.css
+++ b/ui/src/pages/Dashboard.css
@@ -99,21 +99,21 @@
   border-radius: 36px;
   background:
     radial-gradient(125% 120% at 50% 50%, rgba(94, 163, 255, 0.24) 0%, rgba(94, 163, 255, 0.12) 44%, rgba(94, 163, 255, 0) 84%),
-    radial-gradient(110% 90% at 20% 30%, rgba(255, 173, 208, 0.22) 0%, rgba(255, 173, 208, 0.1) 40%, rgba(255, 173, 208, 0) 82%),
-    radial-gradient(130% 100% at 82% 78%, rgba(130, 255, 221, 0.2) 0%, rgba(130, 255, 221, 0.08) 46%, rgba(130, 255, 221, 0) 88%);
+    radial-gradient(120% 100% at 25% 35%, rgba(255, 173, 208, 0.22) 0%, rgba(255, 173, 208, 0.1) 42%, rgba(255, 173, 208, 0) 82%),
+    radial-gradient(120% 100% at 75% 65%, rgba(130, 255, 221, 0.2) 0%, rgba(130, 255, 221, 0.08) 42%, rgba(130, 255, 221, 0) 82%);
   filter: blur(68px);
   opacity: 0.58;
   pointer-events: none;
   z-index: -2;
   -webkit-mask-image:
     radial-gradient(170% 150% at 50% 52%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 38%, rgba(0,0,0,0.75) 64%, rgba(0,0,0,0.25) 84%, rgba(0,0,0,0) 100%),
-    radial-gradient(210% 170% at 18% 18%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 40%, rgba(0,0,0,0.55) 70%, rgba(0,0,0,0.12) 88%, rgba(0,0,0,0) 100%),
-    radial-gradient(210% 170% at 84% 86%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 42%, rgba(0,0,0,0.5) 72%, rgba(0,0,0,0.12) 90%, rgba(0,0,0,0) 100%);
+    radial-gradient(210% 170% at 25% 35%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 40%, rgba(0,0,0,0.55) 70%, rgba(0,0,0,0.12) 88%, rgba(0,0,0,0) 100%),
+    radial-gradient(210% 170% at 75% 65%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 40%, rgba(0,0,0,0.55) 70%, rgba(0,0,0,0.12) 88%, rgba(0,0,0,0) 100%);
   -webkit-mask-composite: source-in, source-in;
   mask-image:
     radial-gradient(170% 150% at 50% 52%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 38%, rgba(0,0,0,0.75) 64%, rgba(0,0,0,0.25) 84%, rgba(0,0,0,0) 100%),
-    radial-gradient(210% 170% at 18% 18%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 40%, rgba(0,0,0,0.55) 70%, rgba(0,0,0,0.12) 88%, rgba(0,0,0,0) 100%),
-    radial-gradient(210% 170% at 84% 86%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 42%, rgba(0,0,0,0.5) 72%, rgba(0,0,0,0.12) 90%, rgba(0,0,0,0) 100%);
+    radial-gradient(210% 170% at 25% 35%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 40%, rgba(0,0,0,0.55) 70%, rgba(0,0,0,0.12) 88%, rgba(0,0,0,0) 100%),
+    radial-gradient(210% 170% at 75% 65%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 40%, rgba(0,0,0,0.55) 70%, rgba(0,0,0,0.12) 88%, rgba(0,0,0,0) 100%);
   mask-composite: intersect, intersect;
 }
 


### PR DESCRIPTION
## Summary
- Symmetrized the dashboard ambient background gradients so the side glows share matching focal points and falloff stops.
- Updated the accompanying mask gradients to mirror each other, keeping the center highlight intact while balancing both sides.

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd8838af7c8325bb3a38e8fc50e9e3