### PR TITLE
Display Obsidian lore content with metadata

### DIFF
--- a/service_api.py
+++ b/service_api.py
@@ -276,6 +276,7 @@ def list_lore() -> List[Dict[str, Any]]:
                 "path": rel_path,
                 "title": title,
                 "summary": summary,
+                "content": parsed.text,
                 "aliases": parsed.aliases,
                 "tags": parsed.tags,
                 "fields": parsed.fields,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -16,7 +16,7 @@ use std::{
 use chrono::{DateTime, Duration as ChronoDuration, SecondsFormat, Utc};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
 use tauri::path::BaseDirectory;
 use tauri::Emitter;
 use tauri::Manager;
@@ -347,6 +347,10 @@ struct LoreItem {
     path: String,
     title: String,
     summary: String,
+    content: String,
+    tags: Vec<String>,
+    aliases: Vec<String>,
+    fields: Map<String, Value>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone)]
@@ -473,11 +477,43 @@ fn lore_list() -> Result<Vec<LoreItem>, String> {
             .and_then(|v| v.as_str())
             .unwrap_or_default()
             .to_string();
+        let content = note
+            .get("content")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let tags = note
+            .get("tags")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|value| value.as_str().map(|s| s.to_string()))
+                    .collect::<Vec<String>>()
+            })
+            .unwrap_or_default();
+        let aliases = note
+            .get("aliases")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|value| value.as_str().map(|s| s.to_string()))
+                    .collect::<Vec<String>>()
+            })
+            .unwrap_or_default();
+        let fields = note
+            .get("fields")
+            .and_then(|v| v.as_object())
+            .cloned()
+            .unwrap_or_else(Map::new);
 
         lore_items.push(LoreItem {
             path,
             title,
             summary,
+            content,
+            tags,
+            aliases,
+            fields,
         });
     }
 

--- a/tests/test_lore_listing.py
+++ b/tests/test_lore_listing.py
@@ -1,0 +1,79 @@
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+# Ensure repository root on sys.path so ``service_api`` can be imported when tests
+# are executed directly.
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import service_api  # noqa: E402  (import after path adjustment)
+from notes.chunker import ensure_chunk_tables  # noqa: E402
+from notes.watchdog import DEFAULT_DB_PATH  # noqa: E402
+
+
+@pytest.mark.parametrize("subdir", ["", "lore"])
+def test_list_lore_includes_note_content(tmp_path: Path, monkeypatch, subdir: str) -> None:
+    """Notes tagged ``#lore`` should surface content and metadata."""
+
+    vault = tmp_path
+    note_dir = vault / subdir if subdir else vault
+    note_dir.mkdir(parents=True, exist_ok=True)
+    note_rel_path = f"{subdir + '/' if subdir else ''}ancient-tales.md"
+    note_path = note_dir / "ancient-tales.md"
+    note_path.write_text(
+        """---
+aliases: [Ancient Tales]
+tags: [lore, story]
+---
+First paragraph about the lost city.
+
+Second paragraph with extra details.
+""",
+        encoding="utf-8",
+    )
+
+    db_path = vault / DEFAULT_DB_PATH
+    conn = sqlite3.connect(db_path)
+    try:
+        ensure_chunk_tables(conn)
+        conn.execute(
+            "INSERT OR REPLACE INTO chunks(id, path, heading, content) VALUES(?, ?, ?, ?)",
+            (
+                "chunk-1",
+                note_rel_path,
+                "",
+                "First paragraph about the lost city.\n\nSecond paragraph with extra details.",
+            ),
+        )
+        conn.execute(
+            "INSERT INTO tags(chunk_id, tag) VALUES(?, ?)",
+            ("chunk-1", "lore"),
+        )
+        conn.execute(
+            "INSERT INTO tags(chunk_id, tag) VALUES(?, ?)",
+            ("chunk-1", "story"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    monkeypatch.setattr(service_api, "get_vault", lambda: vault)
+
+    items = service_api.list_lore()
+    assert len(items) == 1
+    entry = items[0]
+
+    assert entry["path"] == note_rel_path
+    assert entry["title"] == "Ancient Tales"
+    assert entry["summary"] == "First paragraph about the lost city."
+    assert (
+        entry["content"]
+        == "First paragraph about the lost city.\n\nSecond paragraph with extra details."
+    )
+    assert entry["aliases"] == ["Ancient Tales"]
+    assert sorted(entry["tags"]) == ["lore", "story"]
+    assert entry["fields"] == {}
+

--- a/ui/src/pages/Dnd.css
+++ b/ui/src/pages/Dnd.css
@@ -10,3 +10,139 @@
 .dnd-card-grid .card p {
   margin: 0;
 }
+
+.dnd-lore {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  margin-top: var(--space-md);
+}
+
+.dnd-lore-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.dnd-lore-list {
+  display: grid;
+  gap: 1.25rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.lore-card {
+  background: #111827;
+  border: 1px solid #1f2937;
+  border-radius: 12px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.lore-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.lore-title {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.lore-path {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.6);
+  word-break: break-word;
+}
+
+.lore-aliases {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.lore-chip {
+  display: inline-flex;
+  align-items: center;
+  background: #1f2937;
+  color: #f9fafb;
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.lore-summary {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.6;
+  white-space: pre-wrap;
+}
+
+.lore-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.lore-body p {
+  margin: 0;
+  line-height: 1.6;
+  white-space: pre-wrap;
+}
+
+.lore-fields {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.lore-field {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.lore-field dt {
+  font-size: 0.8rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.lore-field dd {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  white-space: pre-wrap;
+}
+
+.lore-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.lore-tag {
+  background: rgba(59, 130, 246, 0.15);
+  color: #bfdbfe;
+}
+
+.dnd-lore .warning {
+  background: rgba(239, 68, 68, 0.15);
+  border: 1px solid rgba(248, 113, 113, 0.4);
+  border-radius: 12px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.dnd-lore .warning button {
+  align-self: flex-start;
+}

--- a/ui/src/pages/DndLore.jsx
+++ b/ui/src/pages/DndLore.jsx
@@ -3,6 +3,54 @@ import { listLore } from '../api/lore';
 import BackButton from '../components/BackButton.jsx';
 import './Dnd.css';
 
+const splitParagraphs = (text) =>
+  String(text ?? '')
+    .replace(/\r\n/g, '\n')
+    .split(/\n{2,}/)
+    .map((paragraph) => paragraph.trim())
+    .filter((paragraph) => paragraph.length > 0);
+
+const extractLeadAndBody = (content, summary) => {
+  const paragraphs = splitParagraphs(content);
+  const trimmedSummary = String(summary ?? '').trim();
+  if (!trimmedSummary) {
+    if (paragraphs.length === 0) {
+      return ['', []];
+    }
+    return [paragraphs[0], paragraphs.slice(1)];
+  }
+
+  let removed = false;
+  const body = paragraphs.filter((paragraph) => {
+    if (!removed && paragraph.trim() === trimmedSummary) {
+      removed = true;
+      return false;
+    }
+    return true;
+  });
+  return [trimmedSummary, body];
+};
+
+const formatFieldLabel = (key) =>
+  String(key)
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+
+const formatFieldValue = (value) => {
+  if (Array.isArray(value)) {
+    return value.map((entry) => String(entry)).join(', ');
+  }
+  if (value && typeof value === 'object') {
+    return JSON.stringify(value, null, 2);
+  }
+  if (value === null || value === undefined) {
+    return '';
+  }
+  return String(value);
+};
+
 export default function DndLore() {
   const [lore, setLore] = useState([]);
   const [loreLoading, setLoreLoading] = useState(false);
@@ -34,21 +82,14 @@ export default function DndLore() {
       <BackButton />
       <h1>Dungeons &amp; Dragons &middot; Lore</h1>
       <div className="dnd-lore">
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '0.5rem',
-            marginBottom: '1rem',
-          }}
-        >
+        <div className="dnd-lore-controls">
           <button type="button" onClick={fetchLore} disabled={loreLoading}>
-            {loreLoading ? 'Loading...' : 'Refresh'}
+            {loreLoading ? 'Loading…' : 'Refresh'}
           </button>
-          {loreLoading && <span>Loading lore...</span>}
+          {loreLoading && <span>Loading lore…</span>}
         </div>
         {loreError && (
-          <div className="warning" style={{ marginBottom: '1rem' }}>
+          <div className="warning">
             <div>Failed to load lore: {loreError}</div>
             <button type="button" onClick={fetchLore} disabled={loreLoading}>
               Try again
@@ -59,35 +100,87 @@ export default function DndLore() {
           <p>No lore entries found.</p>
         )}
         {lore.length > 0 && (
-          <ul
-            style={{
-              display: 'grid',
-              gap: '1rem',
-              listStyle: 'none',
-              margin: 0,
-              padding: 0,
-            }}
-          >
-            {lore.map((item) => (
-              <li
-                key={item.path || item.title}
-                style={{
-                  background: '#111827',
-                  borderRadius: '12px',
-                  padding: '1rem',
-                  border: '1px solid #1f2937',
-                }}
-              >
-                <h3 style={{ margin: '0 0 0.5rem' }}>{item.title}</h3>
-                {item.summary ? (
-                  <p style={{ margin: 0 }}>{item.summary}</p>
-                ) : (
-                  <p style={{ margin: 0, fontStyle: 'italic', opacity: 0.8 }}>
-                    No summary available.
-                  </p>
-                )}
-              </li>
-            ))}
+          <ul className="dnd-lore-list">
+            {lore.map((item) => {
+              const [lead, body] = extractLeadAndBody(item.content, item.summary);
+              const title = item.title || item.path || 'Untitled Lore Entry';
+
+              const aliasSource = Array.isArray(item.aliases)
+                ? item.aliases.filter((alias) => alias && alias.trim().length > 0)
+                : [];
+              const aliasSet = new Set(aliasSource.map((alias) => alias.trim()));
+              if (title) {
+                aliasSet.delete(title.trim());
+              }
+              const aliases = Array.from(aliasSet);
+
+              const tagList = Array.isArray(item.tags)
+                ? Array.from(
+                    new Set(
+                      item.tags
+                        .map((tag) => (tag ? String(tag).trim() : ''))
+                        .filter((tag) => tag.length > 0),
+                    ),
+                  )
+                : [];
+
+              const fieldEntriesRaw =
+                item.fields && typeof item.fields === 'object' && !Array.isArray(item.fields)
+                  ? Object.entries(item.fields)
+                  : [];
+              const fieldEntries = fieldEntriesRaw
+                .map(([key, value]) => [key, formatFieldValue(value)])
+                .filter(([, value]) => value && value.length > 0);
+
+              return (
+                <li key={item.path || item.title} className="lore-card">
+                  <div className="lore-header">
+                    <h3 className="lore-title">{title}</h3>
+                    {item.path && <span className="lore-path">{item.path}</span>}
+                    {aliases.length > 0 && (
+                      <div className="lore-aliases">
+                        {aliases.map((alias) => (
+                          <span key={alias} className="lore-chip">
+                            {alias}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+
+                  {lead && <p className="lore-summary">{lead}</p>}
+
+                  {body.length > 0 && (
+                    <div className="lore-body">
+                      {body.map((paragraph, index) => (
+                        <p key={`${item.path || item.title}-p-${index}`}>{paragraph}</p>
+                      ))}
+                    </div>
+                  )}
+
+                  {fieldEntries.length > 0 && (
+                    <dl className="lore-fields">
+                      {fieldEntries.map(([key, value]) => (
+                        <div key={key} className="lore-field">
+                          <dt>{formatFieldLabel(key)}</dt>
+                          <dd>{value}</dd>
+                        </div>
+                      ))}
+                    </dl>
+                  )}
+
+                  {tagList.length > 0 && (
+                    <div className="lore-tags">
+                      {tagList.map((tag) => (
+                        <span key={tag} className="lore-chip lore-tag">
+                          #{tag}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </li>
+              );
+            })}
           </ul>
         )}
       </div>


### PR DESCRIPTION
## Summary
- include cleaned Markdown content when listing lore entries from the selected Obsidian vault
- enrich the Tauri lore command and UI to surface titles, aliases, tags, fields, and full text in styled lore cards
- add regression coverage ensuring lore notes tagged in the chunk database expose their content

## Testing
- pytest tests/test_empty_database.py tests/test_lore_listing.py
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd976c5e4483258278ff63be6e6687