### PR TITLE
Improve dashboard responsiveness on smaller viewports

### DIFF
--- a/ui/src/pages/Dashboard.css
+++ b/ui/src/pages/Dashboard.css
@@ -234,6 +234,7 @@
   max-width: 1800px;
   margin: 0 auto;
   padding: 0 var(--space-xl) var(--space-xl);
+  box-sizing: border-box;
 }
 
 .feature-wheel {
@@ -246,3 +247,21 @@
 }
 
 /* remove overriding width to keep clamp sizing above */
+
+@media (max-width: 1200px) {
+  .dashboard-main {
+    grid-template-columns: minmax(0, 1fr);
+    justify-items: center;
+    gap: var(--space-xl);
+    padding: 0 var(--space-lg) var(--space-xl);
+  }
+
+  .feature-wheel,
+  .screen-wrapper {
+    justify-self: center;
+  }
+
+  .screen {
+    width: min(100%, 720px);
+  }
+}


### PR DESCRIPTION
## Summary
- add a responsive breakpoint that collapses the dashboard grid into a centered single column on narrow screens
- allow the screen component to shrink below its previous 720px minimum while keeping the wheel aligned
- ensure the dashboard container accounts for padding with border-box sizing to avoid overflow

## Testing
- npm --prefix ui run build

------
https://chatgpt.com/codex/tasks/task_e_68cd8de8b0688325a2e1d05c7464073d