### PR TITLE
Add ElevenLabs v3 model selection

### DIFF
--- a/ui/src/pages/DndElevenLabs.jsx
+++ b/ui/src/pages/DndElevenLabs.jsx
@@ -4,11 +4,17 @@ import { invoke } from '@tauri-apps/api/core';
 import BackButton from '../components/BackButton.jsx';
 import './Dnd.css';
 
+const ELEVEN_MODEL_OPTIONS = [
+  'eleven_multilingual_v3',
+  'eleven_multilingual_v2',
+  'eleven_turbo_v2',
+];
+
 export default function DndElevenLabs() {
   const [apiKey, setApiKey] = useState('');
   const [profiles, setProfiles] = useState([]);
   const [selectedName, setSelectedName] = useState('');
-  const [modelId, setModelId] = useState('eleven_multilingual_v2');
+  const [modelId, setModelId] = useState(ELEVEN_MODEL_OPTIONS[0]);
   const [text, setText] = useState('');
   const [audioUrl, setAudioUrl] = useState('');
   const [error, setError] = useState('');
@@ -86,8 +92,9 @@ export default function DndElevenLabs() {
               onChange={(e) => setModelId(e.target.value)}
               style={{ marginLeft: '0.5rem' }}
             >
-              <option value="eleven_multilingual_v2">eleven_multilingual_v2</option>
-              <option value="eleven_turbo_v2">eleven_turbo_v2</option>
+              {ELEVEN_MODEL_OPTIONS.map((option) => (
+                <option key={option} value={option}>{option}</option>
+              ))}
             </select>
           </label>
         </div>

--- a/ui/src/pages/DndPiper.jsx
+++ b/ui/src/pages/DndPiper.jsx
@@ -8,6 +8,12 @@ import { appDataDir } from '@tauri-apps/api/path';
 import BackButton from '../components/BackButton.jsx';
 import './Dnd.css';
 
+const ELEVEN_MODEL_OPTIONS = [
+  'eleven_multilingual_v3',
+  'eleven_multilingual_v2',
+  'eleven_turbo_v2',
+];
+
 export default function DndPiper() {
   const [aiModel, setAiModel] = useState('piper');
   const [voices, setVoices] = useState([]);
@@ -15,6 +21,7 @@ export default function DndPiper() {
   const [elVoices, setElVoices] = useState([]);
   const [elevenVoice, setElevenVoice] = useState('');
   const [elevenApiKey, setElevenApiKey] = useState('');
+  const [elevenModelId, setElevenModelId] = useState(ELEVEN_MODEL_OPTIONS[0]);
   const [elStatus, setElStatus] = useState('');
   const [piperText, setPiperText] = useState('');
   const [piperAudio, setPiperAudio] = useState('');
@@ -355,6 +362,20 @@ export default function DndPiper() {
                 {elStatus && <span style={{ opacity: 0.85 }}>{elStatus}</span>}
               </div>
             )}
+            <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center', flexWrap: 'wrap' }}>
+              <label>
+                Model
+                <select
+                  value={elevenModelId}
+                  onChange={(e) => setElevenModelId(e.target.value)}
+                  style={{ marginLeft: '0.5rem' }}
+                >
+                  {ELEVEN_MODEL_OPTIONS.map((option) => (
+                    <option key={option} value={option}>{option}</option>
+                  ))}
+                </select>
+              </label>
+            </div>
             <select
               value={elevenVoice}
               onChange={(e) => {
@@ -400,6 +421,7 @@ export default function DndPiper() {
                     },
                     body: JSON.stringify({
                       text: piperText,
+                      model_id: elevenModelId,
                     }),
                   });
                   if (!res.ok) {


### PR DESCRIPTION
## Summary
- add the new ElevenLabs multilingual v3 identifier to the model choices
- expose the shared model list in the dedicated ElevenLabs page and the combined Piper/Eleven interface
- include the selected model identifier when issuing ElevenLabs synthesis requests

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d1e5226b008325a941436c77044f8f