### PR TITLE
Support secrets.json fallback for Discord token

### DIFF
--- a/config/discord_token.py
+++ b/config/discord_token.py
@@ -2,12 +2,23 @@ from __future__ import annotations
 
 """Utilities for persisting the Discord bot token."""
 
+from collections.abc import Iterable
+import json
+import os
 from pathlib import Path
+import sys
 
 __all__ = ["get_token", "set_token", "TOKEN_FILE"]
 
 # Location where the Discord token will be stored.
 TOKEN_FILE = Path(__file__).with_name("discord_token.txt")
+
+# Canonical ``secrets.json`` file name and Tauri identifier.
+SECRETS_FILE_NAME = "secrets.json"
+TAURI_IDENTIFIER = "com.blossom.musicgen"
+
+# Repository root used for the project-level secrets file.
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
 # Internal cached token value.
 _TOKEN: str | None = None
@@ -20,8 +31,16 @@ def get_token() -> str | None:
     if _TOKEN is not None:
         return _TOKEN
     if TOKEN_FILE.exists():
-        _TOKEN = TOKEN_FILE.read_text().strip()
-    return _TOKEN
+        _TOKEN = TOKEN_FILE.read_text(encoding="utf-8").strip()
+        return _TOKEN
+
+    for secrets_file in _candidate_secrets_files():
+        token = _read_token_from_secrets(secrets_file)
+        if token is not None:
+            _TOKEN = token
+            return token
+
+    return None
 
 
 def set_token(token: str) -> str:
@@ -32,8 +51,7 @@ def set_token(token: str) -> str:
     """
 
     token = token.strip()
-    existing = get_token()
-    if existing is not None:
+    if TOKEN_FILE.exists():
         raise RuntimeError("Token already set")
 
     TOKEN_FILE.write_text(token)
@@ -48,3 +66,85 @@ def set_token(token: str) -> str:
     global _TOKEN
     _TOKEN = token
     return token
+
+
+def _candidate_secrets_files() -> Iterable[Path]:
+    """Yield candidate ``secrets.json`` paths in priority order."""
+
+    yield PROJECT_ROOT / SECRETS_FILE_NAME
+    yield from _tauri_store_secret_files()
+
+
+def _tauri_store_secret_files(platform: str | None = None) -> Iterable[Path]:
+    """Return possible ``secrets.json`` locations for the Tauri store."""
+
+    platform = platform or sys.platform
+    store_name = SECRETS_FILE_NAME
+    identifier = TAURI_IDENTIFIER
+    candidates: list[Path] = []
+
+    if platform.startswith("win"):
+        for env_var in ("APPDATA", "LOCALAPPDATA"):
+            base = os.environ.get(env_var)
+            if base:
+                candidates.append(Path(base) / identifier / store_name)
+        home = Path.home()
+        candidates.extend(
+            [
+                home / "AppData" / "Roaming" / identifier / store_name,
+                home / "AppData" / "Local" / identifier / store_name,
+            ]
+        )
+    elif platform == "darwin":
+        candidates.append(
+            Path.home()
+            / "Library"
+            / "Application Support"
+            / identifier
+            / store_name
+        )
+    else:
+        data_home = os.environ.get("XDG_DATA_HOME")
+        if data_home:
+            candidates.append(Path(data_home) / identifier / store_name)
+        config_home = os.environ.get("XDG_CONFIG_HOME")
+        if config_home:
+            candidates.append(Path(config_home) / identifier / store_name)
+        home = Path.home()
+        candidates.extend(
+            [
+                home / ".local" / "share" / identifier / store_name,
+                home / ".config" / identifier / store_name,
+            ]
+        )
+
+    seen: set[Path] = set()
+    for path in candidates:
+        if path in seen:
+            continue
+        seen.add(path)
+        yield path
+
+
+def _read_token_from_secrets(path: Path) -> str | None:
+    """Extract the Discord token from ``secrets.json`` if available."""
+
+    if not path.exists():
+        return None
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return None
+    discord_section = data.get("discord", {})
+    if not isinstance(discord_section, dict):
+        return None
+    token = discord_section.get("botToken")
+    if isinstance(token, str):
+        token = token.strip()
+        if token:
+            return token
+    return None

--- a/tests/test_discord_token.py
+++ b/tests/test_discord_token.py
@@ -1,0 +1,63 @@
+"""Tests for the Discord token helpers."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from config import discord_token
+
+
+@pytest.fixture(autouse=True)
+def reset_token_cache() -> None:
+    """Ensure the module-level token cache is cleared between tests."""
+
+    discord_token._TOKEN = None
+    yield
+    discord_token._TOKEN = None
+
+
+def _write_secrets(path: Path, token: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"discord": {"botToken": token}}), encoding="utf-8")
+
+
+def test_get_token_from_project_root_secrets(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The project-root ``secrets.json`` is used when no token file exists."""
+
+    monkeypatch.setattr(discord_token, "TOKEN_FILE", tmp_path / "discord_token.txt")
+    monkeypatch.setattr(discord_token, "PROJECT_ROOT", tmp_path)
+
+    _write_secrets(tmp_path / "secrets.json", "abc123")
+
+    assert discord_token.get_token() == "abc123"
+
+    # Cache is honored even if the secrets file changes on disk.
+    _write_secrets(tmp_path / "secrets.json", "changed")
+    assert discord_token.get_token() == "abc123"
+
+
+def test_get_token_from_tauri_store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fallback to the Tauri store secrets when present."""
+
+    monkeypatch.setattr(discord_token, "TOKEN_FILE", tmp_path / "config" / "discord_token.txt")
+    monkeypatch.setattr(discord_token, "PROJECT_ROOT", tmp_path / "project")
+
+    data_dir = tmp_path / "appdata"
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+
+    monkeypatch.setenv("XDG_DATA_HOME", str(data_dir))
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.setenv("HOME", str(home_dir))
+
+    secrets_path = data_dir / discord_token.TAURI_IDENTIFIER / discord_token.SECRETS_FILE_NAME
+    _write_secrets(secrets_path, "store-token")
+
+    assert discord_token.get_token() == "store-token"


### PR DESCRIPTION
## Summary
- teach `config.discord_token.get_token` to read the D&D app `secrets.json` from the project root or Tauri store when the token file is absent
- keep `set_token` write protection tied to the on-disk token file so fallback tokens can still be synced
- add regression tests that exercise the secrets.json fallback paths

## Testing
- pytest tests/test_discord_token.py

------
https://chatgpt.com/codex/tasks/task_e_68d1f34567b48325bf56e5150fb650b4