### PR TITLE
Sync slash commands on startup

### DIFF
--- a/discord_bot.py
+++ b/discord_bot.py
@@ -49,6 +49,17 @@ class BlossomBot(commands.Bot):
         self.tree.add_command(self.scene_group)
         self.tree.add_command(self.export_group)
 
+        guild_id = os.getenv("DISCORD_GUILD_ID")
+        if guild_id:
+            try:
+                guild = discord.Object(id=int(guild_id))
+            except ValueError:
+                guild = None
+            if guild is not None:
+                await self.tree.sync(guild=guild)
+
+        await self.tree.sync()
+
     # ------------------------------------------------------------------
     @app_commands.command(name="npc", description="Fetch NPC info or speak in their voice")
     @app_commands.describe(query="NPC alias optionally followed by ':' and dialogue")


### PR DESCRIPTION
## Summary
- sync the Discord command tree once the bot registers its slash commands
- optionally sync to a specific guild when DISCORD_GUILD_ID is set for faster testing updates

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d209c7179483258e664e027743a952