### PR TITLE
Add pantheon modal creation flow

### DIFF
--- a/ui/src/api/gods.js
+++ b/ui/src/api/gods.js
@@ -1,0 +1,3 @@
+import { invoke } from '@tauri-apps/api/core';
+
+export const createGod = (name, template) => invoke('god_create', { name, template });


### PR DESCRIPTION
## Summary
- update the pantheon page to use a modal reader and controls similar to the monster interface
- add a lightbox-backed creation form that uses the new god template and helper
- introduce the API helper for creating gods

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1fe4deaf08325a8bd0b2ba1e14744