### PR TITLE
Add D&D world bank pages and routes

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -38,6 +38,9 @@ import AlgorithmicGenerator from './pages/Generate.jsx';
 import DndWorldPantheon from './pages/DndWorldPantheon.jsx';
 import DndWorldRegions from './pages/DndWorldRegions.jsx';
 import DndWorldFactions from './pages/DndWorldFactions.jsx';
+import DndWorldBank from './pages/DndWorldBank.jsx';
+import DndWorldBankEconomy from './pages/DndWorldBankEconomy.jsx';
+import DndWorldBankTransactions from './pages/DndWorldBankTransactions.jsx';
 import SoundLab from './pages/SoundLab.jsx';
 import Queue from './pages/Queue.jsx';
 import Tools from './pages/Tools.jsx';
@@ -172,6 +175,9 @@ export default function App() {
         <Route path="/dnd" element={<Dnd />} />
         <Route path="/dnd/inbox" element={<DndInbox />} />
         <Route path="/dnd/world" element={<DndWorld />} />
+        <Route path="/dnd/world/bank" element={<DndWorldBank />} />
+        <Route path="/dnd/world/bank/economy" element={<DndWorldBankEconomy />} />
+        <Route path="/dnd/world/bank/transactions" element={<DndWorldBankTransactions />} />
         <Route path="/dnd/world/pantheon" element={<DndWorldPantheon />} />
         <Route path="/dnd/world/regions" element={<DndWorldRegions />} />
         <Route path="/dnd/world/factions" element={<DndWorldFactions />} />

--- a/ui/src/pages/DndWorld.jsx
+++ b/ui/src/pages/DndWorld.jsx
@@ -21,6 +21,12 @@ const sections = [
     title: 'Factions',
     description: 'Organizations, alliances, and power blocs.',
   },
+  {
+    to: '/dnd/world/bank',
+    icon: 'Coins',
+    title: 'Bank',
+    description: 'Treasury planning tools and ledgers.',
+  },
 ];
 
 export default function DndWorld() {

--- a/ui/src/pages/DndWorldBank.jsx
+++ b/ui/src/pages/DndWorldBank.jsx
@@ -1,0 +1,34 @@
+import BackButton from '../components/BackButton.jsx';
+import Card from '../components/Card.jsx';
+import './Dnd.css';
+
+const bankSections = [
+  {
+    to: '/dnd/world/bank/economy',
+    icon: 'Landmark',
+    title: 'Economy',
+    description: 'Balance currencies, reserves, and realm-wide funds.',
+  },
+  {
+    to: '/dnd/world/bank/transactions',
+    icon: 'Receipt',
+    title: 'Transactions',
+    description: 'Review deposits, withdrawals, and ledger activity.',
+  },
+];
+
+export default function DndWorldBank() {
+  return (
+    <>
+      <BackButton />
+      <h1>Dungeons & Dragons · Bank</h1>
+      <main className="dashboard dnd-card-grid">
+        {bankSections.map(({ to, icon, title, description }) => (
+          <Card key={to} to={to} icon={icon} title={title}>
+            {description}
+          </Card>
+        ))}
+      </main>
+    </>
+  );
+}

--- a/ui/src/pages/DndWorldBankEconomy.jsx
+++ b/ui/src/pages/DndWorldBankEconomy.jsx
@@ -1,0 +1,24 @@
+import BackButton from '../components/BackButton.jsx';
+import './Dnd.css';
+
+export default function DndWorldBankEconomy() {
+  return (
+    <>
+      <BackButton />
+      <h1>Dungeons & Dragons · Bank Economy</h1>
+      <main className="dashboard" style={{ padding: '1rem' }}>
+        <div
+          style={{
+            background: 'var(--card-bg)',
+            color: 'var(--text)',
+            border: '1px solid var(--border)',
+            borderRadius: 8,
+            padding: '1rem',
+          }}
+        >
+          Chart the flow of wealth, set exchange rates, and plan the fiscal health of your world.
+        </div>
+      </main>
+    </>
+  );
+}

--- a/ui/src/pages/DndWorldBankTransactions.jsx
+++ b/ui/src/pages/DndWorldBankTransactions.jsx
@@ -1,0 +1,24 @@
+import BackButton from '../components/BackButton.jsx';
+import './Dnd.css';
+
+export default function DndWorldBankTransactions() {
+  return (
+    <>
+      <BackButton />
+      <h1>Dungeons & Dragons · Bank Transactions</h1>
+      <main className="dashboard" style={{ padding: '1rem' }}>
+        <div
+          style={{
+            background: 'var(--card-bg)',
+            color: 'var(--text)',
+            border: '1px solid var(--border)',
+            borderRadius: 8,
+            padding: '1rem',
+          }}
+        >
+          Track deposits, payouts, and party reimbursements to keep every gold piece accountable.
+        </div>
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add a Bank card to the D&D world overview
- create bank landing, economy, and transactions placeholder pages
- register new D&D world bank routes in the app

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d210038fe88325866054a684f62337