### PR TITLE
Update monster template path references

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2082,7 +2082,9 @@ fn monster_create(app: AppHandle, name: String, template: Option<String>) -> Res
 
     // Resolve template path (be tolerant of malformed Windows paths and relative inputs)
     eprintln!("[blossom] monster_create: resolving template path");
-    let default_template = r"D:\\Documents\\DreadHaven\\_Templates\\Monster_Template.md".to_string();
+    let default_template =
+        r"D:\\Documents\\DreadHaven\\_Templates\\Monster Template + Universal (D&D 5e Statblock).md"
+            .to_string();
     let mut candidates: Vec<PathBuf> = Vec::new();
     if let Some(mut s) = template {
         eprintln!("[blossom] monster_create: raw template arg='{}'", s);

--- a/ui/src/pages/DndDmMonsters.jsx
+++ b/ui/src/pages/DndDmMonsters.jsx
@@ -10,7 +10,7 @@ import './Dnd.css';
 
 const DEFAULT_MONSTERS = 'D\\\\Documents\\\\DreadHaven\\\\20_DM\\\\Monsters'.replace(/\\\\/g, '\\\\');
 const DEFAULT_PORTRAITS = 'D\\\\Documents\\\\DreadHaven\\\\30_Assets\\\\Images\\\\Monster_Portraits'.replace(/\\\\/g, '\\\\');
-const MONSTER_TEMPLATE = 'D\\\\Documents\\\\DreadHaven\\\\_Templates\\\\Monster_Template.md';
+const MONSTER_TEMPLATE = 'D\\\\Documents\\\\DreadHaven\\\\_Templates\\\\Monster Template + Universal (D&D 5e Statblock).md';
 const IMG_RE = /\.(png|jpe?g|gif|webp|bmp|svg)$/i;
 
 function formatDate(ms) {


### PR DESCRIPTION
## Summary
- point the D&D monsters page constant at the new universal statblock template file
- update the Tauri monster creation command to default to the same template path

## Testing
- cargo build --manifest-path src-tauri/Cargo.toml *(fails: missing system `glib-2.0` library required by tauri)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b3485c9883259623c369407a0df7