### PR TITLE
Add D&D world factions page

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -36,6 +36,7 @@ import MusicGen from './pages/MusicGen.jsx';
 import AlgorithmicGenerator from './pages/Generate.jsx';
 import DndWorldPantheon from './pages/DndWorldPantheon.jsx';
 import DndWorldRegions from './pages/DndWorldRegions.jsx';
+import DndWorldFactions from './pages/DndWorldFactions.jsx';
 import SoundLab from './pages/SoundLab.jsx';
 import Queue from './pages/Queue.jsx';
 import Tools from './pages/Tools.jsx';
@@ -169,6 +170,7 @@ export default function App() {
         <Route path="/dnd/world" element={<DndWorld />} />
         <Route path="/dnd/world/pantheon" element={<DndWorldPantheon />} />
         <Route path="/dnd/world/regions" element={<DndWorldRegions />} />
+        <Route path="/dnd/world/factions" element={<DndWorldFactions />} />
         <Route path="/dnd/lore/secrets" element={<DndLoreSecrets />} />
         <Route path="/dnd/lore/journal" element={<DndLoreJournal />} />
         <Route path="/dnd/tasks" element={<DndTasks />} />

--- a/ui/src/pages/DndWorld.jsx
+++ b/ui/src/pages/DndWorld.jsx
@@ -15,6 +15,12 @@ const sections = [
     title: 'Regions',
     description: 'Continents, nations, cities, and locales.',
   },
+  {
+    to: '/dnd/world/factions',
+    icon: 'Shield',
+    title: 'Factions',
+    description: 'Organizations, alliances, and power blocs.',
+  },
 ];
 
 export default function DndWorld() {

--- a/ui/src/pages/DndWorldFactions.jsx
+++ b/ui/src/pages/DndWorldFactions.jsx
@@ -1,0 +1,24 @@
+import BackButton from '../components/BackButton.jsx';
+import './Dnd.css';
+
+export default function DndWorldFactions() {
+  return (
+    <>
+      <BackButton />
+      <h1>Dungeons & Dragons · Factions</h1>
+      <main className="dashboard" style={{ padding: '1rem' }}>
+        <div
+          style={{
+            background: 'var(--card-bg)',
+            color: 'var(--text)',
+            border: '1px solid var(--border)',
+            borderRadius: 8,
+            padding: '1rem',
+          }}
+        >
+          Chronicle the influential factions, guilds, and secret societies that shape your world.
+        </div>
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add a Factions card to the D&D World menu
- create a placeholder D&D World Factions page with navigation scaffolding
- register the factions route in the app router

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d1bf4b0bf08325a02b9ad8d5658aea