### PR TITLE
Add D&D player sheet editor and player_create command

### DIFF
--- a/ui/src/api/players.js
+++ b/ui/src/api/players.js
@@ -1,0 +1,20 @@
+import { invoke } from '@tauri-apps/api/core';
+
+export const createPlayer = ({
+  name,
+  markdown,
+  sheet,
+  template,
+  directory,
+  usePrefill,
+  prefillPrompt,
+}) =>
+  invoke('player_create', {
+    name,
+    markdown,
+    sheet,
+    template,
+    directory,
+    usePrefill,
+    prefillPrompt,
+  });

--- a/ui/src/components/AbilityScoreInputs.jsx
+++ b/ui/src/components/AbilityScoreInputs.jsx
@@ -1,0 +1,28 @@
+import { ABILITY_SCORES, formatModifier } from '../lib/playerSheet.js';
+
+export default function AbilityScoreInputs({ scores, modifiers, onChange }) {
+  return (
+    <div className="dnd-ability-grid">
+      {ABILITY_SCORES.map(({ key, label }) => {
+        const scoreValue = scores?.[key];
+        const displayValue = scoreValue === undefined || scoreValue === null ? '' : scoreValue;
+        const modifier = modifiers?.[key] ?? 0;
+        return (
+          <div key={key} className="dnd-ability-card">
+            <span className="dnd-ability-label">{label}</span>
+            <input
+              className="dnd-ability-score"
+              type="number"
+              min="1"
+              max="30"
+              inputMode="numeric"
+              value={displayValue}
+              onChange={(event) => onChange?.(key, event.target.value)}
+            />
+            <span className="dnd-ability-modifier">{formatModifier(modifier)}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/ui/src/components/AttacksEditor.jsx
+++ b/ui/src/components/AttacksEditor.jsx
@@ -1,0 +1,58 @@
+const EMPTY_ATTACK = { name: '', bonus: '', damage: '', notes: '' };
+
+export default function AttacksEditor({ attacks = [], onChange, onAdd, onRemove }) {
+  const handleChange = (index, field, value) => {
+    const next = attacks.map((attack, idx) =>
+      idx === index ? { ...attack, [field]: value } : attack
+    );
+    onChange?.(next);
+  };
+
+  return (
+    <div className="dnd-attacks-editor">
+      {attacks.map((attack, index) => (
+        <div key={index} className="dnd-attack-row">
+          <input
+            type="text"
+            value={attack.name}
+            placeholder="Attack or spell"
+            onChange={(event) => handleChange(index, 'name', event.target.value)}
+          />
+          <input
+            type="text"
+            value={attack.bonus}
+            placeholder="Bonus"
+            onChange={(event) => handleChange(index, 'bonus', event.target.value)}
+          />
+          <input
+            type="text"
+            value={attack.damage}
+            placeholder="Damage / Type"
+            onChange={(event) => handleChange(index, 'damage', event.target.value)}
+          />
+          <input
+            type="text"
+            value={attack.notes}
+            placeholder="Notes"
+            onChange={(event) => handleChange(index, 'notes', event.target.value)}
+          />
+          <button
+            type="button"
+            className="dnd-attack-remove"
+            onClick={() => onRemove?.(index)}
+            aria-label={`Remove attack ${attack.name || index + 1}`}
+          >
+            Remove
+          </button>
+        </div>
+      ))}
+      <button
+        type="button"
+        className="dnd-attack-add"
+        onClick={() => onAdd?.(EMPTY_ATTACK)}
+      >
+        Add attack
+      </button>
+    </div>
+  );
+}

--- a/ui/src/components/CharacterSheetSection.jsx
+++ b/ui/src/components/CharacterSheetSection.jsx
@@ -1,0 +1,23 @@
+export default function CharacterSheetSection({
+  title,
+  description,
+  actions,
+  children,
+  className = '',
+  id,
+}) {
+  return (
+    <section className={`dnd-sheet-section ${className}`.trim()} id={id}>
+      <header className="dnd-sheet-section__header">
+        <div className="dnd-sheet-section__headings">
+          <h2>{title}</h2>
+          {description ? (
+            <p className="dnd-sheet-section__description">{description}</p>
+          ) : null}
+        </div>
+        {actions ? <div className="dnd-sheet-section__actions">{actions}</div> : null}
+      </header>
+      <div className="dnd-sheet-section__body">{children}</div>
+    </section>
+  );
+}

--- a/ui/src/components/CurrencyInputs.jsx
+++ b/ui/src/components/CurrencyInputs.jsx
@@ -1,0 +1,28 @@
+const CURRENCIES = [
+  { key: 'cp', label: 'CP' },
+  { key: 'sp', label: 'SP' },
+  { key: 'ep', label: 'EP' },
+  { key: 'gp', label: 'GP' },
+  { key: 'pp', label: 'PP' },
+];
+
+export default function CurrencyInputs({ values, onChange }) {
+  return (
+    <div className="dnd-currency-grid">
+      {CURRENCIES.map(({ key, label }) => {
+        const value = values?.[key] ?? '';
+        return (
+          <label key={key} className="dnd-currency-field">
+            <span>{label}</span>
+            <input
+              type="text"
+              inputMode="numeric"
+              value={value}
+              onChange={(event) => onChange?.(key, event.target.value)}
+            />
+          </label>
+        );
+      })}
+    </div>
+  );
+}

--- a/ui/src/components/DeathSavesTracker.jsx
+++ b/ui/src/components/DeathSavesTracker.jsx
@@ -1,0 +1,44 @@
+function buildTrack(count) {
+  return Array.from({ length: 3 }, (_, index) => index < count);
+}
+
+export default function DeathSavesTracker({ successes = 0, failures = 0, onChange }) {
+  const handleToggle = (type, index) => {
+    const current = type === 'success' ? successes : failures;
+    const next = current === index + 1 ? index : index + 1;
+    onChange?.(type, next);
+  };
+
+  return (
+    <div className="dnd-death-saves">
+      <div className="dnd-death-saves-column">
+        <span className="dnd-death-saves-label">Successes</span>
+        <div className="dnd-death-saves-track">
+          {buildTrack(successes).map((filled, index) => (
+            <button
+              key={`success-${index}`}
+              type="button"
+              className={`dnd-death-saves-dot ${filled ? 'is-filled' : ''}`}
+              onClick={() => handleToggle('success', index)}
+              aria-label={`Toggle success ${index + 1}`}
+            />
+          ))}
+        </div>
+      </div>
+      <div className="dnd-death-saves-column">
+        <span className="dnd-death-saves-label">Failures</span>
+        <div className="dnd-death-saves-track">
+          {buildTrack(failures).map((filled, index) => (
+            <button
+              key={`failure-${index}`}
+              type="button"
+              className={`dnd-death-saves-dot ${filled ? 'is-filled' : ''}`}
+              onClick={() => handleToggle('failure', index)}
+              aria-label={`Toggle failure ${index + 1}`}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/SavingThrowList.jsx
+++ b/ui/src/components/SavingThrowList.jsx
@@ -1,0 +1,45 @@
+import { ABILITY_SCORES, formatModifier } from '../lib/playerSheet.js';
+
+export default function SavingThrowList({
+  savingThrows,
+  abilityModifiers,
+  proficiencyBonus,
+  onToggle,
+  onMiscChange,
+}) {
+  return (
+    <div className="dnd-saving-throws">
+      {ABILITY_SCORES.map(({ key, label }) => {
+        const item = savingThrows?.[key] || {};
+        const miscValue = item.misc ?? '';
+        const total = item.total ?? abilityModifiers?.[key] ?? 0;
+        return (
+          <div key={key} className="dnd-saving-throw-row">
+            <label className="dnd-saving-throw-main">
+              <input
+                type="checkbox"
+                checked={Boolean(item.proficient)}
+                onChange={() => onToggle?.(key)}
+              />
+              <span className="dnd-saving-throw-label">{label}</span>
+            </label>
+            <div className="dnd-saving-throw-values" aria-label={`${label} save value`}>
+              <span className="dnd-saving-throw-total">{formatModifier(total)}</span>
+              <span className="dnd-saving-throw-mod">MOD {formatModifier(abilityModifiers?.[key] ?? 0)}</span>
+              <span className="dnd-saving-throw-prof">PB {formatModifier(item.proficient ? proficiencyBonus : 0)}</span>
+            </div>
+            <label className="dnd-saving-throw-misc">
+              <span>Misc</span>
+              <input
+                type="number"
+                inputMode="numeric"
+                value={miscValue}
+                onChange={(event) => onMiscChange?.(key, event.target.value)}
+              />
+            </label>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/ui/src/components/SkillList.jsx
+++ b/ui/src/components/SkillList.jsx
@@ -1,0 +1,70 @@
+import { SKILL_LIST, formatModifier } from '../lib/playerSheet.js';
+
+export default function SkillList({
+  skills,
+  abilityModifiers,
+  onToggleProficiency,
+  onToggleExpertise,
+  onMiscChange,
+}) {
+  return (
+    <table className="dnd-skill-table">
+      <thead>
+        <tr>
+          <th scope="col">Skill</th>
+          <th scope="col">Ability</th>
+          <th scope="col">Total</th>
+          <th scope="col">Prof.</th>
+          <th scope="col">Expertise</th>
+          <th scope="col">Misc</th>
+        </tr>
+      </thead>
+      <tbody>
+        {SKILL_LIST.map(({ key, label, ability }) => {
+          const item = skills?.[key] || {};
+          const miscValue = item.misc ?? '';
+          const total = item.total ?? abilityModifiers?.[ability] ?? 0;
+          return (
+            <tr key={key}>
+              <td>
+                <label className="dnd-skill-label">
+                  <input
+                    type="checkbox"
+                    checked={Boolean(item.proficient)}
+                    onChange={() => onToggleProficiency?.(key)}
+                    aria-label={`Toggle proficiency for ${label}`}
+                  />
+                  {label}
+                </label>
+              </td>
+              <td>{ability.toUpperCase()}</td>
+              <td className="dnd-skill-total">{formatModifier(total)}</td>
+              <td className="dnd-skill-flag">
+                {item.proficient ? '✔️' : ''}
+              </td>
+              <td className="dnd-skill-flag">
+                <label className="dnd-skill-expertise">
+                  <input
+                    type="checkbox"
+                    checked={Boolean(item.expertise)}
+                    onChange={() => onToggleExpertise?.(key)}
+                    aria-label={`Toggle expertise for ${label}`}
+                  />
+                </label>
+              </td>
+              <td>
+                <input
+                  type="number"
+                  inputMode="numeric"
+                  value={miscValue}
+                  onChange={(event) => onMiscChange?.(key, event.target.value)}
+                  className="dnd-skill-misc"
+                />
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}

--- a/ui/src/components/SpellSlotsEditor.jsx
+++ b/ui/src/components/SpellSlotsEditor.jsx
@@ -1,0 +1,36 @@
+import { SPELL_SLOT_LEVELS } from '../lib/playerSheet.js';
+
+const LABELS = {
+  cantrips: 'Cantrips',
+  level1: '1st',
+  level2: '2nd',
+  level3: '3rd',
+  level4: '4th',
+  level5: '5th',
+  level6: '6th',
+  level7: '7th',
+  level8: '8th',
+  level9: '9th',
+};
+
+export default function SpellSlotsEditor({ slots, onChange }) {
+  return (
+    <div className="dnd-spell-slots">
+      {SPELL_SLOT_LEVELS.map((levelKey) => {
+        const label = LABELS[levelKey] || levelKey;
+        const value = slots?.[levelKey] ?? '';
+        return (
+          <label key={levelKey} className="dnd-spell-slot-row">
+            <span>{label}</span>
+            <input
+              type="text"
+              value={value}
+              onChange={(event) => onChange?.(levelKey, event.target.value)}
+              placeholder={levelKey === 'cantrips' ? 'Known cantrips' : 'Slots / expended'}
+            />
+          </label>
+        );
+      })}
+    </div>
+  );
+}

--- a/ui/src/lib/playerSheet.js
+++ b/ui/src/lib/playerSheet.js
@@ -1,0 +1,610 @@
+const ABILITY_SCORES = Object.freeze([
+  { key: 'str', label: 'Strength' },
+  { key: 'dex', label: 'Dexterity' },
+  { key: 'con', label: 'Constitution' },
+  { key: 'int', label: 'Intelligence' },
+  { key: 'wis', label: 'Wisdom' },
+  { key: 'cha', label: 'Charisma' },
+]);
+
+const SKILL_LIST = Object.freeze([
+  { key: 'acrobatics', label: 'Acrobatics', ability: 'dex' },
+  { key: 'animalHandling', label: 'Animal Handling', ability: 'wis' },
+  { key: 'arcana', label: 'Arcana', ability: 'int' },
+  { key: 'athletics', label: 'Athletics', ability: 'str' },
+  { key: 'deception', label: 'Deception', ability: 'cha' },
+  { key: 'history', label: 'History', ability: 'int' },
+  { key: 'insight', label: 'Insight', ability: 'wis' },
+  { key: 'intimidation', label: 'Intimidation', ability: 'cha' },
+  { key: 'investigation', label: 'Investigation', ability: 'int' },
+  { key: 'medicine', label: 'Medicine', ability: 'wis' },
+  { key: 'nature', label: 'Nature', ability: 'int' },
+  { key: 'perception', label: 'Perception', ability: 'wis' },
+  { key: 'performance', label: 'Performance', ability: 'cha' },
+  { key: 'persuasion', label: 'Persuasion', ability: 'cha' },
+  { key: 'religion', label: 'Religion', ability: 'int' },
+  { key: 'sleightOfHand', label: 'Sleight of Hand', ability: 'dex' },
+  { key: 'stealth', label: 'Stealth', ability: 'dex' },
+  { key: 'survival', label: 'Survival', ability: 'wis' },
+]);
+
+const SKILL_BASE_STATE = SKILL_LIST.reduce((acc, skill) => {
+  acc[skill.key] = { proficient: false, expertise: false, misc: 0 };
+  return acc;
+}, {});
+
+const ABILITY_BASE_STATE = ABILITY_SCORES.reduce((acc, ability) => {
+  acc[ability.key] = 10;
+  return acc;
+}, {});
+
+const SAVING_THROW_BASE = ABILITY_SCORES.reduce((acc, ability) => {
+  acc[ability.key] = { proficient: false, misc: 0 };
+  return acc;
+}, {});
+
+const SPELL_SLOT_LEVELS = Object.freeze([
+  'cantrips',
+  'level1',
+  'level2',
+  'level3',
+  'level4',
+  'level5',
+  'level6',
+  'level7',
+  'level8',
+  'level9',
+]);
+
+const INITIAL_PLAYER_SHEET = Object.freeze({
+  identity: {
+    name: '',
+    class: '',
+    background: '',
+    playerName: '',
+    race: '',
+    alignment: '',
+    experience: '',
+    level: 1,
+    inspiration: false,
+    proficiencyBonusOverride: '',
+  },
+  abilityScores: { ...ABILITY_BASE_STATE },
+  savingThrows: { ...SAVING_THROW_BASE },
+  skills: { ...SKILL_BASE_STATE },
+  proficiencies: '',
+  languages: '',
+  features: '',
+  senses: '',
+  passiveInsightNotes: '',
+  passiveInvestigationNotes: '',
+  combat: {
+    armorClass: '',
+    initiativeBonus: '',
+    speed: '',
+    maxHp: '',
+    currentHp: '',
+    tempHp: '',
+    hitDice: '',
+    deathSaves: { successes: 0, failures: 0 },
+    attacks: [
+      { name: '', bonus: '', damage: '', notes: '' },
+      { name: '', bonus: '', damage: '', notes: '' },
+      { name: '', bonus: '', damage: '', notes: '' },
+    ],
+  },
+  spellcasting: {
+    ability: 'int',
+    saveDc: '',
+    attackBonus: '',
+    slots: SPELL_SLOT_LEVELS.reduce((acc, lvl) => {
+      acc[lvl] = '';
+      return acc;
+    }, {}),
+    prepared: '',
+    known: '',
+    notes: '',
+  },
+  equipment: {
+    cp: '',
+    sp: '',
+    ep: '',
+    gp: '',
+    pp: '',
+    inventory: '',
+    treasure: '',
+    other: '',
+  },
+  personality: {
+    traits: '',
+    ideals: '',
+    bonds: '',
+    flaws: '',
+    appearance: '',
+    allies: '',
+    organizations: '',
+    backstory: '',
+    notes: '',
+  },
+  resources: {
+    features: '',
+    notes: '',
+  },
+});
+
+function deepClone(value) {
+  if (Array.isArray(value)) {
+    return value.map((item) => deepClone(item));
+  }
+  if (value && typeof value === 'object') {
+    const out = {};
+    for (const [key, val] of Object.entries(value)) {
+      out[key] = deepClone(val);
+    }
+    return out;
+  }
+  return value;
+}
+
+export function createEmptyPlayerSheet() {
+  return deepClone(INITIAL_PLAYER_SHEET);
+}
+
+function normalizeNumber(value) {
+  if (value === null || value === undefined || value === '') return 0;
+  const num = Number(value);
+  return Number.isFinite(num) ? num : 0;
+}
+
+export function deriveAbilityModifier(score) {
+  const val = normalizeNumber(score);
+  return Math.floor(val / 2) - 5;
+}
+
+export function computeProficiencyBonus(level) {
+  const lvl = Math.max(1, Math.floor(normalizeNumber(level)) || 1);
+  return Math.floor((lvl - 1) / 4) + 2;
+}
+
+export function determineProficiencyBonus(sheet) {
+  const override = sheet?.identity?.proficiencyBonusOverride;
+  if (override !== undefined && override !== null && `${override}`.trim() !== '') {
+    const num = Number(override);
+    if (Number.isFinite(num)) {
+      return num;
+    }
+  }
+  return computeProficiencyBonus(sheet?.identity?.level);
+}
+
+export function formatModifier(mod) {
+  return mod >= 0 ? `+${mod}` : `${mod}`;
+}
+
+function updatePath(state, path, value) {
+  if (!Array.isArray(path) || !path.length) {
+    return state;
+  }
+  const [head, ...rest] = path;
+  if (Array.isArray(state)) {
+    const idx = Number(head);
+    return state.map((item, index) => {
+      if (index !== idx) return item;
+      if (rest.length === 0) return value;
+      return updatePath(item, rest, value);
+    });
+  }
+  const base =
+    state && typeof state === 'object' && !Array.isArray(state) ? state : {};
+  return {
+    ...base,
+    [head]:
+      rest.length === 0
+        ? value
+        : updatePath(base[head], rest, value),
+  };
+}
+
+export function playerSheetReducer(state, action) {
+  switch (action.type) {
+    case 'setField': {
+      return updatePath(state, action.path, action.value);
+    }
+    case 'toggleSavingThrow': {
+      const current = state.savingThrows?.[action.ability] || { proficient: false, misc: 0 };
+      return {
+        ...state,
+        savingThrows: {
+          ...state.savingThrows,
+          [action.ability]: {
+            ...current,
+            proficient: !current.proficient,
+          },
+        },
+      };
+    }
+    case 'setSavingThrowMisc': {
+      const current = state.savingThrows?.[action.ability] || { proficient: false, misc: 0 };
+      return {
+        ...state,
+        savingThrows: {
+          ...state.savingThrows,
+          [action.ability]: {
+            ...current,
+            misc: action.value,
+          },
+        },
+      };
+    }
+    case 'toggleSkill': {
+      const current = state.skills?.[action.skill] || {
+        proficient: false,
+        expertise: false,
+        misc: 0,
+      };
+      const nextProficient = !current.proficient;
+      return {
+        ...state,
+        skills: {
+          ...state.skills,
+          [action.skill]: {
+            ...current,
+            proficient: nextProficient,
+            expertise: nextProficient ? current.expertise : false,
+          },
+        },
+      };
+    }
+    case 'toggleSkillExpertise': {
+      const current = state.skills?.[action.skill] || { proficient: false, expertise: false, misc: 0 };
+      return {
+        ...state,
+        skills: {
+          ...state.skills,
+          [action.skill]: {
+            ...current,
+            expertise: !current.expertise,
+            proficient: current.expertise ? current.proficient : true,
+          },
+        },
+      };
+    }
+    case 'setSkillMisc': {
+      const current = state.skills?.[action.skill] || { proficient: false, expertise: false, misc: 0 };
+      return {
+        ...state,
+        skills: {
+          ...state.skills,
+          [action.skill]: {
+            ...current,
+            misc: action.value,
+          },
+        },
+      };
+    }
+    case 'updateAttacks': {
+      const nextAttacks = Array.isArray(action.attacks)
+        ? action.attacks.map((attack) => ({ ...attack }))
+        : [];
+      return {
+        ...state,
+        combat: {
+          ...state.combat,
+          attacks: nextAttacks,
+        },
+      };
+    }
+    case 'replace': {
+      return mergeDefaults(action.value);
+    }
+    case 'reset':
+      return createEmptyPlayerSheet();
+    default:
+      return state;
+  }
+}
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function getSkillMeta(key) {
+  return SKILL_LIST.find((skill) => skill.key === key) || null;
+}
+
+export function buildDerivedStats(sheet) {
+  const abilityModifiers = {};
+  for (const ability of ABILITY_SCORES) {
+    abilityModifiers[ability.key] = deriveAbilityModifier(sheet?.abilityScores?.[ability.key]);
+  }
+  const proficiencyBonus = determineProficiencyBonus(sheet);
+  const savingThrows = {};
+  for (const ability of ABILITY_SCORES) {
+    const data = sheet?.savingThrows?.[ability.key] || {};
+    const misc = normalizeNumber(data.misc);
+    const proficient = Boolean(data.proficient);
+    const total = abilityModifiers[ability.key] + (proficient ? proficiencyBonus : 0) + misc;
+    savingThrows[ability.key] = total;
+  }
+  const skills = {};
+  for (const skill of SKILL_LIST) {
+    const data = sheet?.skills?.[skill.key] || {};
+    const misc = normalizeNumber(data.misc);
+    const proficient = Boolean(data.proficient);
+    const expertise = Boolean(data.expertise);
+    const profMultiplier = expertise ? 2 : proficient ? 1 : 0;
+    const total = abilityModifiers[skill.ability] + proficiencyBonus * profMultiplier + misc;
+    skills[skill.key] = {
+      total,
+      ability: skill.ability,
+      proficient,
+      expertise,
+      misc,
+      label: skill.label,
+    };
+  }
+  const passivePerception = 10 + (skills.perception?.total ?? abilityModifiers.wis);
+  const passiveInvestigation = 10 + (skills.investigation?.total ?? abilityModifiers.int);
+  const passiveInsight = 10 + (skills.insight?.total ?? abilityModifiers.wis);
+  const initiative = abilityModifiers.dex + normalizeNumber(sheet?.combat?.initiativeBonus);
+  const spellAbility = sheet?.spellcasting?.ability || 'int';
+  const spellAbilityMod = abilityModifiers[spellAbility] ?? 0;
+  const spellSaveSuggestion = 8 + spellAbilityMod + proficiencyBonus;
+  const spellAttackSuggestion = spellAbilityMod + proficiencyBonus;
+
+  return {
+    abilityModifiers,
+    proficiencyBonus,
+    savingThrows,
+    skills,
+    passivePerception,
+    passiveInvestigation,
+    passiveInsight,
+    initiative,
+    spellcasting: {
+      ability: spellAbility,
+      abilityModifier: spellAbilityMod,
+      suggestedSaveDc: spellSaveSuggestion,
+      suggestedAttackBonus: spellAttackSuggestion,
+    },
+  };
+}
+
+export function validatePlayerSheet(sheet) {
+  const errors = [];
+  const name = (sheet?.identity?.name || '').trim();
+  if (!name) {
+    errors.push('Character name is required.');
+  }
+  const level = Math.floor(normalizeNumber(sheet?.identity?.level));
+  if (!Number.isFinite(level) || level < 1 || level > 20) {
+    errors.push('Level must be between 1 and 20.');
+  }
+  for (const ability of ABILITY_SCORES) {
+    const score = normalizeNumber(sheet?.abilityScores?.[ability.key]);
+    if (score < 1 || score > 30) {
+      errors.push(`${ability.label} score should be between 1 and 30.`);
+    }
+  }
+  return errors;
+}
+
+function escapePipe(text) {
+  return String(text ?? '').replace(/\|/g, '\\|');
+}
+
+function renderAbilityTable(sheet, derived) {
+  const rows = ABILITY_SCORES.map((ability) => {
+    const score = sheet?.abilityScores?.[ability.key] ?? '';
+    const mod = derived.abilityModifiers[ability.key];
+    const save = derived.savingThrows[ability.key];
+    const proficient = sheet?.savingThrows?.[ability.key]?.proficient;
+    const misc = normalizeNumber(sheet?.savingThrows?.[ability.key]?.misc);
+    return `| ${ability.label} | ${score || ''} | ${formatModifier(mod)} | ${formatModifier(save)} | ${proficient ? '✔️' : ''} | ${misc ? formatModifier(misc) : ''} |`;
+  });
+  return [
+    '| Ability | Score | Modifier | Save | Proficient | Misc |',
+    '|:--|:--:|:--:|:--:|:--:|:--:|',
+    ...rows,
+  ].join('\n');
+}
+
+function renderSkillTable(sheet, derived) {
+  const rows = SKILL_LIST.map((skill) => {
+    const data = derived.skills[skill.key];
+    const baseMod = derived.abilityModifiers[skill.ability];
+    const misc = normalizeNumber(sheet?.skills?.[skill.key]?.misc);
+    const proficient = sheet?.skills?.[skill.key]?.proficient;
+    const expertise = sheet?.skills?.[skill.key]?.expertise;
+    return `| ${skill.label} (${skill.ability.toUpperCase()}) | ${formatModifier(data.total)} | ${proficient ? '✔️' : ''} | ${expertise ? '✔️' : ''} | ${formatModifier(baseMod)} | ${misc ? formatModifier(misc) : ''} |`;
+  });
+  return [
+    '| Skill | Total | Proficient | Expertise | Ability Mod | Misc |',
+    '|:--|:--:|:--:|:--:|:--:|:--:|',
+    ...rows,
+  ].join('\n');
+}
+
+function renderAttacks(attacks) {
+  const valid = Array.isArray(attacks) ? attacks.filter((attack) => {
+    return (
+      (attack?.name || '').trim() ||
+      (attack?.bonus || '').trim() ||
+      (attack?.damage || '').trim() ||
+      (attack?.notes || '').trim()
+    );
+  }) : [];
+  if (!valid.length) {
+    return '';
+  }
+  const rows = valid.map((attack) => {
+    return `| ${escapePipe(attack.name)} | ${escapePipe(attack.bonus)} | ${escapePipe(attack.damage)} | ${escapePipe(attack.notes)} |`;
+  });
+  return [
+    '| Attack | Bonus | Damage | Notes |',
+    '|:--|:--:|:--:|:--|',
+    ...rows,
+  ].join('\n');
+}
+
+function sectionIfContent(title, content) {
+  const trimmed = (content || '').trim();
+  if (!trimmed) return '';
+  return `## ${title}\n\n${trimmed}\n\n`;
+}
+
+export function serializeCharacterSheet(sheet) {
+  const derived = buildDerivedStats(sheet);
+  const identity = sheet?.identity || {};
+  const frontmatterLines = ['---'];
+  frontmatterLines.push(`Title: ${identity.name || 'Unnamed Adventurer'}`);
+  frontmatterLines.push(`Class: ${identity.class || ''}`);
+  frontmatterLines.push(`Level: ${Math.max(1, Math.floor(normalizeNumber(identity.level)) || 1)}`);
+  frontmatterLines.push(`Background: ${identity.background || ''}`);
+  frontmatterLines.push(`Player: ${identity.playerName || ''}`);
+  frontmatterLines.push(`Race: ${identity.race || ''}`);
+  frontmatterLines.push(`Alignment: ${identity.alignment || ''}`);
+  frontmatterLines.push(`Experience: ${identity.experience || ''}`);
+  frontmatterLines.push(`Inspiration: ${identity.inspiration ? 'Yes' : 'No'}`);
+  frontmatterLines.push(`Proficiency Bonus: ${formatModifier(derived.proficiencyBonus)}`);
+  frontmatterLines.push(`Passive Perception: ${derived.passivePerception}`);
+  frontmatterLines.push(`Passive Investigation: ${derived.passiveInvestigation}`);
+  frontmatterLines.push(`Passive Insight: ${derived.passiveInsight}`);
+  frontmatterLines.push('---');
+
+  const abilityTable = renderAbilityTable(sheet, derived);
+  const skillTable = renderSkillTable(sheet, derived);
+  const attacksTable = renderAttacks(sheet?.combat?.attacks);
+
+  const combatSection = [
+    `- Armor Class: ${sheet?.combat?.armorClass || ''}`,
+    `- Initiative: ${formatModifier(derived.initiative)}`,
+    `- Speed: ${sheet?.combat?.speed || ''}`,
+    `- Hit Points: ${sheet?.combat?.currentHp || sheet?.combat?.maxHp || ''} / ${sheet?.combat?.maxHp || ''}`,
+    `- Temporary HP: ${sheet?.combat?.tempHp || '0'}`,
+    `- Hit Dice: ${sheet?.combat?.hitDice || ''}`,
+  ].join('\n');
+
+  const deathSaves = sheet?.combat?.deathSaves || { successes: 0, failures: 0 };
+  const deathSaveLine = `- Death Saves: Successes ${clamp(normalizeNumber(deathSaves.successes), 0, 3)}/3, Failures ${clamp(normalizeNumber(deathSaves.failures), 0, 3)}/3`;
+
+  const spellcasting = sheet?.spellcasting || {};
+  const spellLines = [
+    `- Spellcasting Ability: ${(spellcasting.ability || '').toUpperCase()}`,
+    `- Spell Save DC: ${spellcasting.saveDc || derived.spellcasting.suggestedSaveDc}`,
+    `- Spell Attack Bonus: ${spellcasting.attackBonus || formatModifier(derived.spellcasting.suggestedAttackBonus)}`,
+  ];
+  if (spellcasting.slots?.cantrips) {
+    spellLines.push(`- Cantrips Known: ${spellcasting.slots.cantrips}`);
+  }
+
+  const slotLines = SPELL_SLOT_LEVELS.filter((lvl) => lvl !== 'cantrips').map((lvl, index) => {
+    const display = sheet?.spellcasting?.slots?.[lvl];
+    if (!display && display !== 0) return `- Level ${index + 1}: 0`;
+    return `- Level ${index + 1}: ${display}`;
+  });
+
+  const coin = sheet?.equipment || {};
+  const coinLines = [
+    `- CP: ${coin.cp || 0}`,
+    `- SP: ${coin.sp || 0}`,
+    `- EP: ${coin.ep || 0}`,
+    `- GP: ${coin.gp || 0}`,
+    `- PP: ${coin.pp || 0}`,
+  ];
+
+  let out = '';
+  out += frontmatterLines.join('\n');
+  out += '\n\n';
+  out += `# ${identity.name || 'Adventurer'}\n\n`;
+  out += '## Abilities\n\n';
+  out += `${abilityTable}\n\n`;
+  out += '## Skills\n\n';
+  out += `${skillTable}\n\n`;
+  out += '## Combat\n\n';
+  out += `${combatSection}\n${deathSaveLine}\n\n`;
+  if (attacksTable) {
+    out += '### Attacks & Spellcasting\n\n';
+    out += `${attacksTable}\n\n`;
+  }
+  out += '## Spellcasting\n\n';
+  out += `${spellLines.join('\n')}\n`;
+  out += slotLines.join('\n');
+  out += '\n\n';
+  out += sectionIfContent('Prepared Spells', spellcasting.prepared);
+  out += sectionIfContent('Known Spells', spellcasting.known);
+  out += sectionIfContent('Spell Notes', spellcasting.notes);
+  out += '## Proficiencies & Languages\n\n';
+  out += `- Proficiencies: ${(sheet?.proficiencies || '').trim()}`;
+  out += '\n';
+  out += `- Languages: ${(sheet?.languages || '').trim()}`;
+  out += '\n';
+  out += sectionIfContent('Features & Traits', sheet?.features);
+  out += sectionIfContent('Senses', sheet?.senses);
+  out += '## Equipment\n\n';
+  out += `${coinLines.join('\n')}\n\n`;
+  out += sectionIfContent('Inventory', sheet?.equipment?.inventory);
+  out += sectionIfContent('Treasure', sheet?.equipment?.treasure);
+  out += sectionIfContent('Other Equipment', sheet?.equipment?.other);
+  out += '## Personality\n\n';
+  out += `- Traits: ${(sheet?.personality?.traits || '').trim()}`;
+  out += '\n';
+  out += `- Ideals: ${(sheet?.personality?.ideals || '').trim()}`;
+  out += '\n';
+  out += `- Bonds: ${(sheet?.personality?.bonds || '').trim()}`;
+  out += '\n';
+  out += `- Flaws: ${(sheet?.personality?.flaws || '').trim()}`;
+  out += '\n\n';
+  out += sectionIfContent('Appearance', sheet?.personality?.appearance);
+  out += sectionIfContent('Allies & Organizations', sheet?.personality?.allies);
+  out += sectionIfContent('Organizations', sheet?.personality?.organizations);
+  out += sectionIfContent('Backstory', sheet?.personality?.backstory);
+  out += sectionIfContent('Notes', sheet?.personality?.notes);
+  out += sectionIfContent('Resource Notes', sheet?.resources?.notes);
+  out += sectionIfContent('Class Features', sheet?.resources?.features);
+  out += '\n';
+  return out.trimEnd();
+}
+
+export function serializePlayerSheetToJson(sheet) {
+  return JSON.stringify(sheet, null, 2);
+}
+
+function mergeDefaults(partial) {
+  const base = createEmptyPlayerSheet();
+  const merge = (target, source) => {
+    if (Array.isArray(target) && Array.isArray(source)) {
+      return source.map((item, index) => merge(target[index], item));
+    }
+    if (target && typeof target === 'object' && source && typeof source === 'object') {
+      const result = { ...target };
+      for (const [key, value] of Object.entries(source)) {
+        result[key] = merge(target[key], value);
+      }
+      return result;
+    }
+    return source !== undefined ? source : target;
+  };
+  return merge(base, partial || {});
+}
+
+export function parsePlayerSheetImport(text) {
+  if (!text || typeof text !== 'string') {
+    throw new Error('No data provided');
+  }
+  let parsed = null;
+  try {
+    parsed = JSON.parse(text);
+  } catch (err) {
+    throw new Error('File must be a JSON export from the character sheet.');
+  }
+  return mergeDefaults(parsed);
+}
+
+export {
+  ABILITY_SCORES,
+  SKILL_LIST,
+  SPELL_SLOT_LEVELS,
+  INITIAL_PLAYER_SHEET,
+};
+

--- a/ui/src/pages/Dnd.css
+++ b/ui/src/pages/Dnd.css
@@ -1237,3 +1237,480 @@
   background: rgba(251, 191, 36, 0.15);
 }
 
+
+.dnd-sheet-page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.dnd-sheet-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-lg);
+}
+
+.dnd-sheet-header h1 {
+  margin: 0;
+}
+
+.dnd-sheet-header p {
+  margin: 0.5rem 0 0;
+  color: rgba(226, 232, 240, 0.8);
+  max-width: 60ch;
+}
+
+.dnd-sheet-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.dnd-sheet-toolbar button {
+  padding: 0.45rem 0.9rem;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(30, 41, 59, 0.8);
+  color: inherit;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.dnd-sheet-toolbar button:hover,
+.dnd-sheet-toolbar button:focus {
+  border-color: rgba(96, 165, 250, 0.5);
+  background: rgba(37, 99, 235, 0.18);
+}
+
+.dnd-sheet-alert,
+.dnd-sheet-success {
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  border: 1px solid;
+}
+
+.dnd-sheet-alert {
+  background: rgba(239, 68, 68, 0.15);
+  border-color: rgba(248, 113, 113, 0.4);
+  color: #fecaca;
+}
+
+.dnd-sheet-success {
+  background: rgba(34, 197, 94, 0.12);
+  border-color: rgba(134, 239, 172, 0.45);
+  color: #bbf7d0;
+}
+
+.dnd-sheet-path {
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.dnd-sheet-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.dnd-sheet-grid {
+  display: grid;
+  gap: var(--space-xl);
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  align-items: flex-start;
+}
+
+.dnd-sheet-column {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.dnd-sheet-section {
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 18px;
+  padding: var(--space-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.dnd-sheet-section__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-md);
+}
+
+.dnd-sheet-section__headings h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.dnd-sheet-section__description {
+  margin: 0.35rem 0 0;
+  font-size: 0.95rem;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.dnd-sheet-section__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.dnd-sheet-section__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.dnd-identity-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.dnd-identity-grid label,
+.dnd-identity-checkbox,
+.dnd-sheet-section label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+}
+
+.dnd-identity-checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.dnd-sheet-quickstats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+  margin-top: var(--space-md);
+}
+
+.dnd-sheet-quickstats div {
+  background: rgba(37, 99, 235, 0.08);
+  border: 1px solid rgba(96, 165, 250, 0.25);
+  border-radius: 12px;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.dnd-sheet-quickstats span {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: rgba(191, 219, 254, 0.85);
+}
+
+.dnd-sheet-quickstats strong {
+  font-size: 1.1rem;
+}
+
+.dnd-ability-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.85rem;
+}
+
+.dnd-ability-card {
+  background: rgba(30, 41, 59, 0.9);
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  padding: 0.85rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  text-align: center;
+}
+
+.dnd-ability-label {
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.dnd-ability-score {
+  width: 100%;
+  text-align: center;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.dnd-ability-modifier {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: rgba(96, 165, 250, 0.95);
+}
+
+.dnd-saving-throws {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.dnd-saving-throw-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.dnd-saving-throw-main {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.dnd-saving-throw-values {
+  display: flex;
+  align-items: baseline;
+  gap: 0.65rem;
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.dnd-saving-throw-total {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: rgba(96, 165, 250, 0.95);
+}
+
+.dnd-saving-throw-misc {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.8rem;
+}
+
+.dnd-skill-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: rgba(15, 23, 42, 0.55);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.dnd-skill-table th,
+.dnd-skill-table td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+  text-align: left;
+  font-size: 0.9rem;
+}
+
+.dnd-skill-table th {
+  background: rgba(30, 41, 59, 0.75);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.dnd-skill-table tr:last-child td {
+  border-bottom: none;
+}
+
+.dnd-skill-total {
+  font-weight: 600;
+}
+
+.dnd-skill-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.dnd-skill-misc {
+  width: 4rem;
+}
+
+.dnd-combat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
+  margin-bottom: var(--space-md);
+}
+
+.dnd-attacks-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.dnd-attack-row {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  align-items: center;
+}
+
+.dnd-attack-remove {
+  justify-self: flex-end;
+}
+
+.dnd-attack-add {
+  align-self: flex-start;
+}
+
+.dnd-spellcasting-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+  margin-bottom: var(--space-md);
+}
+
+.dnd-spell-slots {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.65rem;
+}
+
+.dnd-spell-slot-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.dnd-currency-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  gap: 0.5rem;
+  margin-bottom: var(--space-md);
+}
+
+.dnd-currency-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+}
+
+.dnd-death-saves {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  margin-bottom: var(--space-md);
+}
+
+.dnd-death-saves-column {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.dnd-death-saves-track {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.dnd-death-saves-dot {
+  width: 1.35rem;
+  height: 1.35rem;
+  border-radius: 50%;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: transparent;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.dnd-death-saves-dot.is-filled {
+  background: rgba(34, 197, 94, 0.55);
+  border-color: rgba(134, 239, 172, 0.7);
+}
+
+.dnd-template-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 0.5rem;
+  align-items: end;
+}
+
+.dnd-template-grid button {
+  height: 100%;
+  padding: 0.5rem 0.9rem;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(30, 41, 59, 0.8);
+  cursor: pointer;
+}
+
+.dnd-template-grid button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.dnd-prefill-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.dnd-sheet-submit {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.dnd-sheet-submit button {
+  padding: 0.75rem 1.75rem;
+  font-size: 1rem;
+  border-radius: 14px;
+  border: none;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.65), rgba(14, 116, 144, 0.75));
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.dnd-sheet-submit button:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+
+.dnd-sheet-submit button:not(:disabled):hover,
+.dnd-sheet-submit button:not(:disabled):focus {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 30px rgba(59, 130, 246, 0.25);
+}
+
+.dnd-sheet-section textarea,
+.dnd-sheet-section input,
+.dnd-sheet-section select {
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 10px;
+  padding: 0.55rem 0.75rem;
+  color: inherit;
+  font: inherit;
+}
+
+.dnd-sheet-section textarea {
+  resize: vertical;
+}
+
+@media (max-width: 720px) {
+  .dnd-template-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .dnd-template-grid button {
+    width: 100%;
+  }
+}

--- a/ui/src/pages/DndDmPlayers.jsx
+++ b/ui/src/pages/DndDmPlayers.jsx
@@ -1,13 +1,1124 @@
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import BackButton from '../components/BackButton.jsx';
+import CharacterSheetSection from '../components/CharacterSheetSection.jsx';
+import AbilityScoreInputs from '../components/AbilityScoreInputs.jsx';
+import SavingThrowList from '../components/SavingThrowList.jsx';
+import SkillList from '../components/SkillList.jsx';
+import SpellSlotsEditor from '../components/SpellSlotsEditor.jsx';
+import AttacksEditor from '../components/AttacksEditor.jsx';
+import CurrencyInputs from '../components/CurrencyInputs.jsx';
+import DeathSavesTracker from '../components/DeathSavesTracker.jsx';
+import { createPlayer } from '../api/players';
+import { getConfig, setConfig } from '../api/config';
+import {
+  buildDerivedStats,
+  createEmptyPlayerSheet,
+  formatModifier,
+  parsePlayerSheetImport,
+  playerSheetReducer,
+  serializeCharacterSheet,
+  serializePlayerSheetToJson,
+  validatePlayerSheet,
+} from '../lib/playerSheet.js';
 import './Dnd.css';
 
+function slugify(value) {
+  return (value || '')
+    .toString()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gi, '-')
+    .replace(/(^-|-$)/g, '')
+    .replace(/--+/g, '-')
+    || 'character';
+}
+
+function downloadFile(filename, contents, mimeType) {
+  const blob = new Blob([contents], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+function toNumeric(value, { clampMin, clampMax } = {}) {
+  if (value === '' || value === null || value === undefined) return '';
+  const num = Number(value);
+  if (!Number.isFinite(num)) return '';
+  if (typeof clampMin === 'number' && num < clampMin) return clampMin;
+  if (typeof clampMax === 'number' && num > clampMax) return clampMax;
+  return num;
+}
+
 export default function DndDmPlayers() {
+  const [sheet, dispatch] = useReducer(playerSheetReducer, null, createEmptyPlayerSheet);
+  const derived = useMemo(() => buildDerivedStats(sheet), [sheet]);
+  const [status, setStatus] = useState('');
+  const [error, setError] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [lastSavedPath, setLastSavedPath] = useState('');
+  const [templatePath, setTemplatePath] = useState('');
+  const [directoryOverride, setDirectoryOverride] = useState('');
+  const [templateDefault, setTemplateDefault] = useState('');
+  const [directoryDefault, setDirectoryDefault] = useState('');
+  const [usePrefill, setUsePrefill] = useState(false);
+  const [prefillPrompt, setPrefillPrompt] = useState('');
+  const fileInputRef = useRef(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const [templateValue, directoryValue] = await Promise.all([
+          getConfig('dndPlayerTemplate').catch(() => ''),
+          getConfig('dndPlayerDirectory').catch(() => ''),
+        ]);
+        if (cancelled) return;
+        if (typeof templateValue === 'string') {
+          setTemplatePath(templateValue);
+          setTemplateDefault(templateValue);
+        }
+        if (typeof directoryValue === 'string') {
+          setDirectoryOverride(directoryValue);
+          setDirectoryDefault(directoryValue);
+        }
+      } catch (err) {
+        console.warn('Failed to load player sheet configuration', err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleAbilityChange = useCallback((ability, value) => {
+    const next = value === '' ? '' : toNumeric(value, { clampMin: 0, clampMax: 30 });
+    dispatch({ type: 'setField', path: ['abilityScores', ability], value: next });
+  }, []);
+
+  const handleSavingThrowMisc = useCallback((ability, value) => {
+    const next = value === '' ? '' : toNumeric(value, { clampMin: -99, clampMax: 99 });
+    dispatch({ type: 'setSavingThrowMisc', ability, value: next });
+  }, []);
+
+  const handleSkillMisc = useCallback((skill, value) => {
+    const next = value === '' ? '' : toNumeric(value, { clampMin: -99, clampMax: 99 });
+    dispatch({ type: 'setSkillMisc', skill, value: next });
+  }, []);
+
+  const handleAttackChange = useCallback((attacks) => {
+    dispatch({ type: 'updateAttacks', attacks });
+  }, []);
+
+  const handleAttackAdd = useCallback((template) => {
+    const current = Array.isArray(sheet?.combat?.attacks) ? sheet.combat.attacks : [];
+    if (current.length >= 8) return;
+    const next = [...current, { ...template }];
+    dispatch({ type: 'updateAttacks', attacks: next });
+  }, [sheet?.combat?.attacks]);
+
+  const handleAttackRemove = useCallback((index) => {
+    const current = Array.isArray(sheet?.combat?.attacks) ? sheet.combat.attacks : [];
+    const next = current.filter((_, idx) => idx !== index);
+    dispatch({ type: 'updateAttacks', attacks: next });
+  }, [sheet?.combat?.attacks]);
+
+  const handleDeathSaveChange = useCallback((type, count) => {
+    const clamped = Math.max(0, Math.min(3, count));
+    const key = type === 'success' ? 'successes' : 'failures';
+    dispatch({ type: 'setField', path: ['combat', 'deathSaves', key], value: clamped });
+  }, []);
+
+  const handleSpellSlotChange = useCallback((levelKey, value) => {
+    dispatch({ type: 'setField', path: ['spellcasting', 'slots', levelKey], value });
+  }, []);
+
+  const handleCurrencyChange = useCallback((key, value) => {
+    dispatch({ type: 'setField', path: ['equipment', key], value });
+  }, []);
+
+  const triggerImport = useCallback(() => {
+    setError('');
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleImportFile = useCallback(async (event) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    try {
+      const text = await file.text();
+      const imported = parsePlayerSheetImport(text);
+      dispatch({ type: 'replace', value: imported });
+      setStatus(`Imported ${file.name}`);
+      setError('');
+    } catch (err) {
+      setStatus('');
+      setError(err?.message || 'Failed to import file.');
+    } finally {
+      event.target.value = '';
+    }
+  }, []);
+
+  const handleExportJson = useCallback(() => {
+    try {
+      const json = serializePlayerSheetToJson(sheet);
+      const filename = `${slugify(sheet?.identity?.name)}.character.json`;
+      downloadFile(filename, json, 'application/json');
+      setStatus('Exported sheet as JSON.');
+      setError('');
+    } catch (err) {
+      setError('Unable to export sheet as JSON.');
+      console.error(err);
+    }
+  }, [sheet]);
+
+  const handleExportMarkdown = useCallback(() => {
+    try {
+      const markdown = serializeCharacterSheet(sheet);
+      const filename = `${slugify(sheet?.identity?.name)}.md`;
+      downloadFile(filename, markdown, 'text/markdown');
+      setStatus('Exported sheet as Markdown.');
+      setError('');
+    } catch (err) {
+      setError('Unable to export sheet as Markdown.');
+      console.error(err);
+    }
+  }, [sheet]);
+
+  const handleReset = useCallback(() => {
+    dispatch({ type: 'reset' });
+    setStatus('Cleared character sheet.');
+    setError('');
+  }, []);
+
+  const saveTemplateDefault = useCallback(async () => {
+    try {
+      await setConfig('dndPlayerTemplate', templatePath || '');
+      setTemplateDefault(templatePath || '');
+      setStatus('Updated default template path.');
+      setError('');
+    } catch (err) {
+      setError('Failed to update template preference.');
+      console.error(err);
+    }
+  }, [templatePath]);
+
+  const saveDirectoryDefault = useCallback(async () => {
+    try {
+      await setConfig('dndPlayerDirectory', directoryOverride || '');
+      setDirectoryDefault(directoryOverride || '');
+      setStatus('Updated default player directory.');
+      setError('');
+    } catch (err) {
+      setError('Failed to update directory preference.');
+      console.error(err);
+    }
+  }, [directoryOverride]);
+
+  const handleSubmit = useCallback(async (event) => {
+    event.preventDefault();
+    if (saving) return;
+    setStatus('');
+    const validation = validatePlayerSheet(sheet);
+    if (validation.length) {
+      setError(validation.join(' '));
+      return;
+    }
+    try {
+      setSaving(true);
+      setError('');
+      const markdown = serializeCharacterSheet(sheet);
+      const payload = {
+        name: sheet?.identity?.name || 'Adventurer',
+        markdown,
+        sheet,
+        template: templatePath?.trim() ? templatePath.trim() : undefined,
+        directory: directoryOverride?.trim() ? directoryOverride.trim() : undefined,
+        usePrefill: usePrefill || Boolean(prefillPrompt.trim()),
+        prefillPrompt: prefillPrompt.trim() || undefined,
+      };
+      const savedPath = await createPlayer(payload);
+      setLastSavedPath(savedPath || '');
+      setStatus(savedPath ? `Saved character sheet to ${savedPath}` : 'Character sheet saved.');
+    } catch (err) {
+      console.error(err);
+      setError(err?.message || 'Failed to save character sheet.');
+    } finally {
+      setSaving(false);
+    }
+  }, [saving, sheet, templatePath, directoryOverride, usePrefill, prefillPrompt]);
+
+  const savingThrowItems = useMemo(() => {
+    return Object.fromEntries(
+      Object.entries(derived.savingThrows).map(([key, total]) => {
+        const source = sheet?.savingThrows?.[key] || {};
+        return [key, { total, misc: source.misc ?? '', proficient: Boolean(source.proficient) }];
+      })
+    );
+  }, [derived.savingThrows, sheet?.savingThrows]);
+
+  const skillItems = useMemo(() => {
+    const items = {};
+    for (const [key, data] of Object.entries(derived.skills)) {
+      const source = sheet?.skills?.[key] || {};
+      items[key] = {
+        ...data,
+        misc: source.misc ?? '',
+      };
+    }
+    return items;
+  }, [derived.skills, sheet?.skills]);
+
+  const renderQuickStats = (
+    <div className="dnd-sheet-quickstats">
+      <div>
+        <span>Proficiency Bonus</span>
+        <strong>{formatModifier(derived.proficiencyBonus)}</strong>
+      </div>
+      <div>
+        <span>Initiative</span>
+        <strong>{formatModifier(derived.initiative)}</strong>
+      </div>
+      <div>
+        <span>Passive Perception</span>
+        <strong>{derived.passivePerception}</strong>
+      </div>
+      <div>
+        <span>Passive Investigation</span>
+        <strong>{derived.passiveInvestigation}</strong>
+      </div>
+      <div>
+        <span>Passive Insight</span>
+        <strong>{derived.passiveInsight}</strong>
+      </div>
+    </div>
+  );
+
+  const inspirationId = 'player-inspiration';
+
   return (
     <>
       <BackButton />
-      <h1>Dungeons & Dragons · Players</h1>
-      <p>PC sheets, party info, and player handouts.</p>
+      <div className="dnd-sheet-page">
+        <header className="dnd-sheet-header">
+          <div>
+            <h1>Dungeons &amp; Dragons · Player Sheets</h1>
+            <p>
+              Craft and export rich Roll20-style character sheets with automated modifiers,
+              skill tracking, spell slots, and vault persistence.
+            </p>
+          </div>
+          <div className="dnd-sheet-toolbar">
+            <button type="button" onClick={triggerImport}>
+              Import JSON
+            </button>
+            <button type="button" onClick={handleExportJson}>
+              Export JSON
+            </button>
+            <button type="button" onClick={handleExportMarkdown}>
+              Export Markdown
+            </button>
+            <button type="button" onClick={handleReset}>
+              Reset
+            </button>
+          </div>
+        </header>
+
+        {error && (
+          <div className="dnd-sheet-alert" role="alert">
+            {error}
+          </div>
+        )}
+        {status && (
+          <div className="dnd-sheet-success" role="status">
+            {status}
+          </div>
+        )}
+        {lastSavedPath && (
+          <div className="dnd-sheet-path">Last saved to: {lastSavedPath}</div>
+        )}
+
+        <form className="dnd-sheet-form" onSubmit={handleSubmit}>
+          <div className="dnd-sheet-grid">
+            <div className="dnd-sheet-column">
+              <CharacterSheetSection
+                title="Identity"
+                description="Core character information and quick stats."
+              >
+                <div className="dnd-identity-grid">
+                  <label>
+                    <span>Name</span>
+                    <input
+                      type="text"
+                      value={sheet.identity.name}
+                      onChange={(event) =>
+                        dispatch({
+                          type: 'setField',
+                          path: ['identity', 'name'],
+                          value: event.target.value,
+                        })
+                      }
+                      required
+                    />
+                  </label>
+                  <label>
+                    <span>Class &amp; Subclass</span>
+                    <input
+                      type="text"
+                      value={sheet.identity.class}
+                      onChange={(event) =>
+                        dispatch({
+                          type: 'setField',
+                          path: ['identity', 'class'],
+                          value: event.target.value,
+                        })
+                      }
+                    />
+                  </label>
+                  <label>
+                    <span>Level</span>
+                    <input
+                      type="number"
+                      min="1"
+                      max="20"
+                      value={sheet.identity.level}
+                      onChange={(event) =>
+                        dispatch({
+                          type: 'setField',
+                          path: ['identity', 'level'],
+                          value: toNumeric(event.target.value, {
+                            clampMin: 1,
+                            clampMax: 20,
+                          }),
+                        })
+                      }
+                    />
+                  </label>
+                  <label>
+                    <span>Background</span>
+                    <input
+                      type="text"
+                      value={sheet.identity.background}
+                      onChange={(event) =>
+                        dispatch({
+                          type: 'setField',
+                          path: ['identity', 'background'],
+                          value: event.target.value,
+                        })
+                      }
+                    />
+                  </label>
+                  <label>
+                    <span>Player</span>
+                    <input
+                      type="text"
+                      value={sheet.identity.playerName}
+                      onChange={(event) =>
+                        dispatch({
+                          type: 'setField',
+                          path: ['identity', 'playerName'],
+                          value: event.target.value,
+                        })
+                      }
+                    />
+                  </label>
+                  <label>
+                    <span>Race</span>
+                    <input
+                      type="text"
+                      value={sheet.identity.race}
+                      onChange={(event) =>
+                        dispatch({
+                          type: 'setField',
+                          path: ['identity', 'race'],
+                          value: event.target.value,
+                        })
+                      }
+                    />
+                  </label>
+                  <label>
+                    <span>Alignment</span>
+                    <input
+                      type="text"
+                      value={sheet.identity.alignment}
+                      onChange={(event) =>
+                        dispatch({
+                          type: 'setField',
+                          path: ['identity', 'alignment'],
+                          value: event.target.value,
+                        })
+                      }
+                    />
+                  </label>
+                  <label>
+                    <span>Experience</span>
+                    <input
+                      type="text"
+                      value={sheet.identity.experience}
+                      onChange={(event) =>
+                        dispatch({
+                          type: 'setField',
+                          path: ['identity', 'experience'],
+                          value: event.target.value,
+                        })
+                      }
+                    />
+                  </label>
+                  <label>
+                    <span>Proficiency Bonus Override</span>
+                    <input
+                      type="number"
+                      inputMode="numeric"
+                      value={sheet.identity.proficiencyBonusOverride}
+                      onChange={(event) =>
+                        dispatch({
+                          type: 'setField',
+                          path: ['identity', 'proficiencyBonusOverride'],
+                          value: event.target.value,
+                        })
+                      }
+                      placeholder="Auto from level"
+                    />
+                  </label>
+                  <label className="dnd-identity-checkbox" htmlFor={inspirationId}>
+                    <input
+                      id={inspirationId}
+                      type="checkbox"
+                      checked={Boolean(sheet.identity.inspiration)}
+                      onChange={(event) =>
+                        dispatch({
+                          type: 'setField',
+                          path: ['identity', 'inspiration'],
+                          value: event.target.checked,
+                        })
+                      }
+                    />
+                    Inspiration
+                  </label>
+                </div>
+                {renderQuickStats}
+              </CharacterSheetSection>
+
+              <CharacterSheetSection
+                title="Ability Scores"
+                description="Track ability scores with automatic modifier calculation."
+              >
+                <AbilityScoreInputs
+                  scores={sheet.abilityScores}
+                  modifiers={derived.abilityModifiers}
+                  onChange={handleAbilityChange}
+                />
+              </CharacterSheetSection>
+
+              <CharacterSheetSection
+                title="Saving Throws"
+                description="Toggle proficiency and add situational modifiers."
+              >
+                <SavingThrowList
+                  savingThrows={savingThrowItems}
+                  abilityModifiers={derived.abilityModifiers}
+                  proficiencyBonus={derived.proficiencyBonus}
+                  onToggle={(ability) =>
+                    dispatch({ type: 'toggleSavingThrow', ability })
+                  }
+                  onMiscChange={handleSavingThrowMisc}
+                />
+              </CharacterSheetSection>
+
+              <CharacterSheetSection
+                title="Skills"
+                description="Mark proficiency/expertise and capture miscellaneous bonuses."
+              >
+                <SkillList
+                  skills={skillItems}
+                  abilityModifiers={derived.abilityModifiers}
+                  onToggleProficiency={(skill) =>
+                    dispatch({ type: 'toggleSkill', skill })
+                  }
+                  onToggleExpertise={(skill) =>
+                    dispatch({ type: 'toggleSkillExpertise', skill })
+                  }
+                  onMiscChange={handleSkillMisc}
+                />
+              </CharacterSheetSection>
+
+              <CharacterSheetSection
+                title="Spell Slots"
+                description="Update cantrips, slots, and expended tracking."
+              >
+                <SpellSlotsEditor
+                  slots={sheet.spellcasting.slots}
+                  onChange={handleSpellSlotChange}
+                />
+              </CharacterSheetSection>
+            </div>
+
+            <div className="dnd-sheet-column">
+              <CharacterSheetSection
+                title="Combat"
+                description="Armor class, hit points, death saves, and attacks."
+              >
+                <div className="dnd-combat-grid">
+                  <label>
+                    <span>Armor Class</span>
+                    <input
+                      type="text"
+                      value={sheet.combat.armorClass}
+                      onChange={(event) =>
+                        dispatch({
+                          type: 'setField',
+                          path: ['combat', 'armorClass'],
+                          value: event.target.value,
+                        })
+                      }
+                    />
+                  </label>
+                  <label>
+                    <span>Initiative Bonus</span>
+                    <input
+                      type="number"
+                      value={sheet.combat.initiativeBonus}
+                      onChange={(event) =>
+                        dispatch({
+                          type: 'setField',
+                          path: ['combat', 'initiativeBonus'],
+                          value: event.target.value,
+                        })
+                      }
+                    />
+                  </label>
+                  <label>
+                    <span>Speed</span>
+                    <input
+                      type="text"
+                      value={sheet.combat.speed}
+                      onChange={(event) =>
+                        dispatch({
+                          type: 'setField',
+                          path: ['combat', 'speed'],
+                          value: event.target.value,
+                        })
+                      }
+                    />
+                  </label>
+                  <label>
+                    <span>Max HP</span>
+                    <input
+                      type="text"
+                      value={sheet.combat.maxHp}
+                      onChange={(event) =>
+                        dispatch({
+                          type: 'setField',
+                          path: ['combat', 'maxHp'],
+                          value: event.target.value,
+                        })
+                      }
+                    />
+                  </label>
+                  <label>
+                    <span>Current HP</span>
+                    <input
+                      type="text"
+                      value={sheet.combat.currentHp}
+                      onChange={(event) =>
+                        dispatch({
+                          type: 'setField',
+                          path: ['combat', 'currentHp'],
+                          value: event.target.value,
+                        })
+                      }
+                    />
+                  </label>
+                  <label>
+                    <span>Temp HP</span>
+                    <input
+                      type="text"
+                      value={sheet.combat.tempHp}
+                      onChange={(event) =>
+                        dispatch({
+                          type: 'setField',
+                          path: ['combat', 'tempHp'],
+                          value: event.target.value,
+                        })
+                      }
+                    />
+                  </label>
+                  <label>
+                    <span>Hit Dice</span>
+                    <input
+                      type="text"
+                      value={sheet.combat.hitDice}
+                      onChange={(event) =>
+                        dispatch({
+                          type: 'setField',
+                          path: ['combat', 'hitDice'],
+                          value: event.target.value,
+                        })
+                      }
+                    />
+                  </label>
+                </div>
+                <DeathSavesTracker
+                  successes={sheet.combat.deathSaves.successes}
+                  failures={sheet.combat.deathSaves.failures}
+                  onChange={handleDeathSaveChange}
+                />
+                <AttacksEditor
+                  attacks={sheet.combat.attacks}
+                  onChange={handleAttackChange}
+                  onAdd={handleAttackAdd}
+                  onRemove={handleAttackRemove}
+                />
+              </CharacterSheetSection>
+
+              <CharacterSheetSection
+                title="Spellcasting"
+                description="Spellcasting ability, DC, attack bonus, and spell lists."
+              >
+                <div className="dnd-spellcasting-grid">
+                  <label>
+                    <span>Spellcasting Ability</span>
+                    <select
+                      value={sheet.spellcasting.ability}
+                      onChange={(event) =>
+                        dispatch({
+                          type: 'setField',
+                          path: ['spellcasting', 'ability'],
+                          value: event.target.value,
+                        })
+                      }
+                    >
+                      <option value="str">Strength</option>
+                      <option value="dex">Dexterity</option>
+                      <option value="con">Constitution</option>
+                      <option value="int">Intelligence</option>
+                      <option value="wis">Wisdom</option>
+                      <option value="cha">Charisma</option>
+                    </select>
+                  </label>
+                  <label>
+                    <span>Spell Save DC</span>
+                    <input
+                      type="text"
+                      value={sheet.spellcasting.saveDc}
+                      onChange={(event) =>
+                        dispatch({
+                          type: 'setField',
+                          path: ['spellcasting', 'saveDc'],
+                          value: event.target.value,
+                        })
+                      }
+                      placeholder={`Suggested ${derived.spellcasting.suggestedSaveDc}`}
+                    />
+                  </label>
+                  <label>
+                    <span>Spell Attack Bonus</span>
+                    <input
+                      type="text"
+                      value={sheet.spellcasting.attackBonus}
+                      onChange={(event) =>
+                        dispatch({
+                          type: 'setField',
+                          path: ['spellcasting', 'attackBonus'],
+                          value: event.target.value,
+                        })
+                      }
+                      placeholder={`Suggested ${formatModifier(
+                        derived.spellcasting.suggestedAttackBonus
+                      )}`}
+                    />
+                  </label>
+                </div>
+                <label>
+                  <span>Prepared Spells</span>
+                  <textarea
+                    value={sheet.spellcasting.prepared}
+                    onChange={(event) =>
+                      dispatch({
+                        type: 'setField',
+                        path: ['spellcasting', 'prepared'],
+                        value: event.target.value,
+                      })
+                    }
+                    rows={3}
+                  />
+                </label>
+                <label>
+                  <span>Known Spells</span>
+                  <textarea
+                    value={sheet.spellcasting.known}
+                    onChange={(event) =>
+                      dispatch({
+                        type: 'setField',
+                        path: ['spellcasting', 'known'],
+                        value: event.target.value,
+                      })
+                    }
+                    rows={3}
+                  />
+                </label>
+                <label>
+                  <span>Spell Notes</span>
+                  <textarea
+                    value={sheet.spellcasting.notes}
+                    onChange={(event) =>
+                      dispatch({
+                        type: 'setField',
+                        path: ['spellcasting', 'notes'],
+                        value: event.target.value,
+                      })
+                    }
+                    rows={3}
+                  />
+                </label>
+              </CharacterSheetSection>
+
+              <CharacterSheetSection
+                title="Inventory & Resources"
+                description="Currency, equipment, features, and senses."
+              >
+                <CurrencyInputs values={sheet.equipment} onChange={handleCurrencyChange} />
+                <label>
+                  <span>Inventory</span>
+                  <textarea
+                    value={sheet.equipment.inventory}
+                    onChange={(event) =>
+                      dispatch({
+                        type: 'setField',
+                        path: ['equipment', 'inventory'],
+                        value: event.target.value,
+                      })
+                    }
+                    rows={3}
+                  />
+                </label>
+                <label>
+                  <span>Treasure &amp; Magic Items</span>
+                  <textarea
+                    value={sheet.equipment.treasure}
+                    onChange={(event) =>
+                      dispatch({
+                        type: 'setField',
+                        path: ['equipment', 'treasure'],
+                        value: event.target.value,
+                      })
+                    }
+                    rows={3}
+                  />
+                </label>
+                <label>
+                  <span>Other Equipment</span>
+                  <textarea
+                    value={sheet.equipment.other}
+                    onChange={(event) =>
+                      dispatch({
+                        type: 'setField',
+                        path: ['equipment', 'other'],
+                        value: event.target.value,
+                      })
+                    }
+                    rows={3}
+                  />
+                </label>
+                <label>
+                  <span>Features &amp; Traits</span>
+                  <textarea
+                    value={sheet.features}
+                    onChange={(event) =>
+                      dispatch({
+                        type: 'setField',
+                        path: ['features'],
+                        value: event.target.value,
+                      })
+                    }
+                    rows={3}
+                  />
+                </label>
+                <label>
+                  <span>Class Resources</span>
+                  <textarea
+                    value={sheet.resources.features}
+                    onChange={(event) =>
+                      dispatch({
+                        type: 'setField',
+                        path: ['resources', 'features'],
+                        value: event.target.value,
+                      })
+                    }
+                    rows={3}
+                  />
+                </label>
+                <label>
+                  <span>Resource Notes</span>
+                  <textarea
+                    value={sheet.resources.notes}
+                    onChange={(event) =>
+                      dispatch({
+                        type: 'setField',
+                        path: ['resources', 'notes'],
+                        value: event.target.value,
+                      })
+                    }
+                    rows={3}
+                  />
+                </label>
+                <label>
+                  <span>Senses</span>
+                  <textarea
+                    value={sheet.senses}
+                    onChange={(event) =>
+                      dispatch({
+                        type: 'setField',
+                        path: ['senses'],
+                        value: event.target.value,
+                      })
+                    }
+                    rows={2}
+                  />
+                </label>
+                <label>
+                  <span>Proficiencies</span>
+                  <textarea
+                    value={sheet.proficiencies}
+                    onChange={(event) =>
+                      dispatch({
+                        type: 'setField',
+                        path: ['proficiencies'],
+                        value: event.target.value,
+                      })
+                    }
+                    rows={2}
+                  />
+                </label>
+                <label>
+                  <span>Languages</span>
+                  <textarea
+                    value={sheet.languages}
+                    onChange={(event) =>
+                      dispatch({
+                        type: 'setField',
+                        path: ['languages'],
+                        value: event.target.value,
+                      })
+                    }
+                    rows={2}
+                  />
+                </label>
+              </CharacterSheetSection>
+
+              <CharacterSheetSection
+                title="Personality & Story"
+                description="Capture roleplaying notes, allies, and backstory."
+              >
+                <label>
+                  <span>Personality Traits</span>
+                  <textarea
+                    value={sheet.personality.traits}
+                    onChange={(event) =>
+                      dispatch({
+                        type: 'setField',
+                        path: ['personality', 'traits'],
+                        value: event.target.value,
+                      })
+                    }
+                    rows={2}
+                  />
+                </label>
+                <label>
+                  <span>Ideals</span>
+                  <textarea
+                    value={sheet.personality.ideals}
+                    onChange={(event) =>
+                      dispatch({
+                        type: 'setField',
+                        path: ['personality', 'ideals'],
+                        value: event.target.value,
+                      })
+                    }
+                    rows={2}
+                  />
+                </label>
+                <label>
+                  <span>Bonds</span>
+                  <textarea
+                    value={sheet.personality.bonds}
+                    onChange={(event) =>
+                      dispatch({
+                        type: 'setField',
+                        path: ['personality', 'bonds'],
+                        value: event.target.value,
+                      })
+                    }
+                    rows={2}
+                  />
+                </label>
+                <label>
+                  <span>Flaws</span>
+                  <textarea
+                    value={sheet.personality.flaws}
+                    onChange={(event) =>
+                      dispatch({
+                        type: 'setField',
+                        path: ['personality', 'flaws'],
+                        value: event.target.value,
+                      })
+                    }
+                    rows={2}
+                  />
+                </label>
+                <label>
+                  <span>Appearance</span>
+                  <textarea
+                    value={sheet.personality.appearance}
+                    onChange={(event) =>
+                      dispatch({
+                        type: 'setField',
+                        path: ['personality', 'appearance'],
+                        value: event.target.value,
+                      })
+                    }
+                    rows={3}
+                  />
+                </label>
+                <label>
+                  <span>Allies &amp; Contacts</span>
+                  <textarea
+                    value={sheet.personality.allies}
+                    onChange={(event) =>
+                      dispatch({
+                        type: 'setField',
+                        path: ['personality', 'allies'],
+                        value: event.target.value,
+                      })
+                    }
+                    rows={3}
+                  />
+                </label>
+                <label>
+                  <span>Organizations</span>
+                  <textarea
+                    value={sheet.personality.organizations}
+                    onChange={(event) =>
+                      dispatch({
+                        type: 'setField',
+                        path: ['personality', 'organizations'],
+                        value: event.target.value,
+                      })
+                    }
+                    rows={3}
+                  />
+                </label>
+                <label>
+                  <span>Backstory</span>
+                  <textarea
+                    value={sheet.personality.backstory}
+                    onChange={(event) =>
+                      dispatch({
+                        type: 'setField',
+                        path: ['personality', 'backstory'],
+                        value: event.target.value,
+                      })
+                    }
+                    rows={4}
+                  />
+                </label>
+                <label>
+                  <span>Notes</span>
+                  <textarea
+                    value={sheet.personality.notes}
+                    onChange={(event) =>
+                      dispatch({
+                        type: 'setField',
+                        path: ['personality', 'notes'],
+                        value: event.target.value,
+                      })
+                    }
+                    rows={3}
+                  />
+                </label>
+              </CharacterSheetSection>
+
+              <CharacterSheetSection
+                title="Vault Output & AI Prefill"
+                description="Control template overrides, vault folder, and optional AI enrichment."
+              >
+                <div className="dnd-template-grid">
+                  <label>
+                    <span>Template Path</span>
+                    <input
+                      type="text"
+                      value={templatePath}
+                      onChange={(event) => setTemplatePath(event.target.value)}
+                      placeholder="Uses default 5e template if blank"
+                    />
+                  </label>
+                  <button type="button" onClick={saveTemplateDefault}>
+                    Save as Default
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setTemplatePath(templateDefault || '')}
+                    disabled={!templateDefault}
+                  >
+                    Use Saved Default
+                  </button>
+                </div>
+                <div className="dnd-template-grid">
+                  <label>
+                    <span>Vault Subdirectory</span>
+                    <input
+                      type="text"
+                      value={directoryOverride}
+                      onChange={(event) => setDirectoryOverride(event.target.value)}
+                      placeholder="Defaults to 20_DM/Players"
+                    />
+                  </label>
+                  <button type="button" onClick={saveDirectoryDefault}>
+                    Save as Default
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setDirectoryOverride(directoryDefault || '')}
+                    disabled={!directoryDefault}
+                  >
+                    Use Saved Default
+                  </button>
+                </div>
+                <label className="dnd-prefill-checkbox">
+                  <input
+                    type="checkbox"
+                    checked={usePrefill}
+                    onChange={(event) => setUsePrefill(event.target.checked)}
+                  />
+                  Ask the AI assistant to prefill narrative sections before saving.
+                </label>
+                <textarea
+                  value={prefillPrompt}
+                  onChange={(event) => setPrefillPrompt(event.target.value)}
+                  rows={3}
+                  placeholder="Optional prompt for the AI (e.g., party goals, tone, secrets)."
+                  disabled={!usePrefill}
+                />
+              </CharacterSheetSection>
+            </div>
+          </div>
+          <footer className="dnd-sheet-submit">
+            <button type="submit" disabled={saving}>
+              {saving ? 'Saving…' : 'Save to Vault'}
+            </button>
+          </footer>
+        </form>
+        <input
+          type="file"
+          ref={fileInputRef}
+          accept="application/json"
+          style={{ display: 'none' }}
+          onChange={handleImportFile}
+        />
+      </div>
     </>
   );
 }
-

--- a/ui/tests/playerSheet.test.js
+++ b/ui/tests/playerSheet.test.js
@@ -1,0 +1,83 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildDerivedStats,
+  createEmptyPlayerSheet,
+  parsePlayerSheetImport,
+  playerSheetReducer,
+  serializeCharacterSheet,
+  serializePlayerSheetToJson,
+} from '../src/lib/playerSheet.js';
+
+test('playerSheetReducer updates nested fields and ability modifiers', () => {
+  let state = createEmptyPlayerSheet();
+  state = playerSheetReducer(state, {
+    type: 'setField',
+    path: ['identity', 'name'],
+    value: 'Lyra Dawn',
+  });
+  state = playerSheetReducer(state, {
+    type: 'setField',
+    path: ['abilityScores', 'int'],
+    value: 16,
+  });
+  state = playerSheetReducer(state, {
+    type: 'toggleSkill',
+    skill: 'arcana',
+  });
+  const derived = buildDerivedStats(state);
+  assert.equal(state.identity.name, 'Lyra Dawn');
+  assert.equal(derived.abilityModifiers.int, 3);
+  assert.equal(derived.skills.arcana.total, 5, 'Arcana should include proficiency bonus');
+});
+
+test('serializeCharacterSheet includes skill totals and Markdown structure', () => {
+  let state = createEmptyPlayerSheet();
+  state = playerSheetReducer(state, {
+    type: 'setField',
+    path: ['identity', 'name'],
+    value: 'Rin the Bold',
+  });
+  state = playerSheetReducer(state, {
+    type: 'setField',
+    path: ['identity', 'class'],
+    value: 'Fighter',
+  });
+  state = playerSheetReducer(state, {
+    type: 'setField',
+    path: ['identity', 'level'],
+    value: 5,
+  });
+  state = playerSheetReducer(state, {
+    type: 'setField',
+    path: ['abilityScores', 'str'],
+    value: 18,
+  });
+  state = playerSheetReducer(state, {
+    type: 'toggleSavingThrow',
+    ability: 'str',
+  });
+  state = playerSheetReducer(state, {
+    type: 'toggleSkill',
+    skill: 'athletics',
+  });
+  const markdown = serializeCharacterSheet(state);
+  assert.match(markdown, /Rin the Bold/);
+  assert.match(markdown, /Class: Fighter/);
+  assert.match(markdown, /Athletics/);
+  assert.match(markdown, /\+7/, 'Athletics should show total bonus');
+});
+
+test('parsePlayerSheetImport restores defaults and custom values', () => {
+  const sheet = createEmptyPlayerSheet();
+  sheet.identity.name = 'Seren';
+  sheet.abilityScores.dex = 14;
+  sheet.skills.stealth.proficient = true;
+  const json = serializePlayerSheetToJson(sheet);
+  const imported = parsePlayerSheetImport(json);
+  assert.equal(imported.identity.name, 'Seren');
+  assert.equal(imported.abilityScores.dex, 14);
+  assert.equal(imported.skills.stealth.proficient, true);
+  assert.ok(Array.isArray(imported.combat.attacks), 'attacks array should exist');
+});


### PR DESCRIPTION
## Summary
- build a Roll20-inspired multi-column D&D 5e player sheet editor with reusable React components, export/import controls, and derived stat calculations
- add player sheet reducer/serialization utilities, a players API helper, and inline notifications for save success or validation errors
- implement a `player_create` Tauri command with template resolution, optional AI prefill, config-aware paths, and unit tests

## Testing
- npm test
- cargo test *(fails: missing glib-2.0 system library in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2ada932988325911efaa83640e412