### PR TITLE
Handle string rejections when persisting shared state

### DIFF
--- a/ui/src/lib/sharedState.jsx
+++ b/ui/src/lib/sharedState.jsx
@@ -144,9 +144,14 @@ export function SharedStateProvider({ children }) {
             await store.save();
             return;
           } catch (err) {
-            const message =
-              typeof err?.message === 'string' ? err.message.toLowerCase() : '';
-            if (message.includes('resource id') && message.includes('invalid')) {
+            let rawMessage = '';
+            if (typeof err === 'string') {
+              rawMessage = err;
+            } else if (err && typeof err.message === 'string') {
+              rawMessage = err.message;
+            }
+            const normalizedMessage = rawMessage.toLowerCase();
+            if (normalizedMessage.includes('resource id') && normalizedMessage.includes('invalid')) {
               // React StrictMode remounts can leave us with a stale store handle; fall back to localStorage.
               storeRef.current = null;
               useLocalRef.current = true;


### PR DESCRIPTION
## Summary
- normalize persistence errors to produce a consistent message for both Error objects and string rejections
- reuse the normalized message when detecting invalid store handles so the localStorage fallback activates and subsequent calls stay on the fallback path

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cdf9ead6748325a28a82ece0d65949