### PR TITLE
Render vault attachment embeds and hashtag chips in markdown

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build"
+    "build": "vite build",
+    "test": "node --test --loader ./tests/jsx-loader.mjs"
   },
   "dependencies": {
     "@fontsource/urbanist": "^5.2.7",

--- a/ui/src/lib/vaultAttachments.js
+++ b/ui/src/lib/vaultAttachments.js
@@ -1,0 +1,270 @@
+import { getConfig } from '../api/config.js';
+import { readFileBytes } from '../api/files.js';
+
+const attachmentUrlCache = new Map();
+const attachmentPromiseCache = new Map();
+let customResolver = null;
+let vaultPathPromise = null;
+
+const COMMON_ATTACHMENT_DIRS = [
+  'Attachments',
+  'attachments',
+  '30_Assets',
+  '30_Assets/Images',
+  '30_Assets/Images/NPC_Portraits',
+  '30_Assets/Images/Monster_Portraits',
+];
+
+const MIME_BY_EXT = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  bmp: 'image/bmp',
+  svg: 'image/svg+xml',
+  avif: 'image/avif',
+};
+
+function sanitizeResource(resource) {
+  return String(resource || '').trim();
+}
+
+function normalizeResourceKey(resource) {
+  const cleaned = sanitizeResource(resource);
+  return cleaned ? cleaned.toLowerCase() : '';
+}
+
+function isAbsolutePath(path) {
+  return /^(?:[a-zA-Z]:[\\/]|\\\\|\/)/.test(path);
+}
+
+function getPreferredSeparator(base) {
+  if (!base) return '/';
+  if (base.includes('\\') && !base.includes('/')) return '\\';
+  return '/';
+}
+
+function normalizeRelativePath(relative) {
+  return relative.replace(/^[\\/]+/, '');
+}
+
+function joinPath(base, relative) {
+  if (!base) return relative;
+  const sep = getPreferredSeparator(base);
+  const normalizedBase = base.replace(/[\\/]+$/, '');
+  const normalizedRelative = normalizeRelativePath(relative).replace(/[\\/]+/g, sep);
+  if (!normalizedRelative) return normalizedBase;
+  return `${normalizedBase}${sep}${normalizedRelative}`;
+}
+
+function guessMime(pathOrName) {
+  const name = String(pathOrName || '').toLowerCase();
+  const idx = name.lastIndexOf('.');
+  if (idx === -1 || idx === name.length - 1) {
+    return 'application/octet-stream';
+  }
+  const ext = name.slice(idx + 1);
+  return MIME_BY_EXT[ext] || 'application/octet-stream';
+}
+
+function ensureUint8Array(bytes) {
+  if (bytes instanceof Uint8Array) return bytes;
+  if (ArrayBuffer.isView(bytes)) return new Uint8Array(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength));
+  if (Array.isArray(bytes)) return new Uint8Array(bytes);
+  if (bytes && typeof bytes === 'object' && typeof bytes.length === 'number') {
+    return new Uint8Array(Array.from(bytes));
+  }
+  return new Uint8Array();
+}
+
+function base64FromBytes(byteArray) {
+  const arr = ensureUint8Array(byteArray);
+  if (!arr.length) return '';
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(arr).toString('base64');
+  }
+  let binary = '';
+  const chunkSize = 0x8000;
+  for (let i = 0; i < arr.length; i += chunkSize) {
+    const slice = arr.subarray(i, i + chunkSize);
+    binary += String.fromCharCode.apply(null, slice);
+  }
+  if (typeof btoa === 'function') {
+    return btoa(binary);
+  }
+  try {
+    return Buffer.from(binary, 'binary').toString('base64');
+  } catch (err) {
+    console.warn('Failed to encode attachment bytes to base64', err);
+    return '';
+  }
+}
+
+function bytesToUrl(bytes, mime) {
+  const arr = ensureUint8Array(bytes);
+  if (!arr.length) return '';
+  try {
+    if (typeof Blob !== 'undefined' && typeof URL !== 'undefined' && typeof URL.createObjectURL === 'function') {
+      const blob = new Blob([arr], { type: mime });
+      return URL.createObjectURL(blob);
+    }
+  } catch (err) {
+    console.warn('Failed to create object URL for vault attachment', err);
+  }
+  try {
+    const base64 = base64FromBytes(arr);
+    if (base64) {
+      return `data:${mime};base64,${base64}`;
+    }
+  } catch (err) {
+    console.warn('Failed to create data URL for vault attachment', err);
+  }
+  return '';
+}
+
+function getVaultPath() {
+  if (!vaultPathPromise) {
+    try {
+      const promise = Promise.resolve(getConfig('vaultPath'))
+        .then((value) => (typeof value === 'string' ? value : ''))
+        .catch(() => '');
+      vaultPathPromise = promise;
+    } catch (err) {
+      vaultPathPromise = Promise.resolve('');
+    }
+  }
+  return vaultPathPromise;
+}
+
+async function runCustomResolver(resource) {
+  if (!customResolver) return '';
+  try {
+    const result = await customResolver(resource);
+    if (!result) return '';
+    if (typeof result === 'string') {
+      return result;
+    }
+    if (typeof result === 'object') {
+      if (typeof result.url === 'string' && result.url) {
+        return result.url;
+      }
+      if (result.bytes) {
+        const mime = typeof result.mime === 'string' && result.mime
+          ? result.mime
+          : guessMime(result.path || resource);
+        const url = bytesToUrl(result.bytes, mime);
+        if (url) return url;
+      }
+      if (typeof result.path === 'string' && result.path) {
+        const url = await loadFromPath(result.path, resource);
+        if (url) return url;
+      }
+    }
+  } catch (err) {
+    console.warn('Custom vault attachment resolver failed', err);
+  }
+  return '';
+}
+
+async function loadFromPath(path, fallbackName) {
+  if (!path) return '';
+  try {
+    const bytes = await readFileBytes(path);
+    const arr = ensureUint8Array(bytes);
+    if (!arr.length) return '';
+    const mime = guessMime(path || fallbackName);
+    return bytesToUrl(arr, mime);
+  } catch (err) {
+    return '';
+  }
+}
+
+async function buildCandidates(resource) {
+  const sanitized = sanitizeResource(resource);
+  const candidates = new Set();
+  if (!sanitized) {
+    return candidates;
+  }
+  if (isAbsolutePath(sanitized)) {
+    candidates.add(sanitized);
+    return candidates;
+  }
+  const vault = await getVaultPath();
+  if (vault) {
+    candidates.add(joinPath(vault, sanitized));
+    if (!sanitized.includes('/') && !sanitized.includes('\\')) {
+      COMMON_ATTACHMENT_DIRS.forEach((dir) => {
+        candidates.add(joinPath(vault, `${dir}/${sanitized}`));
+      });
+    }
+  }
+  candidates.add(sanitized);
+  return candidates;
+}
+
+export function setVaultAttachmentResolver(resolver) {
+  customResolver = typeof resolver === 'function' ? resolver : null;
+}
+
+export function clearVaultAttachmentCache() {
+  attachmentUrlCache.clear();
+  attachmentPromiseCache.clear();
+}
+
+export function getCachedVaultAttachment(resource) {
+  const key = normalizeResourceKey(resource);
+  if (!key) return '';
+  const cached = attachmentUrlCache.get(key);
+  return typeof cached === 'string' ? cached : '';
+}
+
+export async function resolveVaultAttachment(resource) {
+  const key = normalizeResourceKey(resource);
+  if (!key) {
+    throw new Error('Invalid vault attachment reference');
+  }
+  const cached = attachmentUrlCache.get(key);
+  if (typeof cached === 'string' && cached) {
+    return cached;
+  }
+  const pending = attachmentPromiseCache.get(key);
+  if (pending) {
+    return pending;
+  }
+  const promise = (async () => {
+    try {
+      const resolved = await runCustomResolver(resource);
+      if (resolved) {
+        attachmentUrlCache.set(key, resolved);
+        return resolved;
+      }
+      const candidates = await buildCandidates(resource);
+      for (const candidate of candidates) {
+        const url = await loadFromPath(candidate, resource);
+        if (url) {
+          attachmentUrlCache.set(key, url);
+          return url;
+        }
+      }
+      throw new Error(`Unable to resolve vault attachment: ${resource}`);
+    } catch (err) {
+      attachmentUrlCache.delete(key);
+      throw err;
+    } finally {
+      attachmentPromiseCache.delete(key);
+    }
+  })();
+  attachmentPromiseCache.set(key, promise);
+  return promise;
+}
+
+export function primeVaultAttachment(resource, url) {
+  const key = normalizeResourceKey(resource);
+  if (!key) return;
+  if (url) {
+    attachmentUrlCache.set(key, url);
+  } else {
+    attachmentUrlCache.delete(key);
+  }
+}

--- a/ui/tests/jsx-loader.mjs
+++ b/ui/tests/jsx-loader.mjs
@@ -1,0 +1,19 @@
+import { readFile } from 'node:fs/promises';
+import { transform } from 'esbuild';
+
+export async function load(url, context, defaultLoad) {
+  if (url.endsWith('.jsx')) {
+    const source = await readFile(new URL(url), 'utf8');
+    const { code } = await transform(source, {
+      loader: 'jsx',
+      format: 'esm',
+      sourcemap: 'inline',
+    });
+    return {
+      format: 'module',
+      source: code,
+      shortCircuit: true,
+    };
+  }
+  return defaultLoad(url, context, defaultLoad);
+}

--- a/ui/tests/markdown.test.js
+++ b/ui/tests/markdown.test.js
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import ReactDOMServer from 'react-dom/server';
+
+import { renderMarkdown } from '../src/lib/markdown.jsx';
+import {
+  clearVaultAttachmentCache,
+  primeVaultAttachment,
+  resolveVaultAttachment,
+  setVaultAttachmentResolver,
+} from '../src/lib/vaultAttachments.js';
+
+test('renderMarkdown renders vault attachment embeds as images', () => {
+  clearVaultAttachmentCache();
+  primeVaultAttachment('portrait.png', 'https://example.test/assets/portrait.png');
+
+  const markup = ReactDOMServer.renderToStaticMarkup(
+    renderMarkdown('Greetings ![[portrait.png|Hero Portrait]] adventurer!')
+  );
+
+  assert.match(
+    markup,
+    /<img[^>]*class="md-img"[^>]*src="https:\/\/example\.test\/assets\/portrait\.png"/,
+    'expected img tag with the resolved attachment URL'
+  );
+  assert.match(
+    markup,
+    /<img[^>]*alt="Hero Portrait"/,
+    'expected img tag to include the resolved alias as alt text'
+  );
+});
+
+test('renderMarkdown wraps standalone hashtags in chips', () => {
+  clearVaultAttachmentCache();
+  const markup = ReactDOMServer.renderToStaticMarkup(
+    renderMarkdown('Talk about #hope and (#quest/line)! Keep C# friendly with #music.')
+  );
+  assert.match(markup, /<span class="chip">#hope<\/span>/);
+  assert.match(markup, /<span class="chip">#quest\/line<\/span>/);
+  assert.match(markup, /<span class="chip">#music<\/span>/);
+  assert.doesNotMatch(markup, /<span class="chip">C#<\/span>/);
+});
+
+test('resolveVaultAttachment prefers the custom resolver when provided', async (t) => {
+  clearVaultAttachmentCache();
+  let resolverCalls = 0;
+  setVaultAttachmentResolver(async (resource) => {
+    resolverCalls += 1;
+    if (resource === 'portrait.png') {
+      return 'blob:mock-url';
+    }
+    return '';
+  });
+
+  t.after(() => {
+    setVaultAttachmentResolver(null);
+    clearVaultAttachmentCache();
+  });
+
+  const url = await resolveVaultAttachment('portrait.png');
+  assert.equal(url, 'blob:mock-url');
+  assert.equal(resolverCalls, 1);
+});


### PR DESCRIPTION
## Summary
- add a vault attachment resolver that turns vault file paths into reusable URLs for markdown rendering
- extend the inline parser to render Obsidian-style ![[...]] embeds as md-img images and wrap hashtag tokens in chip spans
- cover the new behaviors with node-based markdown tests and a JSX loader for node's test runner

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d17c08080c8325b2941736c137bffc