### PR TITLE
Add establishments browser with grouped preview

### DIFF
--- a/ui/src/api/establishments.js
+++ b/ui/src/api/establishments.js
@@ -1,0 +1,169 @@
+import { getConfig } from './config';
+import { listDir } from './dir';
+
+const DEFAULT_REGIONS = 'D:\\Documents\\DreadHaven\\10_World\\Regions';
+const MARKDOWN_RE = /\.(md|mdx|markdown)$/i;
+
+function joinSegments(base, ...segments) {
+  const baseStr = String(base || '').replace(/[\\/]+$/, '');
+  const sep = baseStr.includes('/') ? '/' : '\\';
+  let result = baseStr;
+  for (const raw of segments) {
+    const part = String(raw || '').trim();
+    if (!part) continue;
+    const clean = part.replace(/[\\/]+/g, sep);
+    result = result ? `${result}${sep}${clean}` : clean;
+  }
+  return result;
+}
+
+function normalizeSlashes(path) {
+  return String(path || '').replace(/\\/g, '/');
+}
+
+function relativePath(base, target) {
+  const baseNorm = normalizeSlashes(base).replace(/\/+$/, '');
+  const targetNorm = normalizeSlashes(target);
+  if (!baseNorm || !targetNorm.startsWith(baseNorm)) {
+    return target;
+  }
+  return targetNorm.slice(baseNorm.length).replace(/^\/+/, '');
+}
+
+async function collectFromEstablishments(basePath, estPath, groupSegments) {
+  const results = [];
+  const stack = [{ dir: estPath, inner: [] }];
+  const seen = new Set();
+  while (stack.length) {
+    const { dir, inner } = stack.pop();
+    const key = normalizeSlashes(dir);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    let entries = [];
+    try {
+      entries = await listDir(dir);
+    } catch (err) {
+      console.warn('Failed to read establishments directory', dir, err);
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry) continue;
+      const name = String(entry.name || '');
+      if (entry.is_dir) {
+        stack.push({ dir: entry.path, inner: [...inner, name] });
+        continue;
+      }
+      if (!MARKDOWN_RE.test(name)) continue;
+      const title = name.replace(/\.[^.]+$/, '');
+      const groupSegmentsCopy = [...groupSegments];
+      const categorySegments = [...inner];
+      results.push({
+        path: entry.path,
+        name,
+        title,
+        groupSegments: groupSegmentsCopy,
+        categorySegments,
+        group: groupSegmentsCopy.join(' / '),
+        region: groupSegmentsCopy[0] || '',
+        location: groupSegmentsCopy.slice(1).join(' / '),
+        category: categorySegments.join(' / '),
+        relative: relativePath(basePath, entry.path),
+        modified_ms: entry.modified_ms,
+      });
+    }
+  }
+  return results;
+}
+
+async function crawlRegions(basePath) {
+  const results = [];
+  const stack = [{ dir: basePath, segments: [] }];
+  const seen = new Set();
+  while (stack.length) {
+    const { dir, segments } = stack.pop();
+    const key = normalizeSlashes(dir);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    let entries = [];
+    try {
+      entries = await listDir(dir);
+    } catch (err) {
+      console.warn('Failed to read region directory', dir, err);
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry || !entry.is_dir) continue;
+      const name = String(entry.name || '');
+      const nextSegments = [...segments, name];
+      if (name.toLowerCase() === 'establishments') {
+        const groupSegments = segments.slice();
+        const collected = await collectFromEstablishments(basePath, entry.path, groupSegments);
+        results.push(...collected);
+      } else {
+        stack.push({ dir: entry.path, segments: nextSegments });
+      }
+    }
+  }
+  return results;
+}
+
+function sortItems(items) {
+  return items.sort((a, b) => {
+    const groupA = (a.group || '').toLowerCase();
+    const groupB = (b.group || '').toLowerCase();
+    if (groupA !== groupB) return groupA.localeCompare(groupB);
+    const titleA = (a.title || '').toLowerCase();
+    const titleB = (b.title || '').toLowerCase();
+    if (titleA !== titleB) return titleA.localeCompare(titleB);
+    return (a.path || '').localeCompare(b.path || '');
+  });
+}
+
+export async function loadEstablishments() {
+  const candidates = [];
+  try {
+    const vault = await getConfig('vaultPath');
+    if (typeof vault === 'string' && vault.trim()) {
+      candidates.push(joinSegments(vault, '10_World', 'Regions'));
+    }
+  } catch (err) {
+    console.warn('Failed to read vault path for establishments', err);
+  }
+  if (!candidates.includes(DEFAULT_REGIONS)) {
+    candidates.push(DEFAULT_REGIONS);
+  }
+
+  let lastError = null;
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    try {
+      await listDir(candidate);
+    } catch (err) {
+      lastError = err;
+      continue;
+    }
+    try {
+      const entries = await crawlRegions(candidate);
+      const unique = new Map();
+      for (const entry of entries) {
+        if (!entry?.path) continue;
+        if (!unique.has(entry.path)) {
+          unique.set(entry.path, entry);
+        }
+      }
+      return {
+        root: candidate,
+        items: sortItems(Array.from(unique.values())),
+      };
+    } catch (err) {
+      lastError = err;
+    }
+  }
+
+  if (lastError) {
+    throw lastError;
+  }
+  throw new Error('Unable to load establishments.');
+}
+
+export { MARKDOWN_RE as ESTABLISHMENT_MARKDOWN_RE };

--- a/ui/src/pages/Dnd.css
+++ b/ui/src/pages/Dnd.css
@@ -553,6 +553,115 @@
   padding: 1rem;
 }
 
+/* Establishments layout */
+.establishments-layout {
+  display: grid;
+  grid-template-columns: minmax(320px, 460px) minmax(0, 1fr);
+  gap: 1rem;
+  min-height: 60vh;
+}
+
+.establishments-list {
+  gap: 1rem;
+  max-height: 70vh;
+  overflow-y: auto;
+}
+
+.establishment-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.establishment-group-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.establishment-items {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.establishment-card {
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid #1f2937;
+  border-radius: 10px;
+  padding: 0.75rem 0.9rem;
+  text-align: left;
+  color: var(--text);
+  display: grid;
+  gap: 0.4rem;
+  cursor: pointer;
+  font: inherit;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.establishment-card:hover,
+.establishment-card:focus-visible {
+  border-color: var(--accent);
+  background: var(--card-hover-bg);
+}
+
+.establishment-card.is-active {
+  border-color: var(--accent);
+  background: var(--card-hover-bg);
+}
+
+.establishment-card-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.establishment-title {
+  font-weight: 600;
+  margin: 0;
+}
+
+.establishment-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  font-size: 0.8rem;
+  opacity: 0.8;
+}
+
+.establishment-meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.establishment-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.establishments-reader {
+  max-height: 70vh;
+  overflow-y: auto;
+}
+
+.establishment-reader-empty {
+  text-align: center;
+}
+
+@media (max-width: 960px) {
+  .establishments-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .establishments-list,
+  .establishments-reader {
+    max-height: none;
+  }
+}
+
 /* Assets explorer */
 .assets-controls {
   display: flex;

--- a/ui/src/pages/DndDmEstablishments.jsx
+++ b/ui/src/pages/DndDmEstablishments.jsx
@@ -1,24 +1,218 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import BackButton from '../components/BackButton.jsx';
+import { loadEstablishments } from '../api/establishments';
+import { readInbox } from '../api/inbox';
+import { renderMarkdown } from '../lib/markdown.jsx';
 import './Dnd.css';
 
+function formatDate(ms) {
+  try {
+    return new Date(ms).toLocaleString();
+  } catch {
+    return '';
+  }
+}
+
+function formatRelative(ms) {
+  const value = Number(ms || 0);
+  if (!Number.isFinite(value) || value <= 0) return '';
+  const now = Date.now();
+  const diff = Math.max(0, now - value);
+  const sec = Math.floor(diff / 1000);
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  if (day < 7) return `${day}d ago`;
+  const week = Math.floor(day / 7);
+  if (week < 5) return `${week}w ago`;
+  const month = Math.floor(day / 30);
+  if (month < 12) return `${month}mo ago`;
+  const year = Math.floor(day / 365);
+  return `${year}y ago`;
+}
+
 export default function DndDmEstablishments() {
+  const [items, setItems] = useState([]);
+  const [usingPath, setUsingPath] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [activePath, setActivePath] = useState('');
+  const [activeContent, setActiveContent] = useState('');
+  const [previewLoading, setPreviewLoading] = useState(false);
+
+  const fetchEstablishments = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const result = await loadEstablishments();
+      const list = Array.isArray(result?.items) ? result.items : [];
+      setUsingPath(result?.root || '');
+      setItems(list);
+      setActivePath((prev) => {
+        if (prev && list.some((entry) => entry.path === prev)) {
+          return prev;
+        }
+        return list.length ? list[0].path : '';
+      });
+    } catch (err) {
+      console.error(err);
+      setError(err?.message || String(err));
+      setItems([]);
+      setUsingPath('');
+      setActivePath('');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchEstablishments();
+  }, [fetchEstablishments]);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!activePath) {
+      setActiveContent('');
+      setPreviewLoading(false);
+      return () => {
+        cancelled = true;
+      };
+    }
+    setPreviewLoading(true);
+    setActiveContent('');
+    (async () => {
+      try {
+        const text = await readInbox(activePath);
+        if (!cancelled) {
+          setActiveContent(text || '');
+          setPreviewLoading(false);
+        }
+      } catch (err) {
+        console.error(err);
+        if (!cancelled) {
+          setActiveContent('Failed to load file.');
+          setPreviewLoading(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [activePath]);
+
+  const grouped = useMemo(() => {
+    if (!items.length) return [];
+    const map = new Map();
+    for (const item of items) {
+      const key = Array.isArray(item.groupSegments) && item.groupSegments.length
+        ? item.groupSegments.join('||')
+        : '__ungrouped__';
+      const label = (item.group && item.group.trim()) || 'Ungrouped';
+      if (!map.has(key)) {
+        map.set(key, { key, label, items: [] });
+      }
+      map.get(key).items.push(item);
+    }
+    const groups = Array.from(map.values());
+    groups.sort((a, b) => a.label.localeCompare(b.label, undefined, { sensitivity: 'base' }));
+    for (const group of groups) {
+      group.items.sort((a, b) => (a.title || '').localeCompare(b.title || '', undefined, { sensitivity: 'base' }));
+    }
+    return groups;
+  }, [items]);
+
+  const selected = useMemo(
+    () => items.find((entry) => entry.path === activePath) || null,
+    [items, activePath],
+  );
+
   return (
     <>
       <BackButton />
       <h1>Dungeons & Dragons · Establishments</h1>
-      <main className="dashboard" style={{ padding: '1rem' }}>
-        <div
-          style={{
-            background: 'var(--card-bg)',
-            color: 'var(--text)',
-            border: '1px solid var(--border)',
-            borderRadius: 8,
-            padding: '1rem',
-          }}
-        >
-          Coming soon
-        </div>
-      </main>
+      <div className="pantheon-controls">
+        <button type="button" onClick={fetchEstablishments} disabled={loading}>
+          {loading ? 'Loading…' : 'Refresh'}
+        </button>
+        {usingPath && <span className="muted">Root: {usingPath}</span>}
+        {error && <span className="error">{error}</span>}
+      </div>
+      <div className="establishments-layout">
+        <section className="dnd-surface establishments-list">
+          {grouped.length > 0 ? (
+            grouped.map((group) => (
+              <div key={group.key} className="establishment-group">
+                <h2 className="establishment-group-title">{group.label}</h2>
+                <div className="establishment-items">
+                  {group.items.map((item) => (
+                    <button
+                      type="button"
+                      key={item.path}
+                      className={`establishment-card${item.path === activePath ? ' is-active' : ''}`}
+                      onClick={() => setActivePath(item.path)}
+                      title={item.relative || item.path}
+                    >
+                      <div className="establishment-card-head">
+                        <div className="establishment-title">{item.title || item.name}</div>
+                        <time title={formatDate(item.modified_ms)}>{formatRelative(item.modified_ms)}</time>
+                      </div>
+                      {(item.relative || item.category) && (
+                        <div className="establishment-meta">
+                          {item.relative && <span className="establishment-meta-item">{item.relative}</span>}
+                          {item.category && <span className="establishment-meta-item">{item.category}</span>}
+                        </div>
+                      )}
+                      {(item.location || item.region) && (
+                        <div className="establishment-tags">
+                          {item.region && <span className="chip">Region: {item.region}</span>}
+                          {item.location && <span className="chip">Town: {item.location}</span>}
+                        </div>
+                      )}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ))
+          ) : (
+            <div className="muted">{loading ? 'Searching for establishments…' : 'No establishments found.'}</div>
+          )}
+        </section>
+        <section className="dnd-reader establishments-reader">
+          {selected ? (
+            <>
+              <header className="inbox-reader-header">
+                <h2 className="inbox-reader-title">{selected.title || selected.name}</h2>
+                <div className="inbox-reader-meta">
+                  {selected.group && <span>{selected.group}</span>}
+                  {selected.group && <span>·</span>}
+                  <time title={formatDate(selected.modified_ms)}>{formatDate(selected.modified_ms)}</time>
+                </div>
+                {(selected.category || selected.location || selected.region) && (
+                  <div className="establishment-tags">
+                    {selected.region && <span className="chip">Region: {selected.region}</span>}
+                    {selected.location && <span className="chip">Town: {selected.location}</span>}
+                    {selected.category && <span className="chip">{selected.category}</span>}
+                  </div>
+                )}
+              </header>
+              {previewLoading ? (
+                <div className="muted">Loading…</div>
+              ) : (
+                <article className="inbox-reader-body">
+                  {renderMarkdown(activeContent || '')}
+                </article>
+              )}
+            </>
+          ) : (
+            <div className="muted establishment-reader-empty">
+              {loading ? 'Loading…' : 'Select an establishment to preview.'}
+            </div>
+          )}
+        </section>
+      </div>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- add a frontend API to crawl vault regions for Establishments markdown
- replace the Establishments DM page placeholder with grouped list/preview UI
- style the list and reader to align with the other DM management panels

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d200f1d61c8325ba574755062ded4f