### PR TITLE
Improve NPC metadata parsing and display

### DIFF
--- a/ui/src/pages/Dnd.css
+++ b/ui/src/pages/Dnd.css
@@ -457,3 +457,74 @@
 .monster-kv dd { margin: 0; }
 .section-title { margin: 0.5rem 0 0.25rem; }
 
+/* NPC modal layout */
+.lightbox-panel .npc-header {
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
+  align-items: flex-start;
+  margin-bottom: 1rem;
+}
+
+.npc-portrait {
+  width: 160px;
+  height: 160px;
+  object-fit: cover;
+  border-radius: 10px;
+  background: #0b1220;
+  flex-shrink: 0;
+}
+
+.npc-portrait.placeholder {
+  display: grid;
+  place-items: center;
+  font-size: 2rem;
+  color: var(--text);
+  opacity: 0.7;
+}
+
+.npc-header-main {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.npc-name {
+  margin: 0;
+}
+
+.npc-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.npc-banner {
+  background: rgba(217, 119, 6, 0.18);
+  border: 1px solid rgba(251, 191, 36, 0.35);
+  border-radius: 10px;
+  padding: 0.65rem 0.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  font-size: 0.9rem;
+  color: var(--text);
+}
+
+.npc-banner button {
+  background: transparent;
+  border: 1px solid rgba(251, 191, 36, 0.6);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.25rem 0.6rem;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.npc-banner button:hover {
+  background: rgba(251, 191, 36, 0.15);
+}
+


### PR DESCRIPTION
## Summary
- parse NPC frontmatter to capture metadata separately from the markdown body
- surface metadata chips and a dismissible warning in the NPC modal alongside the portrait
- add supporting styles for the updated NPC profile header and alert banner

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d174f6484c8325aa2bfab14d622aa0