### PR TITLE
Add Establishment placeholder for Dungeon Master dashboard

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -17,6 +17,7 @@ import DndDmQuestsFaction from './pages/DndDmQuestsFaction.jsx';
 import DndDmQuestsMain from './pages/DndDmQuestsMain.jsx';
 import DndDmQuestsPersonal from './pages/DndDmQuestsPersonal.jsx';
 import DndDmQuestsSide from './pages/DndDmQuestsSide.jsx';
+import DndDmEstablishments from './pages/DndDmEstablishments.jsx';
 import DndVoiceLabs from './pages/DndVoiceLabs.jsx';
 import DndPiperOnly from './pages/DndPiperOnly.jsx';
 import DndElevenLabs from './pages/DndElevenLabs.jsx';
@@ -184,6 +185,7 @@ export default function App() {
         <Route path="/dnd/dungeon-master/quests/main" element={<DndDmQuestsMain />} />
         <Route path="/dnd/dungeon-master/quests/personal" element={<DndDmQuestsPersonal />} />
         <Route path="/dnd/dungeon-master/quests/side" element={<DndDmQuestsSide />} />
+        <Route path="/dnd/dungeon-master/establishments" element={<DndDmEstablishments />} />
         <Route path="/dnd/dungeon-master/world-inventory" element={<DndDmWorldInventory />} />
         <Route path="/dnd/assets" element={<DndAssets />} />
         <Route path="/dnd/lore" element={<DndLore />} />

--- a/ui/src/pages/DndDmEstablishments.jsx
+++ b/ui/src/pages/DndDmEstablishments.jsx
@@ -1,0 +1,24 @@
+import BackButton from '../components/BackButton.jsx';
+import './Dnd.css';
+
+export default function DndDmEstablishments() {
+  return (
+    <>
+      <BackButton />
+      <h1>Dungeons & Dragons · Establishments</h1>
+      <main className="dashboard" style={{ padding: '1rem' }}>
+        <div
+          style={{
+            background: 'var(--card-bg)',
+            color: 'var(--text)',
+            border: '1px solid var(--border)',
+            borderRadius: 8,
+            padding: '1rem',
+          }}
+        >
+          Coming soon
+        </div>
+      </main>
+    </>
+  );
+}

--- a/ui/src/pages/DndDungeonMaster.jsx
+++ b/ui/src/pages/DndDungeonMaster.jsx
@@ -3,12 +3,48 @@ import Card from '../components/Card.jsx';
 import './Dnd.css';
 
 const sections = [
-  { to: '/dnd/dungeon-master/events', icon: 'Calendar', title: 'Events', description: 'Session plans, timelines, and hooks.' },
-  { to: '/dnd/dungeon-master/monsters', icon: 'Skull', title: 'Monsters', description: 'Bestiary and custom creature notes.' },
-  { to: '/dnd/dungeon-master/npcs', icon: 'Users', title: 'NPCs', description: 'Quick access to important NPC notes.' },
-  { to: '/dnd/dungeon-master/players', icon: 'User', title: 'Players', description: 'PC sheets, bonds, and party info.' },
-  { to: '/dnd/dungeon-master/quests', icon: 'ScrollText', title: 'Quests', description: 'Active, pending, and completed quests.' },
-  { to: '/dnd/dungeon-master/world-inventory', icon: 'Boxes', title: 'World Inventory', description: 'Under construction' },
+  {
+    to: '/dnd/dungeon-master/events',
+    icon: 'Calendar',
+    title: 'Events',
+    description: 'Session plans, timelines, and hooks.',
+  },
+  {
+    to: '/dnd/dungeon-master/monsters',
+    icon: 'Skull',
+    title: 'Monsters',
+    description: 'Bestiary and custom creature notes.',
+  },
+  {
+    to: '/dnd/dungeon-master/npcs',
+    icon: 'Users',
+    title: 'NPCs',
+    description: 'Quick access to important NPC notes.',
+  },
+  {
+    to: '/dnd/dungeon-master/players',
+    icon: 'User',
+    title: 'Players',
+    description: 'PC sheets, bonds, and party info.',
+  },
+  {
+    to: '/dnd/dungeon-master/quests',
+    icon: 'ScrollText',
+    title: 'Quests',
+    description: 'Active, pending, and completed quests.',
+  },
+  {
+    to: '/dnd/dungeon-master/establishments',
+    icon: 'Building',
+    title: 'Establishment',
+    description: 'Taverns, shops, and notable businesses.',
+  },
+  {
+    to: '/dnd/dungeon-master/world-inventory',
+    icon: 'Boxes',
+    title: 'World Inventory',
+    description: 'Under construction',
+  },
 ];
 
 export default function DndDungeonMaster() {


### PR DESCRIPTION
## Summary
- add an Establishment card to the Dungeon Master dashboard linking to a new route
- add a placeholder Establishments page so the navigation card has a destination

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1e527b0c48325b66f8c831707a43e