### PR TITLE
Rename Piper DnD navigation section to AI Voices

### DIFF
--- a/ui/src/pages/Dnd.jsx
+++ b/ui/src/pages/Dnd.jsx
@@ -18,7 +18,7 @@ const sections = [
   {
     to: '/dnd/piper',
     icon: 'Mic2',
-    title: 'Piper',
+    title: 'AI Voices',
     description: 'Discover voices and synthesize dialogue for your stories.',
   },
   {


### PR DESCRIPTION
## Summary
- rename the Dungeons & Dragons Piper section title to AI Voices so the card label matches the updated feature name

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd9806b3b483258290a41aef7cc8bf