### PR TITLE
Add shopkeeper establishment placeholder UI

### DIFF
--- a/ui/src/pages/Dnd.css
+++ b/ui/src/pages/Dnd.css
@@ -502,6 +502,13 @@
 .monster-create-form label { display: grid; gap: 0.35rem; font-weight: 600; }
 .monster-create-form input { padding: 0.55rem 0.7rem; border-radius: 8px; border: 1px solid #1f2937; background: rgba(15, 23, 42, 0.9); color: var(--text); }
 .monster-create-form input:disabled { opacity: 0.6; }
+.monster-create-form select,
+.monster-create-form textarea { padding: 0.55rem 0.7rem; border-radius: 8px; border: 1px solid #1f2937; background: rgba(15, 23, 42, 0.9); color: var(--text); }
+.monster-create-form select:disabled,
+.monster-create-form textarea:disabled { opacity: 0.6; }
+.monster-create-shopkeeper { display: grid; gap: 0.75rem; padding: 0.85rem; border-radius: 10px; border: 1px solid #1f2937; background: rgba(15, 23, 42, 0.6); }
+.monster-create-shopkeeper button { align-self: flex-start; }
+.monster-create-shopkeeper-title { font-size: 0.8rem; letter-spacing: 0.05em; text-transform: uppercase; font-weight: 600; color: rgba(255, 255, 255, 0.75); }
 .monster-create-actions { display: flex; justify-content: flex-end; gap: 0.9rem; }
 
 /* Monster card portrait */

--- a/ui/src/pages/DndDmNpcs.jsx
+++ b/ui/src/pages/DndDmNpcs.jsx
@@ -56,6 +56,8 @@ export default function DndDmNpcs() {
   const [customPurpose, setCustomPurpose] = useState('');
   const [createError, setCreateError] = useState('');
   const [regionOptions, setRegionOptions] = useState([]);
+  const [establishmentName, setEstablishmentName] = useState('');
+  const [establishmentRecord, setEstablishmentRecord] = useState('');
 
   const parseNpcFrontmatter = useCallback((src) => {
     const text = typeof src === 'string' ? src : '';
@@ -197,6 +199,13 @@ export default function DndDmNpcs() {
       }
     })();
   }, []);
+
+  useEffect(() => {
+    if (selPurpose !== 'Shopkeeper') {
+      setEstablishmentName('');
+      setEstablishmentRecord('');
+    }
+  }, [selPurpose]);
 
   // Build portrait index from Assets folder (optional)
   useEffect(() => {
@@ -559,6 +568,8 @@ export default function DndDmNpcs() {
                 setSelRegion('');
                 setSelPurpose('');
                 setCustomPurpose('');
+                setEstablishmentName('');
+                setEstablishmentRecord('');
                 await fetchItems();
               } catch (err) {
                 setCreateError(err?.message || String(err));
@@ -591,6 +602,38 @@ export default function DndDmNpcs() {
                   <option value="__custom__">Custom…</option>
                 </select>
               </label>
+              {selPurpose === 'Shopkeeper' && (
+                <div className="monster-create-shopkeeper">
+                  <div className="monster-create-shopkeeper-title">Establishment Link</div>
+                  <p className="muted">
+                    Connect this shopkeeper to the storefront they manage. Linking support is coming soon,
+                    but you can note the establishment details here for reference.
+                  </p>
+                  <label>
+                    Establishment Name
+                    <input
+                      type="text"
+                      value={establishmentName}
+                      onChange={(e) => setEstablishmentName(e.target.value)}
+                      disabled={creating}
+                      placeholder="e.g. The Gilded Griffin General Store"
+                    />
+                  </label>
+                  <label>
+                    Existing Shop Record
+                    <select
+                      value={establishmentRecord}
+                      onChange={(e) => setEstablishmentRecord(e.target.value)}
+                      disabled
+                    >
+                      <option value="">Linking support coming soon</option>
+                    </select>
+                  </label>
+                  <button type="button" disabled>
+                    Connect to Establishment
+                  </button>
+                </div>
+              )}
               {selPurpose === '__custom__' && (
                 <label>
                   Custom purpose


### PR DESCRIPTION
## Summary
- add a shopkeeper-specific establishment section to the NPC creation form that is shown when that purpose is selected
- keep placeholder establishment fields reset when the purpose changes or after a creation succeeds
- extend D&D styling so the new block and select controls match the existing monster creation form

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d1f1f42e708325993f0e3ccf72d272