### PR TITLE
Add missing appDataDir import for MusicGen page

### DIFF
--- a/ui/src/pages/MusicGen.jsx
+++ b/ui/src/pages/MusicGen.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { invoke, convertFileSrc } from "@tauri-apps/api/core";
+import { appDataDir } from "@tauri-apps/api/path";
 import { readFile, BaseDirectory } from "@tauri-apps/plugin-fs";
 import { open } from "@tauri-apps/plugin-dialog";
 import { Store } from "@tauri-apps/plugin-store";


### PR DESCRIPTION
## Summary
- add the missing appDataDir import in the MusicGen page so createBlobUrlForPath can resolve it at runtime

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cda03495608325ba408aeda5546b49