### PR TITLE
Add D&D tag automation workflow

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,6 +19,8 @@ tauri-plugin-fs = { version = "2.0.0-rc.8" }
 url = "2"
 futures-sink = "0.3.31"
 tokio = { version = "1", features = ["time"] }
+serde_yaml = "0.9"
+walkdir = "2"
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/ui/src/api/tags.js
+++ b/ui/src/api/tags.js
@@ -1,0 +1,14 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+
+export const TAG_UPDATE_EVENT = "tag-update::progress";
+
+export const updateSectionTags = (section) =>
+  invoke("update_section_tags", { section });
+
+export const listenToTagUpdates = (handler) => listen(TAG_UPDATE_EVENT, handler);
+
+export default {
+  updateSectionTags,
+  listenToTagUpdates,
+};

--- a/ui/src/components/Card.jsx
+++ b/ui/src/components/Card.jsx
@@ -1,12 +1,9 @@
 import { NavLink } from 'react-router-dom';
 import Icon from './Icon.jsx';
 
-export default function Card({ to, icon, title, children }) {
-  return (
-    <NavLink
-      to={to}
-      className={({ isActive }) => `card${isActive ? ' active' : ''}`}
-    >
+export default function Card({ to, icon, title, children, onClick, disabled = false }) {
+  const content = (
+    <>
       {icon && (
         <Icon
           name={icon}
@@ -17,6 +14,30 @@ export default function Card({ to, icon, title, children }) {
       )}
       <h2>{title}</h2>
       {children && <p className="card-caption">{children}</p>}
-    </NavLink>
+    </>
+  );
+
+  if (to) {
+    return (
+      <NavLink
+        to={to}
+        className={({ isActive }) => `card${isActive ? ' active' : ''}`}
+        onClick={onClick}
+      >
+        {content}
+      </NavLink>
+    );
+  }
+
+  const className = `card${disabled ? ' is-disabled' : ''}`;
+  return (
+    <button
+      type="button"
+      className={className}
+      onClick={disabled ? undefined : onClick}
+      disabled={disabled}
+    >
+      {content}
+    </button>
   );
 }

--- a/ui/src/lib/dndTagSections.json
+++ b/ui/src/lib/dndTagSections.json
@@ -1,0 +1,114 @@
+[
+  {
+    "id": "npcs",
+    "label": "NPCs",
+    "vaultSubfolder": "20_DM/NPC",
+    "prompt": "Focus on NPC roles, factions, locations, species, and any story hooks mentioned in the profile.",
+    "tags": [
+      "npc",
+      "faction",
+      "region",
+      "location",
+      "quest-hook",
+      "rumor",
+      "ally",
+      "enemy"
+    ],
+    "fallbacks": [
+      "D\\\\Documents\\\\DreadHaven\\\\20_DM\\\\NPC"
+    ]
+  },
+  {
+    "id": "pantheon",
+    "label": "Pantheon",
+    "vaultSubfolder": "10_World/Gods of the Realm",
+    "prompt": "Highlight divine portfolios, domains, worshippers, rivalries, and sacred sites tied to the deity.",
+    "tags": [
+      "pantheon",
+      "deity",
+      "domain",
+      "religion",
+      "temple",
+      "myth",
+      "worship"
+    ],
+    "fallbacks": [
+      "D\\\\Documents\\\\DreadHaven\\\\10_World\\\\Gods of the Realm"
+    ]
+  },
+  {
+    "id": "monsters",
+    "label": "Monsters",
+    "vaultSubfolder": "20_DM/Monsters",
+    "prompt": "Tag statblocks with creature type, habitat, threat level, tactics, and any signature abilities or loot.",
+    "tags": [
+      "monster",
+      "threat",
+      "encounter",
+      "environment",
+      "loot",
+      "hazard",
+      "legendary"
+    ],
+    "fallbacks": [
+      "D\\\\Documents\\\\DreadHaven\\\\20_DM\\\\Monsters"
+    ]
+  },
+  {
+    "id": "quests",
+    "label": "Quests",
+    "vaultSubfolder": "20_DM/Quests",
+    "prompt": "Emphasize quest status, involved factions, key NPCs, locations, stakes, and promised rewards.",
+    "tags": [
+      "quest",
+      "faction",
+      "region",
+      "reward",
+      "status",
+      "npc",
+      "downtime"
+    ],
+    "fallbacks": [
+      "D\\\\Documents\\\\DreadHaven\\\\20_DM\\\\Quests"
+    ]
+  },
+  {
+    "id": "establishments",
+    "label": "Establishments",
+    "vaultSubfolder": "10_World/Regions",
+    "prompt": "Surface the settlement, services offered, notable staff or owners, clientele, and adventure hooks.",
+    "tags": [
+      "establishment",
+      "shop",
+      "tavern",
+      "region",
+      "location",
+      "npc",
+      "service"
+    ],
+    "includes": [
+      "Establishments"
+    ],
+    "fallbacks": [
+      "D\\\\Documents\\\\DreadHaven\\\\10_World\\\\Regions"
+    ]
+  },
+  {
+    "id": "world-inventory",
+    "label": "World Inventory",
+    "vaultSubfolder": "20_DM/World Inventory",
+    "prompt": "Call out item types, rarity, origin, storage location, owners, and how the party might use the resource.",
+    "tags": [
+      "inventory",
+      "item",
+      "region",
+      "rarity",
+      "crafting",
+      "faction",
+      "loot"
+    ],
+    "fallbacks": [
+      "D\\\\Documents\\\\DreadHaven\\\\20_DM\\\\World Inventory"
+    ]
+  }
+]

--- a/ui/src/lib/dndTags.js
+++ b/ui/src/lib/dndTags.js
@@ -1,3 +1,12 @@
+import sections from './dndTagSections.json';
+
+export const TAG_SECTIONS = sections.map((section) => ({
+  ...section,
+  tags: Array.isArray(section.tags) ? [...section.tags] : [],
+  includes: Array.isArray(section.includes) ? [...section.includes] : [],
+  fallbacks: Array.isArray(section.fallbacks) ? [...section.fallbacks] : [],
+}));
+
 export const TAGS = [
   'NPCs',
   'Pantheon',
@@ -15,5 +24,9 @@ export const TAGS = [
   'Downtime',
   'Worldbuilding',
 ];
+
+export const CANONICAL_TAGS = Array.from(
+  new Set(TAG_SECTIONS.flatMap((section) => section.tags || [])),
+).sort();
 
 export default TAGS;

--- a/ui/src/pages/Dnd.css
+++ b/ui/src/pages/Dnd.css
@@ -11,6 +11,336 @@
   margin: 0;
 }
 
+.card.is-disabled,
+.card:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  pointer-events: none;
+  transform: none;
+  box-shadow: none;
+}
+
+.card.is-disabled:hover,
+.card.is-disabled:focus,
+.card:disabled:hover,
+.card:disabled:focus {
+  background: var(--card-bg);
+}
+
+.dnd-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: var(--space-xl);
+  background: rgba(15, 23, 42, 0.75);
+  backdrop-filter: blur(10px);
+  overflow-y: auto;
+}
+
+.dnd-modal {
+  width: min(960px, 100%);
+  max-height: 90vh;
+  background: var(--card-bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.45);
+  display: flex;
+  flex-direction: column;
+}
+
+.dnd-modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-md);
+  padding: var(--space-lg) var(--space-xl) var(--space-md);
+}
+
+.dnd-modal-header h2 {
+  margin: 0;
+}
+
+.dnd-modal-header button {
+  align-self: flex-start;
+}
+
+.dnd-modal-subtitle {
+  margin: 0.25rem 0 0;
+  color: rgba(226, 232, 240, 0.75);
+  line-height: 1.5;
+  max-width: 60ch;
+}
+
+.dnd-modal-body {
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+  gap: var(--space-xl);
+  padding: 0 var(--space-xl) var(--space-xl);
+  overflow-y: auto;
+}
+
+.dnd-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-md);
+  padding: var(--space-md) var(--space-xl) var(--space-lg);
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.dnd-modal-error {
+  margin: 0 var(--space-xl);
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: rgba(239, 68, 68, 0.18);
+  border: 1px solid rgba(248, 113, 113, 0.45);
+  color: #fecaca;
+}
+
+.dnd-section-picker h3,
+.dnd-task-progress h3 {
+  margin: 0 0 0.75rem;
+}
+
+.dnd-section-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.dnd-section-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 12px;
+  padding: 0.75rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.dnd-section-option.is-selected {
+  border-color: rgba(96, 165, 250, 0.5);
+  background: rgba(37, 99, 235, 0.12);
+}
+
+.dnd-section-option input {
+  margin-top: 0.35rem;
+}
+
+.dnd-section-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.dnd-section-head {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.dnd-section-title {
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.dnd-section-path {
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.9);
+  word-break: break-word;
+}
+
+.dnd-section-prompt {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.dnd-section-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.dnd-section-option .dnd-tag-chip {
+  font-size: 0.75rem;
+  padding: 0.25rem 0.6rem;
+}
+
+.dnd-task-progress {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  min-height: 0;
+}
+
+.dnd-progress-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-md);
+}
+
+.dnd-progress-active {
+  font-size: 0.9rem;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.dnd-progress-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: 320px;
+  overflow-y: auto;
+  padding-right: 0.3rem;
+}
+
+.dnd-progress-item {
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  display: grid;
+  gap: 0.45rem;
+  font-size: 0.95rem;
+}
+
+.dnd-progress-item.status-updated {
+  border-color: rgba(74, 222, 128, 0.45);
+}
+
+.dnd-progress-item.status-error {
+  border-color: rgba(248, 113, 113, 0.5);
+  background: rgba(239, 68, 68, 0.12);
+}
+
+.dnd-progress-item.status-finished {
+  border-color: rgba(129, 140, 248, 0.5);
+}
+
+.dnd-progress-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.dnd-progress-status {
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.dnd-progress-count {
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.dnd-progress-path {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.8rem;
+  color: rgba(226, 232, 240, 0.85);
+  word-break: break-word;
+}
+
+.dnd-progress-message {
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.dnd-progress-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.dnd-progress-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.dnd-progress-summaries {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.dnd-summary-card {
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.dnd-summary-card h4 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.dnd-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.dnd-summary-duration {
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+@media (max-width: 900px) {
+  .dnd-modal-body {
+    grid-template-columns: 1fr;
+    gap: var(--space-lg);
+  }
+
+  .dnd-progress-list {
+    max-height: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .dnd-modal-backdrop {
+    padding: var(--space-md);
+  }
+
+  .dnd-modal {
+    max-height: none;
+  }
+
+  .dnd-modal-header,
+  .dnd-modal-actions {
+    padding-left: var(--space-md);
+    padding-right: var(--space-md);
+  }
+
+  .dnd-modal-body {
+    padding: 0 var(--space-md) var(--space-md);
+  }
+}
+
 .dnd-lore {
   display: flex;
   flex-direction: column;

--- a/ui/src/pages/DndTasks.jsx
+++ b/ui/src/pages/DndTasks.jsx
@@ -1,24 +1,350 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
 import BackButton from '../components/BackButton.jsx';
+import Card from '../components/Card.jsx';
+import { listenToTagUpdates, updateSectionTags } from '../api/tags.js';
+import { TAG_SECTIONS } from '../lib/dndTags.js';
 import './Dnd.css';
 
+const STATUS_LABELS = {
+  started: 'Started',
+  inspecting: 'Inspecting',
+  updated: 'Updated',
+  skipped: 'Skipped',
+  finished: 'Finished',
+  error: 'Error',
+};
+
+function normalizeTags(input) {
+  if (!Array.isArray(input)) return [];
+  const seen = new Set();
+  const out = [];
+  for (const raw of input) {
+    const tag = String(raw || '').trim();
+    if (!tag || seen.has(tag)) continue;
+    seen.add(tag);
+    out.push(tag);
+  }
+  return out;
+}
+
+function selectDefaultSections() {
+  if (!TAG_SECTIONS.length) return [];
+  return [TAG_SECTIONS[0].id];
+}
+
 export default function DndTasks() {
+  const [modalOpen, setModalOpen] = useState(false);
+  const [selected, setSelected] = useState(selectDefaultSections);
+  const [running, setRunning] = useState(false);
+  const [activeSectionId, setActiveSectionId] = useState('');
+  const [error, setError] = useState('');
+  const [progress, setProgress] = useState([]);
+  const [progressRunId, setProgressRunId] = useState(0);
+  const [summaries, setSummaries] = useState({});
+  const runIdRef = useRef(0);
+
+  const sectionOrder = useMemo(() => TAG_SECTIONS.map((section) => section.id), []);
+  const orderMap = useMemo(() => {
+    const map = new Map();
+    sectionOrder.forEach((id, index) => map.set(id, index));
+    return map;
+  }, [sectionOrder]);
+
+  const sectionMap = useMemo(() => {
+    const map = new Map();
+    for (const section of TAG_SECTIONS) {
+      map.set(section.id, section);
+    }
+    return map;
+  }, []);
+
+  const selectedSet = useMemo(() => new Set(selected), [selected]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let unlisten = null;
+    listenToTagUpdates((event) => {
+      const payload = event?.payload || {};
+      const tags = normalizeTags(payload.tags);
+      const relPath = payload.rel_path || payload.relPath || payload.path || '';
+      const item = {
+        id: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
+        runId: runIdRef.current,
+        section: typeof payload.section === 'string' ? payload.section : '',
+        label: typeof payload.label === 'string' ? payload.label : '',
+        status: typeof payload.status === 'string' ? payload.status : 'info',
+        message: payload.message ? String(payload.message) : '',
+        path: relPath ? String(relPath) : '',
+        tags,
+        index: Number.isFinite(payload.index) ? Number(payload.index) : null,
+        total: Number.isFinite(payload.total) ? Number(payload.total) : null,
+        updated: Number.isFinite(payload.updated) ? Number(payload.updated) : null,
+        skipped: Number.isFinite(payload.skipped) ? Number(payload.skipped) : null,
+        failed: Number.isFinite(payload.failed) ? Number(payload.failed) : null,
+        timestamp: Date.now(),
+      };
+      setProgress((prev) => {
+        const next = prev.concat(item);
+        const limit = 400;
+        return next.length > limit ? next.slice(next.length - limit) : next;
+      });
+    })
+      .then((fn) => {
+        if (cancelled) {
+          fn();
+        } else {
+          unlisten = fn;
+        }
+      })
+      .catch((err) => {
+        console.error('Failed to subscribe to tag updates', err);
+      });
+    return () => {
+      cancelled = true;
+      if (unlisten) {
+        unlisten();
+      }
+    };
+  }, []);
+
+  const visibleLogs = useMemo(() => {
+    if (!progressRunId) return progress;
+    return progress.filter((entry) => entry.runId === progressRunId);
+  }, [progress, progressRunId]);
+
+  const toggleSection = (id) => {
+    if (running) return;
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      const ordered = Array.from(next);
+      ordered.sort((a, b) => (orderMap.get(a) ?? 0) - (orderMap.get(b) ?? 0));
+      return ordered;
+    });
+  };
+
+  const handleClose = () => {
+    if (running) return;
+    setModalOpen(false);
+    setError('');
+  };
+
+  const handleBackdropClick = (event) => {
+    if (event.target === event.currentTarget) {
+      handleClose();
+    }
+  };
+
+  const handleStart = async () => {
+    if (!selected.length || running) return;
+    setModalOpen(true);
+    setError('');
+    setSummaries({});
+    const runId = runIdRef.current + 1;
+    runIdRef.current = runId;
+    setProgressRunId(runId);
+    setProgress([]);
+    setRunning(true);
+
+    try {
+      for (const sectionId of selected) {
+        setActiveSectionId(sectionId);
+        const summary = await updateSectionTags(sectionId);
+        if (summary && summary.section) {
+          setSummaries((prev) => ({ ...prev, [summary.section]: summary }));
+        }
+      }
+    } catch (err) {
+      console.error(err);
+      setError(err?.message || String(err));
+    } finally {
+      setRunning(false);
+      setActiveSectionId('');
+    }
+  };
+
+  const activeSectionLabel = activeSectionId
+    ? sectionMap.get(activeSectionId)?.label || activeSectionId
+    : '';
+
+  const summaryItems = useMemo(() => {
+    const items = [];
+    for (const section of TAG_SECTIONS) {
+      if (summaries[section.id]) {
+        items.push({ ...summaries[section.id], label: section.label });
+      }
+    }
+    return items;
+  }, [summaries]);
+
   return (
     <>
       <BackButton />
       <h1>Dungeons &amp; Dragons · Tasks</h1>
-      <main className="dashboard" style={{ padding: '1rem' }}>
-        <div
-          style={{
-            background: 'var(--card-bg)',
-            color: 'var(--text)',
-            border: '1px solid var(--border)',
-            borderRadius: 8,
-            padding: '1rem',
-          }}
-        >
-          Under construction
-        </div>
+      <main className="dashboard dnd-card-grid">
+        <Card icon="Tags" title="Update Tags" onClick={() => setModalOpen(true)}>
+          Refresh YAML tags across campaign notes using the shared taxonomies.
+        </Card>
       </main>
+      {modalOpen && (
+        <div
+          className="dnd-modal-backdrop"
+          role="presentation"
+          onClick={handleBackdropClick}
+        >
+          <div
+            className="dnd-modal"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="dnd-tag-modal-title"
+          >
+            <header className="dnd-modal-header">
+              <div>
+                <h2 id="dnd-tag-modal-title">Update Vault Tags</h2>
+                <p className="dnd-modal-subtitle">
+                  Pick one or more sections to process. Notes are updated sequentially so new runs
+                  wait for the current pass to finish.
+                </p>
+              </div>
+              <button type="button" onClick={handleClose} disabled={running}>
+                Close
+              </button>
+            </header>
+            <div className="dnd-modal-body">
+              <section className="dnd-section-picker">
+                <h3>Select sections</h3>
+                <ul className="dnd-section-list">
+                  {TAG_SECTIONS.map((section) => {
+                    const checked = selectedSet.has(section.id);
+                    return (
+                      <li key={section.id}>
+                        <label
+                          className={`dnd-section-option${checked ? ' is-selected' : ''}`}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            onChange={() => toggleSection(section.id)}
+                            disabled={running}
+                          />
+                          <div className="dnd-section-meta">
+                            <div className="dnd-section-head">
+                              <span className="dnd-section-title">{section.label}</span>
+                              <span className="dnd-section-path">{section.vaultSubfolder}</span>
+                            </div>
+                            <p className="dnd-section-prompt">{section.prompt}</p>
+                            {section.tags?.length > 0 && (
+                              <div className="dnd-section-tags">
+                                {section.tags.map((tag) => (
+                                  <span key={tag} className="dnd-tag-chip">
+                                    {tag}
+                                  </span>
+                                ))}
+                              </div>
+                            )}
+                          </div>
+                        </label>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </section>
+              <section className="dnd-task-progress" aria-live="polite">
+                <div className="dnd-progress-head">
+                  <h3>Progress</h3>
+                  {running && activeSectionLabel && (
+                    <span className="dnd-progress-active">Running: {activeSectionLabel}</span>
+                  )}
+                </div>
+                <ol className="dnd-progress-list">
+                  {visibleLogs.length > 0 ? (
+                    visibleLogs.map((entry) => {
+                      const statusLabel = STATUS_LABELS[entry.status] || entry.status;
+                      const key = entry.id;
+                      return (
+                        <li
+                          key={key}
+                          className={`dnd-progress-item status-${entry.status}`}
+                        >
+                          <div className="dnd-progress-row">
+                            <span className="dnd-progress-status">{statusLabel}</span>
+                            {entry.index != null && entry.total != null && (
+                              <span className="dnd-progress-count">
+                                {entry.index + 1} / {entry.total}
+                              </span>
+                            )}
+                          </div>
+                          {entry.path && (
+                            <div className="dnd-progress-path">{entry.path}</div>
+                          )}
+                          {entry.message && (
+                            <div className="dnd-progress-message">{entry.message}</div>
+                          )}
+                          {entry.tags && entry.tags.length > 0 && (
+                            <div className="dnd-progress-tags">
+                              {entry.tags.map((tag) => (
+                                <span key={tag} className="dnd-tag-chip">
+                                  {tag}
+                                </span>
+                              ))}
+                            </div>
+                          )}
+                          {entry.status === 'finished' && (
+                            <div className="dnd-progress-summary">
+                              <span>Updated: {entry.updated ?? 0}</span>
+                              <span>Skipped: {entry.skipped ?? 0}</span>
+                              <span>Failed: {entry.failed ?? 0}</span>
+                            </div>
+                          )}
+                        </li>
+                      );
+                    })
+                  ) : (
+                    <li className="dnd-progress-item muted">Waiting for the run to start…</li>
+                  )}
+                </ol>
+                {summaryItems.length > 0 && (
+                  <div className="dnd-progress-summaries">
+                    {summaryItems.map((item) => (
+                      <div key={item.section} className="dnd-summary-card">
+                        <h4>{item.label}</h4>
+                        <div className="dnd-summary-grid">
+                          <span>Total: {item.total_notes ?? item.total ?? 0}</span>
+                          <span>Updated: {item.updated_notes ?? item.updated ?? 0}</span>
+                          <span>Skipped: {item.skipped_notes ?? item.skipped ?? 0}</span>
+                          <span>Failed: {item.failed_notes ?? item.failed ?? 0}</span>
+                        </div>
+                        {item.duration_ms != null && (
+                          <span className="dnd-summary-duration">
+                            Duration: {(item.duration_ms / 1000).toFixed(1)}s
+                          </span>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </section>
+            </div>
+            {error && <div className="dnd-modal-error">{error}</div>}
+            <footer className="dnd-modal-actions">
+              <button
+                type="button"
+                onClick={handleStart}
+                disabled={running || !selected.length}
+              >
+                {running ? 'Updating…' : 'Run update'}
+              </button>
+              <button type="button" onClick={handleClose} disabled={running}>
+                Cancel
+              </button>
+            </footer>
+          </div>
+        </div>
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- allow the Card component to render button-style cards with optional onClick and disabled support
- add shared D&D tag section metadata, a UI workflow to launch updates, and the necessary styling and API hooks
- implement a Tauri command that walks section folders, refreshes frontmatter tags via the LLM, and streams structured progress events

## Testing
- npm run build
- cargo check --manifest-path src-tauri/Cargo.toml *(fails: crates.io index blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68d2152ba880832590e1174556ab8f2e