### PR TITLE
Adjust dashboard ambient glow to warm gradients

### DIFF
--- a/ui/src/pages/Dashboard.css
+++ b/ui/src/pages/Dashboard.css
@@ -98,9 +98,8 @@
   inset: -18% -12% -20%;
   border-radius: 36px;
   background:
-    radial-gradient(125% 120% at 50% 50%, rgba(94, 163, 255, 0.24) 0%, rgba(94, 163, 255, 0.12) 44%, rgba(94, 163, 255, 0) 84%),
-    radial-gradient(120% 100% at 25% 35%, rgba(255, 173, 208, 0.22) 0%, rgba(255, 173, 208, 0.1) 42%, rgba(255, 173, 208, 0) 82%),
-    radial-gradient(120% 100% at 75% 65%, rgba(130, 255, 221, 0.2) 0%, rgba(130, 255, 221, 0.08) 42%, rgba(130, 255, 221, 0) 82%);
+    radial-gradient(115% 105% at 50% 46%, rgba(255, 205, 132, 0.52) 0%, rgba(255, 182, 92, 0.26) 40%, rgba(255, 164, 72, 0.08) 68%, rgba(255, 148, 60, 0) 100%),
+    radial-gradient(160% 140% at 50% 54%, rgba(255, 220, 168, 0.3) 0%, rgba(255, 198, 132, 0.18) 48%, rgba(255, 178, 104, 0.06) 78%, rgba(255, 162, 86, 0) 100%);
   filter: blur(68px);
   opacity: 0.58;
   pointer-events: none;


### PR DESCRIPTION
## Summary
- replace the dashboard ambient backdrop gradients with a two-layer warm golden/orange palette for a cohesive glow
- tune opacity distribution so the inner glow reads brighter while the outer glow stays soft across themes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d173b89ce88325bb83dc936c19b749