### PR TITLE
Add store capability for Tauri windows

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -79,6 +79,13 @@
             "core:event:allow-listen",
             "core:event:default"
           ]
+        },
+        {
+          "identifier": "allow-store",
+          "windows": ["*"],
+          "permissions": [
+            "store:default"
+          ]
         }
       ]
     }


### PR DESCRIPTION
## Summary
- add an allow-store capability that grants the store plugin default permissions to every Tauri window

## Testing
- npm --prefix ui run build
- npm run tauri build *(fails: missing glib/gobject/gio system libraries, apt mirrors blocked in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cda326903883259f4d1536a634bec0