### PR TITLE
Link NPC shopkeepers to establishments

### DIFF
--- a/ui/src/api/npcs.js
+++ b/ui/src/api/npcs.js
@@ -3,6 +3,21 @@ import { invoke } from "@tauri-apps/api/core";
 export const listNpcs = () => invoke("npc_list");
 export const saveNpc = (npc) => invoke("npc_save", { npc });
 export const deleteNpc = (name) => invoke("npc_delete", { name });
-export const createNpc = (name, region, purpose, template, randomName) =>
-  invoke("npc_create", { name, region, purpose, template, random_name: !!randomName });
+export const createNpc = (
+  name,
+  region,
+  purpose,
+  template,
+  randomName,
+  establishmentPath,
+  establishmentName,
+) => invoke("npc_create", {
+  name,
+  region,
+  purpose,
+  template,
+  random_name: !!randomName,
+  establishment_path: establishmentPath ?? null,
+  establishment_name: establishmentName ?? null,
+});
 


### PR DESCRIPTION
## Summary
- cache establishment metadata when the NPC creation modal opens and expose a selector so shopkeepers can be linked to an existing storefront
- extend the NPC creation API/command to accept an establishment path/name and persist that data in the generated markdown frontmatter
- add unit coverage for the frontmatter helper that injects establishment metadata

## Testing
- npm --prefix ui test
- cargo test --manifest-path src-tauri/Cargo.toml *(fails: unable to download crates due to CONNECT 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d22315b3048325a4413beba2e51b0b