### PR TITLE
Add monster creation modal to DnD monster list

### DIFF
--- a/ui/src/pages/Dnd.css
+++ b/ui/src/pages/Dnd.css
@@ -427,6 +427,14 @@
 .lightbox-panel { max-width: 920px; max-height: 90vh; overflow: auto; background: var(--card-bg); color: var(--text); border: 1px solid #1f2937; border-radius: 10px; padding: 1rem; }
 .lightbox-panel .inbox-reader-header { display: none; }
 
+.monster-create-panel { width: min(420px, 90vw); display: grid; gap: 1rem; }
+.monster-create-panel h2 { margin: 0; }
+.monster-create-form { display: grid; gap: 0.75rem; }
+.monster-create-form label { display: grid; gap: 0.35rem; font-weight: 600; }
+.monster-create-form input { padding: 0.55rem 0.7rem; border-radius: 8px; border: 1px solid #1f2937; background: rgba(15, 23, 42, 0.9); color: var(--text); }
+.monster-create-form input:disabled { opacity: 0.6; }
+.monster-create-actions { display: flex; justify-content: flex-end; gap: 0.75rem; }
+
 /* Monster card portrait */
 .monster-portrait { width: 100%; height: 120px; object-fit: cover; border-radius: 8px; background: #0b1220; }
 .monster-portrait.placeholder { display: grid; place-items: center; font-size: 2rem; color: var(--text); opacity: 0.7; }


### PR DESCRIPTION
## Summary
- add a toolbar action and modal workflow for creating new monster files from the template
- wire the creation flow to call createMonster, refresh the list, and surface validation or API errors
- style the creation modal to match existing lightbox visuals

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfb1707cb883258a1a77924b70417f