### PR TITLE
Add D&D chat helper and UI integration

### DIFF
--- a/brain/dnd_chat.py
+++ b/brain/dnd_chat.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+"""Helpers for Dungeons & Dragons specific chat interactions."""
+
+from typing import Final
+
+from . import dialogue, prompt_router
+import service_api
+
+
+_ALLOWED_CATEGORIES: Final[frozenset[str]] = frozenset({"lore", "npc"})
+REFUSAL_MESSAGE: Final[str] = (
+    "I'm only able to discuss our Dungeons & Dragons world, its lore, and its NPCs. "
+    "Try asking about the campaign setting, locations, or characters."
+)
+
+
+def _has_relevant_context(message: str, category: str) -> bool:
+    """Return ``True`` if ``message`` appears related to D&D lore or NPCs."""
+
+    if category in _ALLOWED_CATEGORIES:
+        return True
+
+    try:
+        results = service_api.search(message, tags=list(_ALLOWED_CATEGORIES))
+    except Exception:
+        return False
+    return bool(results)
+
+
+def chat(message: str) -> str:
+    """Return a narration for ``message`` or a refusal when off-topic."""
+
+    stripped = message.strip()
+    if not stripped:
+        return REFUSAL_MESSAGE
+
+    category = prompt_router.classify(stripped)
+    if not _has_relevant_context(stripped, category):
+        return REFUSAL_MESSAGE
+
+    response = dialogue.respond(message)
+    if isinstance(response, str):
+        return response
+    return response.narration

--- a/tests/brain/test_dnd_chat.py
+++ b/tests/brain/test_dnd_chat.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+import sys
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+fake_service_api = types.SimpleNamespace(search=lambda q, tags=None: [])
+sys.modules.setdefault("service_api", fake_service_api)
+
+from brain import dnd_chat
+
+
+def test_refuses_when_no_context(monkeypatch):
+    monkeypatch.setattr(dnd_chat.prompt_router, "classify", lambda msg: "note")
+    monkeypatch.setattr(dnd_chat.service_api, "search", lambda q, tags=None: [])
+    result = dnd_chat.chat("What's your favourite color?")
+    assert result == dnd_chat.REFUSAL_MESSAGE
+
+
+def test_calls_dialogue_for_lore(monkeypatch):
+    monkeypatch.setattr(dnd_chat.prompt_router, "classify", lambda msg: "lore")
+
+    captured = {}
+
+    def fake_respond(message: str):
+        captured["message"] = message
+        return types.SimpleNamespace(narration="Lore:" + message)
+
+    monkeypatch.setattr(dnd_chat.dialogue, "respond", fake_respond)
+    output = dnd_chat.chat("Tell me about the capital city")
+    assert output == "Lore:Tell me about the capital city"
+    assert captured["message"] == "Tell me about the capital city"
+
+
+def test_search_fallback_allows_dialogue(monkeypatch):
+    monkeypatch.setattr(dnd_chat.prompt_router, "classify", lambda msg: "note")
+    monkeypatch.setattr(
+        dnd_chat.service_api,
+        "search",
+        lambda q, tags=None: [{"path": "world/towns.md", "content": "Town lore"}],
+    )
+
+    monkeypatch.setattr(
+        dnd_chat.dialogue,
+        "respond",
+        lambda msg: types.SimpleNamespace(narration=f"NPC:{msg}"),
+    )
+
+    output = dnd_chat.chat("Who runs the Silver Spoon tavern?")
+    assert output == "NPC:Who runs the Silver Spoon tavern?"
+
+
+def test_dialogue_string_is_forwarded(monkeypatch):
+    monkeypatch.setattr(dnd_chat.prompt_router, "classify", lambda msg: "npc")
+    monkeypatch.setattr(dnd_chat.dialogue, "respond", lambda msg: "Saved note")
+    output = dnd_chat.chat("note tavern: The owner is friendly")
+    assert output == "Saved note"

--- a/ui/src/pages/Dnd.css
+++ b/ui/src/pages/Dnd.css
@@ -198,6 +198,97 @@
   color: var(--text);
 }
 
+.dnd-chat-panel {
+  background: var(--card-bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: var(--space-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.dnd-chat-history {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background: rgba(17, 24, 39, 0.65);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-height: 260px;
+  max-height: 420px;
+  overflow-y: auto;
+}
+
+.dnd-chat-message {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.dnd-chat-role {
+  font-weight: 600;
+  font-size: 0.9rem;
+  opacity: 0.8;
+}
+
+.dnd-chat-bubble {
+  background: rgba(59, 130, 246, 0.18);
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  border-radius: 12px;
+  padding: 0.65rem 0.8rem;
+  line-height: 1.6;
+  white-space: pre-wrap;
+}
+
+.dnd-chat-message.assistant .dnd-chat-bubble {
+  background: rgba(16, 185, 129, 0.18);
+  border-color: rgba(16, 185, 129, 0.25);
+}
+
+.dnd-chat-message.user .dnd-chat-bubble {
+  align-self: flex-end;
+}
+
+.dnd-chat-form {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.dnd-chat-form textarea {
+  width: 100%;
+  min-height: 120px;
+  resize: vertical;
+  padding: 0.75rem;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: rgba(15, 23, 42, 0.7);
+  color: inherit;
+}
+
+.dnd-chat-form textarea:disabled {
+  opacity: 0.7;
+}
+
+.dnd-chat-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.dnd-chat-status {
+  font-size: 0.9rem;
+  color: rgba(59, 130, 246, 0.85);
+}
+
+.dnd-chat-error {
+  font-size: 0.9rem;
+  color: rgba(248, 113, 113, 0.9);
+}
+
 .inbox-item-preview {
   margin-top: 0.25rem;
   opacity: 0.85;

--- a/ui/src/pages/DndChat.jsx
+++ b/ui/src/pages/DndChat.jsx
@@ -1,12 +1,114 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
 import BackButton from '../components/BackButton.jsx';
 import './Dnd.css';
 
+const INTRO_MESSAGE = 'Ask about your campaign world, its locations, or the characters you have met.';
+
 export default function DndChat() {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+  const [pending, setPending] = useState(false);
+  const [status, setStatus] = useState('');
+  const [error, setError] = useState('');
+  const listRef = useRef(null);
+
+  const scrollToBottom = useCallback(() => {
+    const node = listRef.current;
+    if (!node) return;
+    requestAnimationFrame(() => {
+      node.scrollTop = node.scrollHeight;
+    });
+  }, []);
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages.length, scrollToBottom]);
+
+  const sendMessage = useCallback(async () => {
+    const prompt = input.trim();
+    if (!prompt || pending) return;
+    setPending(true);
+    setStatus('Consulting the archives…');
+    setError('');
+    setMessages((prev) => prev.concat({ role: 'user', content: prompt }));
+    setInput('');
+    try {
+      const reply = await invoke('dnd_chat_message', { message: prompt });
+      const text = typeof reply === 'string' ? reply : reply == null ? '' : String(reply);
+      setMessages((prev) => prev.concat({ role: 'assistant', content: text }));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const rendered = `Error: ${message}`;
+      setError(rendered);
+      setMessages((prev) => prev.concat({ role: 'assistant', content: rendered }));
+    } finally {
+      setPending(false);
+      setStatus('');
+      scrollToBottom();
+    }
+  }, [input, pending, scrollToBottom]);
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    sendMessage();
+  };
+
+  const handleKeyDown = (event) => {
+    if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+      event.preventDefault();
+      sendMessage();
+    }
+  };
+
   return (
     <>
       <BackButton />
       <h1>Dungeons &amp; Dragons &middot; Chat</h1>
-      <p>Chat coming soon.</p>
+      <main className="dashboard" style={{ padding: '1rem' }}>
+        <section className="dnd-chat-panel">
+          <p className="muted" style={{ margin: 0 }}>
+            {INTRO_MESSAGE} Non-campaign topics will be politely declined.
+          </p>
+          {status && (
+            <div className="dnd-chat-status" role="status">
+              {status}
+            </div>
+          )}
+          {error && (
+            <div className="dnd-chat-error" role="alert">
+              {error}
+            </div>
+          )}
+          <div className="dnd-chat-history" ref={listRef}>
+            {messages.length === 0 ? (
+              <div className="muted">Begin a conversation to receive a narrated reply.</div>
+            ) : (
+              messages.map((entry, index) => (
+                <div key={`${entry.role}-${index}`} className={`dnd-chat-message ${entry.role}`}>
+                  <div className="dnd-chat-role">{entry.role === 'user' ? 'You' : 'Blossom'}</div>
+                  <div className="dnd-chat-bubble">{entry.content}</div>
+                </div>
+              ))
+            )}
+          </div>
+          <form className="dnd-chat-form" onSubmit={handleSubmit}>
+            <textarea
+              rows={4}
+              value={input}
+              onChange={(event) => setInput(event.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Share a lore prompt, ask about an NPC, or describe the world…"
+              disabled={pending}
+            />
+            <div className="dnd-chat-actions">
+              <button type="submit" className="p-sm" disabled={pending || !input.trim()}>
+                {pending ? 'Weaving the tale…' : 'Send'}
+              </button>
+            </div>
+          </form>
+        </section>
+      </main>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- add a Python D&D chat helper that screens prompts for lore/NPC context and falls back to the refusal message when needed
- expose the helper through a new `dnd_chat_message` Tauri command and wire it up to the chat page
- replace the chat placeholder with a stateful UI and styling updates that surface assistant replies and refusal notices

## Testing
- pytest tests/brain/test_dnd_chat.py

------
https://chatgpt.com/codex/tasks/task_e_68d1f21d2bb88325bbd79a969b191ea1