### PR TITLE
Fix system prompt type for monster generator

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1917,9 +1917,9 @@ fn monster_create(app: AppHandle, name: String, template: Option<String>) -> Res
         name = name,
         template = template_text
     );
-    let system = Some("You are a meticulous editor that outputs only valid Markdown and YAML frontmatter.
+    let system = Some(String::from("You are a meticulous editor that outputs only valid Markdown and YAML frontmatter.
 Include typical D&D 5e fields: type, size, alignment, AC, HP, speed, abilities, skills, senses, languages, CR, traits, actions. No OGL text.
-");
+"));
     let content = generate_llm(prompt, system)?;
 
     // Build a safe file name


### PR DESCRIPTION
## Summary
- wrap the monster statblock system prompt literal in `String::from` so it is passed to the LLM helper as an owned `String`

## Testing
- cargo build *(fails: missing system dependency `glib-2.0` in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cfb5272a188325b376dbc810feab53