### PR TITLE
Allow store capability to close resources

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -84,7 +84,8 @@
           "identifier": "allow-store",
           "windows": ["*"],
           "permissions": [
-            "store:default"
+            "store:default",
+            "core:resources:allow-close"
           ]
         }
       ]


### PR DESCRIPTION
## Summary
- add the `core:resources:allow-close` permission to the existing allow-store capability so shared state can clean up without errors

## Testing
- npm run tauri dev *(fails: missing system library `glib-2.0` required by `glib-sys`)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb627cfe08325b5018bbe9b432a7b