### PR TITLE
Add LLM-backed spell creation flow

### DIFF
--- a/ui/src/api/spells.js
+++ b/ui/src/api/spells.js
@@ -1,3 +1,9 @@
 import { invoke } from '@tauri-apps/api/core';
 
-export const createSpell = (name) => invoke('spell_create', { name });
+export const createSpell = (name, template) => {
+  const payload = { name };
+  if (typeof template === 'string' && template.trim()) {
+    payload.template = template;
+  }
+  return invoke('spell_create', payload);
+};


### PR DESCRIPTION
## Summary
- add a spell_create Tauri command that mirrors the monster flow, resolves templates, and writes into the Spell Book
- allow the UI to invoke the new command via a createSpell helper with optional template overrides

## Testing
- cargo fmt --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path src-tauri/Cargo.toml *(fails: Unable to download crates index due to 403 CONNECT tunnel error)*

------
https://chatgpt.com/codex/tasks/task_e_68d22359fb108325afbf83402761dc6b