### PR TITLE
Add DnD tag manager view and shared tag list

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -18,6 +18,7 @@ import DndDmQuestsMain from './pages/DndDmQuestsMain.jsx';
 import DndDmQuestsPersonal from './pages/DndDmQuestsPersonal.jsx';
 import DndDmQuestsSide from './pages/DndDmQuestsSide.jsx';
 import DndDmEstablishments from './pages/DndDmEstablishments.jsx';
+import DndDmTagManager from './pages/DndDmTagManager.jsx';
 import DndVoiceLabs from './pages/DndVoiceLabs.jsx';
 import DndPiperOnly from './pages/DndPiperOnly.jsx';
 import DndElevenLabs from './pages/DndElevenLabs.jsx';
@@ -198,6 +199,7 @@ export default function App() {
         <Route path="/dnd/dungeon-master/quests/personal" element={<DndDmQuestsPersonal />} />
         <Route path="/dnd/dungeon-master/quests/side" element={<DndDmQuestsSide />} />
         <Route path="/dnd/dungeon-master/establishments" element={<DndDmEstablishments />} />
+        <Route path="/dnd/dungeon-master/tag-manager" element={<DndDmTagManager />} />
         <Route path="/dnd/dungeon-master/world-inventory" element={<DndDmWorldInventory />} />
         <Route path="/dnd/assets" element={<DndAssets />} />
         <Route path="/dnd/lore" element={<DndLore />} />

--- a/ui/src/lib/dndTags.js
+++ b/ui/src/lib/dndTags.js
@@ -1,0 +1,19 @@
+export const TAGS = [
+  'NPCs',
+  'Pantheon',
+  'Monsters',
+  'Quests',
+  'Factions',
+  'Regions',
+  'Locations',
+  'Items',
+  'Events',
+  'Lore',
+  'Rumors',
+  'Encounters',
+  'Treasures',
+  'Downtime',
+  'Worldbuilding',
+];
+
+export default TAGS;

--- a/ui/src/pages/Dnd.css
+++ b/ui/src/pages/Dnd.css
@@ -198,6 +198,50 @@
   color: var(--text);
 }
 
+.dnd-tag-manager {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  margin-top: var(--space-md);
+}
+
+.dnd-tag-manager-intro {
+  margin: 0;
+  max-width: 60ch;
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.dnd-tag-manager-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+}
+
+.dnd-tag-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(96, 165, 250, 0.35);
+  background: rgba(37, 99, 235, 0.15);
+  color: #dbeafe;
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+@media (max-width: 640px) {
+  .dnd-tag-chip {
+    white-space: normal;
+    text-align: center;
+  }
+}
+
 .dnd-chat-panel {
   background: var(--card-bg);
   color: var(--text);

--- a/ui/src/pages/DndDmTagManager.jsx
+++ b/ui/src/pages/DndDmTagManager.jsx
@@ -1,0 +1,26 @@
+import BackButton from '../components/BackButton.jsx';
+import { TAGS } from '../lib/dndTags.js';
+import './Dnd.css';
+
+export default function DndDmTagManager() {
+  return (
+    <>
+      <BackButton />
+      <main className="dnd-tag-manager">
+        <h1>Dungeons & Dragons · Tag Manager</h1>
+        <p className="dnd-tag-manager-intro">
+          Use this baseline tag set to organize notes, quests, and lore across your campaign.
+          These shared labels keep every card and file searchable while giving you a foundation
+          you can expand with custom tags as your world grows.
+        </p>
+        <div className="dnd-tag-manager-tags" role="list">
+          {TAGS.map((tag) => (
+            <span key={tag} className="dnd-tag-chip" role="listitem">
+              {tag}
+            </span>
+          ))}
+        </div>
+      </main>
+    </>
+  );
+}

--- a/ui/src/pages/DndDungeonMaster.jsx
+++ b/ui/src/pages/DndDungeonMaster.jsx
@@ -1,5 +1,6 @@
 import BackButton from '../components/BackButton.jsx';
 import Card from '../components/Card.jsx';
+import { TAGS } from '../lib/dndTags.js';
 import './Dnd.css';
 
 const sections = [
@@ -44,6 +45,12 @@ const sections = [
     icon: 'Boxes',
     title: 'World Inventory',
     description: 'Under construction',
+  },
+  {
+    to: '/dnd/dungeon-master/tag-manager',
+    icon: 'Tags',
+    title: 'Tag Manager',
+    description: TAGS.join(' · '),
   },
 ];
 


### PR DESCRIPTION
## Summary
- add a shared D&D tag list module and surface it in the Dungeon Master overview
- create a dedicated tag manager page with chips styled for responsive layouts
- register the new page route and styling so navigation and presentation stay consistent

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d213d73ef483259a4c43d5aba55cf6