### PR TITLE
Add god creation support

### DIFF
--- a/ui/src/api/gods.js
+++ b/ui/src/api/gods.js
@@ -1,0 +1,3 @@
+import { invoke } from '@tauri-apps/api/core';
+
+export const createGod = (name, template) => invoke('god_create', { name, template });


### PR DESCRIPTION
## Summary
- add a frontend API helper that calls the new `god_create` Tauri command
- implement the `god_create` backend command to resolve the gods vault path, apply an LLM-filled template, and write a unique markdown file
- register the command so it can be invoked from the UI

## Testing
- ⚠️ `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: missing system library `glib-2.0` in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1ff1ecef083259ab239eb1cb81d6d