### PR TITLE
Add Clone derive to TagUpdateEvent

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -428,7 +428,7 @@ struct TagUpdateSummary {
     duration_ms: u64,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 struct TagUpdateEvent {
     section: String,
     label: String,


### PR DESCRIPTION
## Summary
- derive Clone for TagUpdateEvent so it can be cloned when emitting events

## Testing
- cargo check -p blossom_tauri (fails: network error downloading crates index)


------
https://chatgpt.com/codex/tasks/task_e_68d2a1e159e48325b27cebba3e39d359