### PR TITLE
Add /commands entry to Discord command summaries

### DIFF
--- a/discord_bot.py
+++ b/discord_bot.py
@@ -21,6 +21,7 @@ COMMAND_SUMMARIES = [
     ("/lore <query>", "Query lore notes and generate a response."),
     ("/note <path> <text>", "Append a timestamped entry to a note."),
     ("/track <stat> <delta>", "Update a combat tracker statistic."),
+    ("/commands", "List Blossom's available slash commands."),
     ("/scene as <voice>", "Switch the narrator TTS voice."),
     ("/export session", "Export the current session log."),
 ]


### PR DESCRIPTION
## Summary
- add the /commands slash command to the shared command summary list so it appears in bot help text and UI help

## Testing
- pytest tests/test_discord_permissions.py::test_commands_list_includes_all_entries

------
https://chatgpt.com/codex/tasks/task_e_68d37641a8708325978c458d66685b6c