### PR TITLE
Add NPC voice selector and commands help to Discord page

### DIFF
--- a/ui/src/pages/Dnd.css
+++ b/ui/src/pages/Dnd.css
@@ -420,6 +420,116 @@
   min-height: 0;
 }
 
+.section-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
+
+.npc-voice-table {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.npc-voice-grid {
+  display: grid;
+  grid-template-columns: minmax(180px, 1fr) minmax(140px, 160px) minmax(220px, 1.25fr);
+  gap: 0.75rem;
+  align-items: start;
+}
+
+.npc-voice-grid + .npc-voice-grid {
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  padding-top: 0.75rem;
+}
+
+.npc-voice-grid--header {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.7;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  padding-bottom: 0.5rem;
+}
+
+.npc-voice-name {
+  font-weight: 600;
+}
+
+.npc-voice-description {
+  font-size: 0.85rem;
+  opacity: 0.75;
+  margin-top: 0.25rem;
+}
+
+.npc-voice-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.npc-voice-cell select {
+  width: 100%;
+}
+
+.npc-voice-hint-container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-height: 1rem;
+}
+
+.npc-voice-hint {
+  font-size: 0.75rem;
+  opacity: 0.75;
+}
+
+.npc-voice-hint.error {
+  color: #fecaca;
+  opacity: 1;
+}
+
+.commands-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.commands-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.commands-syntax {
+  font-size: 0.95rem;
+}
+
+.commands-description {
+  font-size: 0.85rem;
+  opacity: 0.8;
+}
+
+@media (max-width: 720px) {
+  .npc-voice-grid {
+    grid-template-columns: 1fr;
+    gap: 0.6rem;
+  }
+
+  .npc-voice-grid--header {
+    display: none;
+  }
+
+  .npc-voice-grid + .npc-voice-grid {
+    padding-top: 1rem;
+  }
+}
+
 .dnd-toolbar,
 .pantheon-controls {
   display: flex;

--- a/ui/src/pages/DndDiscord.jsx
+++ b/ui/src/pages/DndDiscord.jsx
@@ -1,93 +1,465 @@
-import BackButton from '../components/BackButton.jsx';
-import './Dnd.css';
-import { useEffect, useState } from 'react';
-import { Store } from '@tauri-apps/plugin-store';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 
+import BackButton from '../components/BackButton.jsx';
+import { listNpcs, saveNpc } from '../api/npcs.js';
+import { listPiperVoices } from '../lib/piperVoices';
+import './Dnd.css';
+
+const PROVIDERS = [
+  { value: 'piper', label: 'Piper (local)' },
+  { value: 'elevenlabs', label: 'ElevenLabs' },
+];
+
+const EMPTY_STATUS = Object.freeze({});
+
+const decodeVoiceValue = (value) => {
+  if (typeof value !== 'string') {
+    return { provider: 'piper', voice: '' };
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return { provider: 'piper', voice: '' };
+  }
+  const prefixMatch = trimmed.match(/^(elevenlabs|piper):(.+)$/i);
+  if (prefixMatch) {
+    return {
+      provider: prefixMatch[1].toLowerCase(),
+      voice: prefixMatch[2].trim(),
+    };
+  }
+  return { provider: 'piper', voice: trimmed };
+};
+
+const parseCommandSummaries = (source) => {
+  const pattern = /COMMAND_SUMMARIES\s*=\s*\[(.*?)\]/s;
+  const match = pattern.exec(source);
+  if (!match) {
+    return [];
+  }
+  const body = match[1];
+  const tuple = /\(\s*(['"])(.*?)\1\s*,\s*(['"])(.*?)\3\s*\)/gs;
+  const entries = [];
+  let m;
+  while ((m = tuple.exec(body))) {
+    entries.push({ syntax: m[2], description: m[4] });
+  }
+  return entries;
+};
+
 export default function DndDiscord() {
-  const [token, setToken] = useState('');
-  const [status, setStatus] = useState('');
+  const [npcs, setNpcs] = useState([]);
+  const [npcSelections, setNpcSelections] = useState({});
+  const [npcSaving, setNpcSaving] = useState({});
+  const [npcStatus, setNpcStatus] = useState({});
+  const statusTimeouts = useRef({});
+
+  const [voiceOptions, setVoiceOptions] = useState({ piper: [], elevenlabs: [] });
+  const [voiceLoading, setVoiceLoading] = useState({ piper: false, elevenlabs: false });
+  const [voiceErrors, setVoiceErrors] = useState({ piper: '', elevenlabs: '' });
+
+  const [npcError, setNpcError] = useState('');
+  const [loadingNpcs, setLoadingNpcs] = useState(true);
+
+  const [commands, setCommands] = useState([]);
+  const [commandsLoading, setCommandsLoading] = useState(true);
+  const [commandsError, setCommandsError] = useState('');
+
+  const computeSelections = useCallback((items, piperOpts, elevenOpts) => {
+    const piperSet = new Set(piperOpts.map((opt) => opt.value));
+    const elevenSet = new Set(elevenOpts.map((opt) => opt.value));
+    const map = {};
+    for (const npc of items) {
+      const decoded = decodeVoiceValue(npc.voice || '');
+      let provider = decoded.provider;
+      let voice = decoded.voice;
+      if (!decoded.voice) {
+        provider = 'piper';
+      } else if (!piperSet.has(decoded.voice) && elevenSet.has(decoded.voice)) {
+        provider = 'elevenlabs';
+      } else if (!piperSet.has(decoded.voice) && provider === 'piper' && elevenSet.has(decoded.voice)) {
+        provider = 'elevenlabs';
+      }
+      map[npc.name] = { provider, voice };
+    }
+    return map;
+  }, []);
+
+  const loadPiperVoices = useCallback(async () => {
+    setVoiceLoading((prev) => ({ ...prev, piper: true }));
+    try {
+      const list = await listPiperVoices();
+      const options = Array.isArray(list)
+        ? list.map((voice) => ({ value: voice.id, label: voice.label || voice.id }))
+        : [];
+      setVoiceOptions((prev) => ({ ...prev, piper: options }));
+      setVoiceErrors((prev) => ({ ...prev, piper: '' }));
+      return options;
+    } catch (err) {
+      console.error('Failed to load Piper voices', err);
+      const message = err?.message || 'Failed to load Piper voices';
+      setVoiceOptions((prev) => ({ ...prev, piper: [] }));
+      setVoiceErrors((prev) => ({ ...prev, piper: message }));
+      return [];
+    } finally {
+      setVoiceLoading((prev) => ({ ...prev, piper: false }));
+    }
+  }, []);
+
+  const loadElevenVoices = useCallback(async () => {
+    setVoiceLoading((prev) => ({ ...prev, elevenlabs: true }));
+    try {
+      const list = await invoke('list_piper_profiles');
+      const items = Array.isArray(list) ? list : [];
+      const options = items.map((item) => ({
+        value: typeof item.name === 'string' ? item.name : '',
+        label:
+          typeof item.name === 'string'
+            ? item.voice_id
+              ? `${item.name} (${item.voice_id})`
+              : item.name
+            : '',
+      })).filter((opt) => opt.value);
+      setVoiceOptions((prev) => ({ ...prev, elevenlabs: options }));
+      setVoiceErrors((prev) => ({ ...prev, elevenlabs: '' }));
+      return options;
+    } catch (err) {
+      console.error('Failed to load ElevenLabs voices', err);
+      const message = err?.message || 'Failed to load ElevenLabs voices';
+      setVoiceOptions((prev) => ({ ...prev, elevenlabs: [] }));
+      setVoiceErrors((prev) => ({ ...prev, elevenlabs: message }));
+      return [];
+    } finally {
+      setVoiceLoading((prev) => ({ ...prev, elevenlabs: false }));
+    }
+  }, []);
+
+  const ensureVoiceOptions = useCallback(
+    async (provider) => {
+      if (provider === 'piper') {
+        if (voiceOptions.piper.length) return voiceOptions.piper;
+        return loadPiperVoices();
+      }
+      if (provider === 'elevenlabs') {
+        if (voiceOptions.elevenlabs.length) return voiceOptions.elevenlabs;
+        return loadElevenVoices();
+      }
+      return [];
+    },
+    [loadElevenVoices, loadPiperVoices, voiceOptions.elevenlabs.length, voiceOptions.piper.length],
+  );
+
+  const refreshNpcList = useCallback(async () => {
+    setLoadingNpcs(true);
+    setNpcError('');
+    try {
+      const list = await listNpcs();
+      const items = Array.isArray(list) ? [...list] : [];
+      items.sort((a, b) => (a.name || '').localeCompare(b.name || '', undefined, { sensitivity: 'base' }));
+      setNpcs(items);
+      setNpcSelections(computeSelections(items, voiceOptions.piper, voiceOptions.elevenlabs));
+    } catch (err) {
+      console.error('Failed to load NPCs', err);
+      setNpcError(err?.message || 'Failed to load NPCs');
+    } finally {
+      setLoadingNpcs(false);
+    }
+  }, [computeSelections, voiceOptions.elevenlabs, voiceOptions.piper]);
+
+  const persistNpcVoice = useCallback(
+    async (npc, voice) => {
+      const trimmed = voice.trim();
+      setNpcSaving((prev) => ({ ...prev, [npc.name]: true }));
+      setNpcStatus((prev) => ({ ...prev, [npc.name]: '' }));
+      try {
+        await saveNpc({ ...npc, voice: trimmed });
+        setNpcs((prev) => prev.map((item) => (item.name === npc.name ? { ...item, voice: trimmed } : item)));
+        setNpcStatus((prev) => ({ ...prev, [npc.name]: trimmed ? 'Saved' : 'Cleared' }));
+        if (statusTimeouts.current[npc.name]) {
+          clearTimeout(statusTimeouts.current[npc.name]);
+        }
+        statusTimeouts.current[npc.name] = setTimeout(() => {
+          setNpcStatus((prev) => {
+            const next = { ...prev };
+            delete next[npc.name];
+            return next;
+          });
+        }, 2000);
+      } catch (err) {
+        console.error('Failed to save NPC voice', err);
+        setNpcStatus((prev) => ({ ...prev, [npc.name]: err?.message || 'Failed to save voice' }));
+      } finally {
+        setNpcSaving((prev) => ({ ...prev, [npc.name]: false }));
+      }
+    },
+    [],
+  );
+
+  const handleProviderChange = useCallback(
+    async (npc, provider) => {
+      const current = npcSelections[npc.name];
+      if (current?.provider === provider) {
+        return;
+      }
+      const options = await ensureVoiceOptions(provider);
+      setNpcSelections((prev) => {
+        const existing = prev[npc.name] || { voice: '' };
+        const keep = options.some((opt) => opt.value === existing.voice) ? existing.voice : '';
+        return { ...prev, [npc.name]: { provider, voice: keep } };
+      });
+    },
+    [ensureVoiceOptions, npcSelections],
+  );
+
+  const handleVoiceChange = useCallback(
+    async (npc, provider, value) => {
+      const trimmed = value.trim();
+      setNpcSelections((prev) => ({ ...prev, [npc.name]: { provider, voice: trimmed } }));
+      const existing = npcs.find((item) => item.name === npc.name);
+      if (!existing || (existing.voice || '') === trimmed) {
+        return;
+      }
+      await persistNpcVoice(existing, trimmed);
+    },
+    [npcs, persistNpcVoice],
+  );
+
+  const loadCommands = useCallback(async () => {
+    setCommandsLoading(true);
+    setCommandsError('');
+    try {
+      const candidatePaths = [];
+      try {
+        const resolved = await invoke('resolve_resource', { path: 'discord_bot.py' });
+        if (typeof resolved === 'string' && resolved) {
+          candidatePaths.push(resolved);
+        }
+      } catch (err) {
+        console.warn('resolve_resource failed for discord_bot.py', err);
+      }
+      candidatePaths.push('discord_bot.py', '../discord_bot.py');
+      let bytes = null;
+      let lastError;
+      for (const path of candidatePaths) {
+        try {
+          const result = await invoke('read_file_bytes', { path });
+          if (Array.isArray(result)) {
+            bytes = result;
+            break;
+          }
+        } catch (err) {
+          lastError = err;
+        }
+      }
+      if (!bytes) {
+        throw lastError || new Error('Unable to read discord_bot.py');
+      }
+      const text = new TextDecoder('utf-8').decode(new Uint8Array(bytes));
+      const entries = parseCommandSummaries(text);
+      setCommands(entries);
+    } catch (err) {
+      console.error('Failed to load Discord command summaries', err);
+      setCommands([]);
+      setCommandsError(err?.message || 'Failed to load command summaries');
+    } finally {
+      setCommandsLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
+    let cancelled = false;
     (async () => {
       try {
-        const store = await Store.load('secrets.json');
-        const t = await store.get('discord.botToken');
-        if (typeof t === 'string' && t) {
-          setToken(t);
-        } else {
-          // Attempt to import from a project-root secrets.json if present
-          try {
-            const abs = await invoke('resolve_resource', { path: 'secrets.json' });
-            const bytes = await invoke('read_file_bytes', { path: abs });
-            if (Array.isArray(bytes) && bytes.length) {
-              const txt = new TextDecoder('utf-8').decode(new Uint8Array(bytes));
-              const data = JSON.parse(txt);
-              const bot = data?.discord?.botToken;
-              if (typeof bot === 'string' && bot) {
-                await store.set('discord.botToken', bot);
-                await store.save();
-                setToken(bot);
-              }
-            }
-          } catch {
-            // ignore
-          }
+        const [npcList, piperOpts, elevenOpts] = await Promise.all([
+          listNpcs(),
+          loadPiperVoices(),
+          loadElevenVoices(),
+        ]);
+        if (cancelled) return;
+        const items = Array.isArray(npcList) ? [...npcList] : [];
+        items.sort((a, b) => (a.name || '').localeCompare(b.name || '', undefined, { sensitivity: 'base' }));
+        setNpcs(items);
+        setNpcSelections(computeSelections(items, piperOpts, elevenOpts));
+      } catch (err) {
+        if (!cancelled) {
+          console.error('Failed to initialise Discord NPC data', err);
+          setNpcError(err?.message || 'Failed to load NPCs');
         }
-      } catch (e) {
-        console.warn('Failed to load discord token from secrets', e);
+      } finally {
+        if (!cancelled) {
+          setLoadingNpcs(false);
+        }
       }
     })();
+    return () => {
+      cancelled = true;
+      Object.values(statusTimeouts.current).forEach((timeoutId) => clearTimeout(timeoutId));
+    };
+  }, [computeSelections, loadElevenVoices, loadPiperVoices]);
+
+  useEffect(() => {
+    loadCommands();
+  }, [loadCommands]);
+
+  const voiceHint = (provider, options, loading, error) => {
+    if (loading) {
+      return <span className="muted">Loading voices…</span>;
+    }
+    if (error) {
+      return <span className="npc-voice-hint error">{error}</span>;
+    }
+    if (!options.length) {
+      return (
+        <span className="npc-voice-hint muted">
+          {provider === 'elevenlabs'
+            ? 'Add ElevenLabs voices from Manage Voices to assign NPC dialogue.'
+            : 'No Piper voices discovered. Install voice models to use local TTS.'}
+        </span>
+      );
+    }
+    return <span className="npc-voice-hint" />;
+  };
+
+  const clearNpcStatus = useCallback(() => {
+    setNpcStatus(EMPTY_STATUS);
   }, []);
+
+  useEffect(() => {
+    if (Object.keys(npcStatus).length === 0) {
+      return undefined;
+    }
+    const id = setTimeout(clearNpcStatus, 4000);
+    return () => clearTimeout(id);
+  }, [clearNpcStatus, npcStatus]);
 
   return (
     <>
       <BackButton />
       <h1>Dungeons &amp; Dragons &middot; Discord</h1>
-      <p>Provide your Discord bot token. It is saved to the app store and can be synced to the Python service.</p>
-      <div style={{ display: 'grid', gap: '0.5rem', maxWidth: 640 }}>
-        <label style={{ display: 'grid', gap: '0.25rem' }}>
-          Bot Token
-          <input
-            type="password"
-            value={token}
-            onChange={async (e) => {
-              const v = e.target.value;
-              setToken(v);
-              try {
-                const store = await Store.load('secrets.json');
-                await store.set('discord.botToken', v);
-                await store.save();
-                setStatus('Saved');
-                setTimeout(() => setStatus(''), 1200);
-              } catch (err) {
-                console.warn('Failed to save token', err);
-              }
-            }}
-            placeholder="Paste your Discord bot token"
-          />
-        </label>
-        <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
-          <button
-            type="button"
-            onClick={async () => {
-              try {
-                await invoke('write_discord_token', { token });
-                setStatus('Synced to Python config/discord_token.txt');
-                setTimeout(() => setStatus(''), 2000);
-              } catch (e) {
-                console.error(e);
-                setStatus('Failed to sync to Python');
-                setTimeout(() => setStatus(''), 3000);
-              }
-            }}
-            disabled={!token}
-          >
-            Sync to Python
-          </button>
-          {status && <span style={{ opacity: 0.8 }}>{status}</span>}
-        </div>
-      </div>
+      <main
+        className="dashboard"
+        style={{ display: 'grid', gap: 'var(--space-lg)', marginTop: 'var(--space-lg)' }}
+      >
+        <section className="dnd-surface" aria-labelledby="npc-voice-selector-heading">
+          <div className="section-head">
+            <div>
+              <h2 id="npc-voice-selector-heading">NPC Voice Selector</h2>
+              <p className="muted" style={{ marginTop: '0.25rem' }}>
+                Map lore NPCs to speaking voices for Discord narration.
+              </p>
+            </div>
+            <div className="button-row" style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+              <button type="button" onClick={refreshNpcList} disabled={loadingNpcs}>
+                {loadingNpcs ? 'Refreshing…' : 'Reload NPCs'}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  loadPiperVoices();
+                  loadElevenVoices();
+                }}
+              >
+                Refresh Voices
+              </button>
+            </div>
+          </div>
+          {npcError && <div className="warning">{npcError}</div>}
+          {loadingNpcs ? (
+            <div className="muted">Loading NPCs…</div>
+          ) : npcs.length === 0 ? (
+            <div className="muted">No NPCs discovered yet.</div>
+          ) : (
+            <div className="npc-voice-table" role="table" aria-label="NPC voice mapping">
+              <div className="npc-voice-grid npc-voice-grid--header" role="row">
+                <div role="columnheader">NPC</div>
+                <div role="columnheader">Provider</div>
+                <div role="columnheader">Voice</div>
+              </div>
+              {npcs.map((npc) => {
+                const selection = npcSelections[npc.name] || { provider: 'piper', voice: '' };
+                const provider = selection.provider || 'piper';
+                const options = voiceOptions[provider] || [];
+                const loading = voiceLoading[provider];
+                const error = voiceErrors[provider];
+                const saving = Boolean(npcSaving[npc.name]);
+                const status = npcStatus[npc.name];
+                return (
+                  <div key={npc.name} className="npc-voice-grid" role="row">
+                    <div role="cell">
+                      <div className="npc-voice-name">{npc.name}</div>
+                      {npc.description && (
+                        <div className="npc-voice-description">{npc.description}</div>
+                      )}
+                    </div>
+                    <div role="cell" className="npc-voice-cell">
+                      <select
+                        value={provider}
+                        onChange={(e) => handleProviderChange(npc, e.target.value)}
+                        disabled={saving}
+                      >
+                        {PROVIDERS.map((item) => (
+                          <option key={item.value} value={item.value}>
+                            {item.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <div role="cell" className="npc-voice-cell">
+                      <select
+                        value={selection.voice}
+                        onChange={(e) => handleVoiceChange(npc, provider, e.target.value)}
+                        disabled={saving || loading || options.length === 0}
+                      >
+                        <option value="">Select voice</option>
+                        {options.map((opt) => (
+                          <option key={opt.value} value={opt.value}>
+                            {opt.label || opt.value}
+                          </option>
+                        ))}
+                      </select>
+                      <div className="npc-voice-hint-container">
+                        {voiceHint(provider, options, loading, error)}
+                        {status && !error && !loading && (
+                          <span className="npc-voice-hint muted">{status}</span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </section>
+
+        <section className="dnd-surface" aria-labelledby="commands-help-heading">
+          <div className="section-head">
+            <div>
+              <h2 id="commands-help-heading">Commands Help</h2>
+              <p className="muted" style={{ marginTop: '0.25rem' }}>
+                Slash commands mirrored from <code>discord_bot.py</code>.
+              </p>
+            </div>
+            <button type="button" onClick={loadCommands} disabled={commandsLoading}>
+              {commandsLoading ? 'Refreshing…' : 'Refresh'}
+            </button>
+          </div>
+          {commandsError && <div className="warning">{commandsError}</div>}
+          {commandsLoading ? (
+            <div className="muted">Loading commands…</div>
+          ) : commands.length === 0 ? (
+            <div className="muted">No slash commands detected.</div>
+          ) : (
+            <ul className="commands-list">
+              {commands.map((cmd) => (
+                <li key={cmd.syntax} className="commands-item">
+                  <code className="commands-syntax">{cmd.syntax}</code>
+                  <span className="commands-description">{cmd.description}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </main>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- replace the old Discord token form with an NPC voice selector that loads Piper and ElevenLabs voices on demand
- surface Discord slash command documentation by parsing COMMAND_SUMMARIES in the backend
- extend the D&D card styling to support the new selector and help layouts

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d20b73359c83259f4cca49642b4ad4