### PR TITLE
Remove ambient glow from dashboard screen

### DIFF
--- a/ui/src/pages/Dashboard.css
+++ b/ui/src/pages/Dashboard.css
@@ -93,53 +93,11 @@
 }
 
 .screen-ambient-wrap::after {
-  content: "";
-  position: absolute;
-  inset: -18% -12% -20%;
-  border-radius: 36px;
-  background:
-    radial-gradient(115% 105% at 50% 46%, rgba(255, 205, 132, 0.52) 0%, rgba(255, 182, 92, 0.26) 40%, rgba(255, 164, 72, 0.08) 68%, rgba(255, 148, 60, 0) 100%),
-    radial-gradient(160% 140% at 50% 54%, rgba(255, 220, 168, 0.3) 0%, rgba(255, 198, 132, 0.18) 48%, rgba(255, 178, 104, 0.06) 78%, rgba(255, 162, 86, 0) 100%);
-  filter: blur(68px);
-  opacity: 0.58;
-  pointer-events: none;
-  z-index: -2;
-  -webkit-mask-image:
-    radial-gradient(170% 150% at 50% 52%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 38%, rgba(0,0,0,0.75) 64%, rgba(0,0,0,0.25) 84%, rgba(0,0,0,0) 100%),
-    radial-gradient(210% 170% at 25% 35%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 40%, rgba(0,0,0,0.55) 70%, rgba(0,0,0,0.12) 88%, rgba(0,0,0,0) 100%),
-    radial-gradient(210% 170% at 75% 65%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 40%, rgba(0,0,0,0.55) 70%, rgba(0,0,0,0.12) 88%, rgba(0,0,0,0) 100%);
-  -webkit-mask-composite: source-in, source-in;
-  mask-image:
-    radial-gradient(170% 150% at 50% 52%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 38%, rgba(0,0,0,0.75) 64%, rgba(0,0,0,0.25) 84%, rgba(0,0,0,0) 100%),
-    radial-gradient(210% 170% at 25% 35%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 40%, rgba(0,0,0,0.55) 70%, rgba(0,0,0,0.12) 88%, rgba(0,0,0,0) 100%),
-    radial-gradient(210% 170% at 75% 65%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 40%, rgba(0,0,0,0.55) 70%, rgba(0,0,0,0.12) 88%, rgba(0,0,0,0) 100%);
-  mask-composite: intersect, intersect;
+  content: none;
 }
 
 .screen-ambient-video {
-  position: absolute;
-  inset: 0;
-  width: 104%;
-  height: 104%;
-  left: -2%;
-  top: -2%;
-  object-fit: cover;
-  filter: blur(16px) brightness(1.18) saturate(1.35);
-  opacity: 0.32;
-  mix-blend-mode: screen;
-  pointer-events: none;
-  z-index: 0;
-  /* layered masks to keep the core opaque while easing asymmetrical falloff */
-  -webkit-mask-image:
-    radial-gradient(120% 96% at 50% 48%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 44%, rgba(0,0,0,0.85) 64%, rgba(0,0,0,0.35) 80%, rgba(0,0,0,0) 96%),
-    radial-gradient(140% 120% at 18% 26%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 42%, rgba(0,0,0,0.68) 68%, rgba(0,0,0,0.18) 86%, rgba(0,0,0,0) 98%),
-    radial-gradient(140% 120% at 82% 80%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 44%, rgba(0,0,0,0.66) 70%, rgba(0,0,0,0.2) 88%, rgba(0,0,0,0) 100%);
-  -webkit-mask-composite: source-in, source-in;
-  mask-image:
-    radial-gradient(120% 96% at 50% 48%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 44%, rgba(0,0,0,0.85) 64%, rgba(0,0,0,0.35) 80%, rgba(0,0,0,0) 96%),
-    radial-gradient(140% 120% at 18% 26%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 42%, rgba(0,0,0,0.68) 68%, rgba(0,0,0,0.18) 86%, rgba(0,0,0,0) 98%),
-    radial-gradient(140% 120% at 82% 80%, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 44%, rgba(0,0,0,0.66) 70%, rgba(0,0,0,0.2) 88%, rgba(0,0,0,0) 100%);
-  mask-composite: intersect, intersect;
+  display: none;
 }
 
 .screen {


### PR DESCRIPTION
## Summary
- remove the ambient ::after gradient and blurred video from the dashboard screen wrapper
- ensure the display focuses solely on the main screen content without the glowing halo

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3106d178c83258d94f5fd3d34b581