### PR TITLE
Add General Chat tool card

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -23,6 +23,7 @@ import Snake from './pages/Snake.jsx';
 import BrickBreaker from './pages/BrickBreaker.jsx';
 import AlbumMaker from './pages/AlbumMaker.jsx';
 import Calendar from './pages/Calendar.jsx';
+import GeneralChat from './pages/GeneralChat.jsx';
 
 export default function App() {
   return (
@@ -44,6 +45,7 @@ export default function App() {
         <Route path="/train" element={<Train />} />
         <Route path="/tools" element={<Tools />} />
         <Route path="/calendar" element={<Calendar />} />
+        <Route path="/chat" element={<GeneralChat />} />
         <Route path="/queue" element={<Queue />} />
         <Route path="/fusion" element={<Fusion />} />
         <Route path="/loopmaker" element={<LoopMaker />} />

--- a/ui/src/pages/GeneralChat.jsx
+++ b/ui/src/pages/GeneralChat.jsx
@@ -1,0 +1,11 @@
+import BackButton from '../components/BackButton.jsx';
+
+export default function GeneralChat() {
+  return (
+    <>
+      <BackButton />
+      <h1>General Chat</h1>
+      <p>Chat with Blossom coming soon.</p>
+    </>
+  );
+}

--- a/ui/src/pages/Tools.jsx
+++ b/ui/src/pages/Tools.jsx
@@ -13,6 +13,9 @@ export default function Tools() {
         <Card to="/queue" icon="ListTodo" title="Job Queue">
           Queued + Running Jobs
         </Card>
+        <Card to="/chat" icon="MessagesSquare" title="General Chat">
+          Converse with Blossom
+        </Card>
         <Card to="/loopmaker" icon="Repeat" title="Loop Maker">
           Video Loop Creator
         </Card>


### PR DESCRIPTION
## Summary
- add a General Chat card to the Tools screen for quick access
- register the /chat route and scaffold the General Chat page

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd8d2898b88325996e05fa1e2f78ef