### PR TITLE
Add placeholder DnD lore subpages for stories, notes, and relations

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -55,6 +55,9 @@ import DndTasks from './pages/DndTasks.jsx';
 import DndDmWorldInventory from './pages/DndDmWorldInventory.jsx';
 import DndLoreSecrets from './pages/DndLoreSecrets.jsx';
 import DndLoreJournal from './pages/DndLoreJournal.jsx';
+import DndLoreStories from './pages/DndLoreStories.jsx';
+import DndLoreNotes from './pages/DndLoreNotes.jsx';
+import DndLorePlayerRelations from './pages/DndLorePlayerRelations.jsx';
 import { Store } from '@tauri-apps/plugin-store';
 import { useEffect, useState } from 'react';
 
@@ -174,6 +177,9 @@ export default function App() {
         <Route path="/dnd/world/factions" element={<DndWorldFactions />} />
         <Route path="/dnd/lore/secrets" element={<DndLoreSecrets />} />
         <Route path="/dnd/lore/journal" element={<DndLoreJournal />} />
+        <Route path="/dnd/lore/stories" element={<DndLoreStories />} />
+        <Route path="/dnd/lore/notes" element={<DndLoreNotes />} />
+        <Route path="/dnd/lore/relations" element={<DndLorePlayerRelations />} />
         <Route path="/dnd/tasks" element={<DndTasks />} />
         <Route path="/dnd/dungeon-master" element={<DndDungeonMaster />} />
         <Route path="/dnd/dungeon-master/events" element={<DndDmEvents />} />

--- a/ui/src/pages/DndLore.jsx
+++ b/ui/src/pages/DndLore.jsx
@@ -5,6 +5,9 @@ import './Dnd.css';
 const sections = [
   { to: '/dnd/lore/secrets', icon: 'KeyRound', title: 'Known Secrets', description: 'Discoveries, rumors, and hidden truths. (WIP)' },
   { to: '/dnd/lore/journal', icon: 'Notebook', title: 'Journal Entries', description: 'Session notes and personal journals. (WIP)' },
+  { to: '/dnd/lore/stories', icon: 'ScrollText', title: 'Stories & Legends', description: 'Chronicles of epic moments and table tales. (WIP)' },
+  { to: '/dnd/lore/notes', icon: 'StickyNote', title: 'Loose Notes', description: 'Quick thoughts, sketches, and session scraps. (WIP)' },
+  { to: '/dnd/lore/relations', icon: 'Users', title: 'Player Relations', description: 'Tracking bonds, rivalries, and party dynamics. (WIP)' },
 ];
 
 export default function DndLore() {

--- a/ui/src/pages/DndLoreNotes.jsx
+++ b/ui/src/pages/DndLoreNotes.jsx
@@ -1,0 +1,24 @@
+import BackButton from '../components/BackButton.jsx';
+import './Dnd.css';
+
+export default function DndLoreNotes() {
+  return (
+    <>
+      <BackButton />
+      <h1>Dungeons & Dragons · Loose Notes</h1>
+      <main className="dashboard" style={{ padding: '1rem' }}>
+        <div
+          style={{
+            background: 'var(--card-bg)',
+            color: 'var(--text)',
+            border: '1px solid var(--border)',
+            borderRadius: 8,
+            padding: '1rem',
+          }}
+        >
+          Under construction
+        </div>
+      </main>
+    </>
+  );
+}

--- a/ui/src/pages/DndLorePlayerRelations.jsx
+++ b/ui/src/pages/DndLorePlayerRelations.jsx
@@ -1,0 +1,24 @@
+import BackButton from '../components/BackButton.jsx';
+import './Dnd.css';
+
+export default function DndLorePlayerRelations() {
+  return (
+    <>
+      <BackButton />
+      <h1>Dungeons & Dragons · Player Relations</h1>
+      <main className="dashboard" style={{ padding: '1rem' }}>
+        <div
+          style={{
+            background: 'var(--card-bg)',
+            color: 'var(--text)',
+            border: '1px solid var(--border)',
+            borderRadius: 8,
+            padding: '1rem',
+          }}
+        >
+          Under construction
+        </div>
+      </main>
+    </>
+  );
+}

--- a/ui/src/pages/DndLoreStories.jsx
+++ b/ui/src/pages/DndLoreStories.jsx
@@ -1,0 +1,24 @@
+import BackButton from '../components/BackButton.jsx';
+import './Dnd.css';
+
+export default function DndLoreStories() {
+  return (
+    <>
+      <BackButton />
+      <h1>Dungeons & Dragons · Stories & Legends</h1>
+      <main className="dashboard" style={{ padding: '1rem' }}>
+        <div
+          style={{
+            background: 'var(--card-bg)',
+            color: 'var(--text)',
+            border: '1px solid var(--border)',
+            borderRadius: 8,
+            padding: '1rem',
+          }}
+        >
+          Under construction
+        </div>
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add lore dashboard cards for stories, notes, and player relations with descriptive copy
- create placeholder pages for the new lore sections that match the existing layout
- register routes for the new pages so the dashboard cards navigate correctly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d20b8748908325affd5430504c1d52