### PR TITLE
Refactor D&D pantheon layout

### DIFF
--- a/ui/src/pages/Dnd.css
+++ b/ui/src/pages/Dnd.css
@@ -295,10 +295,49 @@
 }
 
 /* Pantheon layout */
+.dashboard.dnd-detail-layout {
+  grid-template-columns: minmax(320px, 460px) minmax(0, 1fr);
+  align-items: start;
+}
+
+.dashboard.dnd-detail-layout > * {
+  min-width: 0;
+}
+
+@media (max-width: 960px) {
+  .dashboard.dnd-detail-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.dnd-surface,
+.dnd-reader,
+.pantheon-reader {
+  background: var(--card-bg);
+  color: var(--text);
+  border: 1px solid #1f2937;
+  border-radius: 12px;
+  padding: var(--space-md);
+}
+
+.dnd-surface,
+.dnd-reader {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  min-width: 0;
+  min-height: 0;
+}
+
+.dnd-toolbar,
 .pantheon-controls {
   display: flex;
   align-items: center;
   gap: 0.9rem;
+  flex-wrap: wrap;
+}
+
+.pantheon-controls {
   margin: var(--space-sm) 0 var(--space-md);
 }
 
@@ -309,6 +348,7 @@
   min-height: 60vh;
 }
 
+.dnd-card-collection,
 .pantheon-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
@@ -316,6 +356,7 @@
   align-content: start;
 }
 
+.dnd-card-button,
 .pantheon-card {
   background: var(--card-bg);
   color: var(--text);
@@ -323,28 +364,56 @@
   border-radius: 12px;
   padding: 0.9rem;
   text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  width: 100%;
+  height: 100%;
+  font: inherit;
+  cursor: pointer;
+  transition: border-color 0.2s ease, transform 0.2s ease, background 0.2s ease;
 }
 
+.dnd-card-button:hover,
+.dnd-card-button:focus-visible,
+.pantheon-card:hover,
+.pantheon-card:focus-visible {
+  border-color: var(--accent);
+  background: var(--card-hover-bg);
+  transform: translateY(-2px);
+}
+
+.dnd-card-button.is-active,
 .pantheon-card.active {
   border-color: var(--accent);
+  background: var(--card-hover-bg);
 }
 
+.dnd-card-button-title,
 .pantheon-card-title {
   font-weight: 700;
-  margin-bottom: 0.35rem;
+  margin: 0;
 }
 
+.dnd-card-button-meta,
 .pantheon-card-meta {
   font-size: 0.85rem;
   opacity: 0.8;
 }
 
-.pantheon-reader {
-  background: var(--card-bg);
-  color: var(--text);
-  border: 1px solid #1f2937;
+.dnd-card-empty {
+  grid-column: 1 / -1;
+  padding: 0.75rem;
+  text-align: center;
   border-radius: 10px;
-  padding: 1rem;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+@media (max-width: 600px) {
+  .dnd-card-collection,
+  .pantheon-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* Regions layout */

--- a/ui/src/pages/DndWorldPantheon.jsx
+++ b/ui/src/pages/DndWorldPantheon.jsx
@@ -98,33 +98,36 @@ export default function DndWorldPantheon() {
     <>
       <BackButton />
       <h1>Dungeons & Dragons · Pantheon</h1>
-      <div className="pantheon-controls">
-        <button type="button" onClick={fetchItems} disabled={loading}>
-          {loading ? 'Loading…' : 'Refresh'}
-        </button>
-        {usingPath && <span className="muted">Folder: {usingPath}</span>}
-        {error && <span className="error">{error}</span>}
-      </div>
-      <div className="pantheon">
-        <section className="pantheon-grid">
-          {items.map((item) => (
-            <button
-              key={item.path}
-              className={`pantheon-card${item.path === activePath ? ' active' : ''}`}
-              onClick={() => setActivePath(item.path)}
-              title={item.path}
-            >
-              <div className="pantheon-card-title">{item.title || item.name}</div>
-              <div className="pantheon-card-meta">
-                <time title={formatDate(item.modified_ms)}>{formatRelative(item.modified_ms)}</time>
-              </div>
+      <main className="dashboard dnd-detail-layout">
+        <section className="dnd-surface">
+          <div className="dnd-toolbar">
+            <button type="button" onClick={fetchItems} disabled={loading}>
+              {loading ? 'Loading…' : 'Refresh'}
             </button>
-          ))}
-          {!loading && items.length === 0 && (
-            <div className="muted">No gods found in this folder.</div>
-          )}
+            {usingPath && <span className="muted">Folder: {usingPath}</span>}
+            {error && <span className="error">{error}</span>}
+          </div>
+          <div className="dnd-card-collection">
+            {items.map((item) => (
+              <button
+                type="button"
+                key={item.path}
+                className={`dnd-card-button${item.path === activePath ? ' is-active' : ''}`}
+                onClick={() => setActivePath(item.path)}
+                title={item.path}
+              >
+                <span className="dnd-card-button-title">{item.title || item.name}</span>
+                <span className="dnd-card-button-meta">
+                  <time title={formatDate(item.modified_ms)}>{formatRelative(item.modified_ms)}</time>
+                </span>
+              </button>
+            ))}
+            {!loading && items.length === 0 && (
+              <div className="muted dnd-card-empty">No gods found in this folder.</div>
+            )}
+          </div>
         </section>
-        <section className="pantheon-reader">
+        <section className="dnd-reader">
           {selected ? (
             <>
               <header className="inbox-reader-header">
@@ -147,7 +150,7 @@ export default function DndWorldPantheon() {
             <div className="muted">Select a god to view details.</div>
           )}
         </section>
-      </div>
+      </main>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- wrap the pantheon page content in the shared dashboard layout
- restyle pantheon cards with shared D&D styling tokens for consistency

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1e52f8ab48325b0d4347bdbd92548