### PR TITLE
Add D&D world inventory management UI and tests

### DIFF
--- a/ui/src/api/worldInventory.js
+++ b/ui/src/api/worldInventory.js
@@ -1,0 +1,26 @@
+import { invoke } from '@tauri-apps/api/core';
+
+export function fetchWorldInventorySnapshot() {
+  return invoke('world_inventory_fetch');
+}
+
+export function persistWorldInventoryItem(itemId, changes) {
+  return invoke('world_inventory_update_item', { itemId, changes });
+}
+
+export function moveWorldInventoryItem(itemId, targets) {
+  return invoke('world_inventory_move_item', { itemId, targets });
+}
+
+export function createWorldInventoryLedgerEntry(itemId, entry) {
+  return invoke('world_inventory_create_ledger_entry', { itemId, entry });
+}
+
+export function updateWorldInventoryLedgerEntry(itemId, entryId, entry) {
+  return invoke('world_inventory_update_ledger_entry', { itemId, entryId, entry });
+}
+
+export function deleteWorldInventoryLedgerEntry(itemId, entryId) {
+  return invoke('world_inventory_delete_ledger_entry', { itemId, entryId });
+}
+

--- a/ui/src/lib/worldInventoryState.js
+++ b/ui/src/lib/worldInventoryState.js
@@ -1,0 +1,718 @@
+import { createContext, createElement, useContext, useEffect, useMemo, useReducer } from 'react';
+import {
+  fetchWorldInventorySnapshot,
+  persistWorldInventoryItem,
+  moveWorldInventoryItem,
+  createWorldInventoryLedgerEntry,
+  updateWorldInventoryLedgerEntry,
+  deleteWorldInventoryLedgerEntry,
+} from '../api/worldInventory.js';
+
+function slugify(value, fallback = 'item') {
+  const base = value ?? fallback ?? '';
+  return String(base)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+    .replace(/--+/g, '-')
+    || String(fallback ?? 'item');
+}
+
+function stableHash(input) {
+  const str = typeof input === 'string' ? input : JSON.stringify(input ?? '');
+  let hash = 0;
+  for (let i = 0; i < str.length; i += 1) {
+    hash = (hash * 31 + str.charCodeAt(i)) | 0;
+  }
+  const normalized = (hash >>> 0).toString(36);
+  return normalized.padStart(6, '0');
+}
+
+function uniqueStrings(values) {
+  const out = [];
+  const seen = new Set();
+  if (!Array.isArray(values)) return out;
+  for (const value of values) {
+    if (value === undefined || value === null) continue;
+    const str = String(value).trim();
+    if (!str) continue;
+    const lower = str.toLowerCase();
+    if (seen.has(lower)) continue;
+    seen.add(lower);
+    out.push(str);
+  }
+  return out;
+}
+
+function ensureStableId(prefix, entity, fallbackKey = '') {
+  if (entity && typeof entity === 'object') {
+    for (const key of ['id', 'uuid', 'guid', 'slug', 'key', 'identifier']) {
+      const candidate = entity[key];
+      if (candidate !== undefined && candidate !== null && String(candidate).trim()) {
+        return String(candidate).trim();
+      }
+    }
+    const label = entity.name || entity.title || entity.label;
+    if (label) {
+      const slug = slugify(label);
+      const hash = stableHash(
+        `${label}::${entity.createdAt ?? entity.created_at ?? ''}::${entity.origin ?? entity.provenance ?? ''}::${fallbackKey}`
+      );
+      return `${prefix}-${slug}-${hash}`;
+    }
+  }
+  const fallback = stableHash(`${prefix}::${fallbackKey}`);
+  return `${prefix}-${fallback}`;
+}
+
+function toNumber(value, fallback = 0) {
+  if (value === '' || value === null || value === undefined) return fallback;
+  const num = Number(value);
+  if (!Number.isFinite(num)) return fallback;
+  return num;
+}
+
+function normalizeTimestamp(value) {
+  if (value === null || value === undefined) return '';
+  if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) return '';
+    return value.toISOString();
+  }
+  const str = String(value).trim();
+  if (!str) return '';
+  const parsed = new Date(str);
+  if (Number.isNaN(parsed.getTime())) {
+    const num = Number(str);
+    if (Number.isFinite(num)) {
+      const fromNum = new Date(num);
+      if (!Number.isNaN(fromNum.getTime())) {
+        return fromNum.toISOString();
+      }
+    }
+    return str;
+  }
+  return parsed.toISOString();
+}
+
+function normalizeAttunement(raw) {
+  if (!raw || typeof raw !== 'object') {
+    const required = raw === true;
+    return {
+      required,
+      restrictions: [],
+      notes: '',
+      attunedTo: [],
+    };
+  }
+  const required = Boolean(raw.required ?? raw.isRequired ?? raw.mandatory);
+  const notes = raw.notes ? String(raw.notes) : '';
+  const restrictions = uniqueStrings(raw.restrictions ?? raw.limits ?? []);
+  const attunedTo = uniqueStrings(
+    raw.attunedTo ?? raw.boundTo ?? raw.by ?? raw.attuned ?? []
+  );
+  return {
+    required,
+    restrictions,
+    notes,
+    attunedTo,
+  };
+}
+
+function normalizeCharges(raw) {
+  if (!raw || typeof raw !== 'object') {
+    const value = toNumber(raw, 0);
+    return {
+      current: value,
+      maximum: value,
+      recharge: '',
+    };
+  }
+  const maximum = Math.max(0, toNumber(raw.maximum ?? raw.max ?? raw.capacity ?? 0, 0));
+  const current = Math.min(maximum, Math.max(0, toNumber(raw.current ?? raw.value ?? maximum, maximum)));
+  const recharge = raw.recharge ? String(raw.recharge) : '';
+  return {
+    current,
+    maximum,
+    recharge,
+  };
+}
+
+function normalizeDurability(raw) {
+  if (!raw || typeof raw !== 'object') {
+    const value = toNumber(raw, 0);
+    return {
+      current: value,
+      maximum: value,
+      state: value <= 0 ? 'broken' : 'stable',
+      notes: '',
+    };
+  }
+  const maximum = Math.max(0, toNumber(raw.maximum ?? raw.max ?? raw.capacity ?? raw.total ?? 0, 0));
+  const current = Math.min(maximum, Math.max(0, toNumber(raw.current ?? raw.value ?? maximum, maximum)));
+  const state = raw.state
+    ? String(raw.state)
+    : raw.condition
+    ? String(raw.condition)
+    : current <= 0
+    ? 'broken'
+    : 'stable';
+  const notes = raw.notes ? String(raw.notes) : '';
+  return {
+    current,
+    maximum,
+    state,
+    notes,
+  };
+}
+
+function normalizeLedgerEntry(entry, fallbackKey) {
+  if (!entry) return null;
+  const id = ensureStableId('ledger', entry, fallbackKey);
+  const actor = entry.actor ? String(entry.actor) : '';
+  const action = entry.action ? String(entry.action) : '';
+  const notes = entry.notes ? String(entry.notes) : '';
+  const timestamp = normalizeTimestamp(
+    entry.timestamp ?? entry.date ?? entry.recordedAt ?? entry.recorded_at ?? ''
+  );
+  return {
+    id,
+    actor,
+    action,
+    notes,
+    timestamp,
+  };
+}
+
+function normalizeProvenance(raw, itemId) {
+  if (!raw || typeof raw !== 'object') {
+    return {
+      origin: '',
+      ledger: [],
+    };
+  }
+  const origin = raw.origin ? String(raw.origin) : '';
+  const ledgerSource = Array.isArray(raw.ledger) ? raw.ledger : Array.isArray(raw) ? raw : [];
+  const ledger = ledgerSource
+    .map((entry, index) => normalizeLedgerEntry(entry, `${itemId}-${index}`))
+    .filter(Boolean)
+    .sort((a, b) => {
+      const aTime = a.timestamp || '';
+      const bTime = b.timestamp || '';
+      if (aTime === bTime) return a.id.localeCompare(b.id);
+      return bTime.localeCompare(aTime);
+    });
+  return {
+    origin,
+    ledger,
+  };
+}
+
+function normalizeLink(value, prefix) {
+  if (!value && value !== 0) return '';
+  if (typeof value === 'object') {
+    return ensureStableId(prefix, value);
+  }
+  return String(value);
+}
+
+function normalizeItem(raw) {
+  const id = ensureStableId('item', raw, raw?.name ?? raw?.title ?? raw?.slug ?? 'item');
+  const name = raw?.name || raw?.title || 'Unnamed Item';
+  const rarity = raw?.rarity ? String(raw.rarity).toLowerCase() : 'common';
+  const type = raw?.type ? String(raw.type) : '';
+  const tags = uniqueStrings(raw?.tags || []);
+  const quests = uniqueStrings(raw?.quests || []);
+  const tagsLower = tags.map((tag) => tag.toLowerCase());
+  const questsLower = quests.map((quest) => quest.toLowerCase());
+  const attunement = normalizeAttunement(raw?.attunement);
+  const charges = normalizeCharges(raw?.charges);
+  const durability = normalizeDurability(raw?.durability);
+  const provenance = normalizeProvenance(raw?.provenance ?? {}, id);
+  const description = raw?.description ? String(raw.description) : '';
+  const notes = raw?.notes ? String(raw.notes) : '';
+  const ownerId = normalizeLink(raw?.ownerId ?? raw?.owner?.id, 'owner');
+  const containerId = normalizeLink(raw?.containerId ?? raw?.container?.id, 'container');
+  const locationId = normalizeLink(raw?.locationId ?? raw?.location?.id, 'location');
+  const weight = raw?.weight !== undefined ? toNumber(raw.weight, null) : null;
+  const createdAt = raw?.createdAt ?? raw?.created_at ?? '';
+  const updatedAt = raw?.updatedAt ?? raw?.updated_at ?? '';
+
+  const searchParts = [
+    name,
+    rarity,
+    type,
+    tags.join(' '),
+    quests.join(' '),
+    description,
+    notes,
+    provenance.origin,
+    attunement.notes,
+    attunement.restrictions?.join(' ') ?? '',
+  ];
+  for (const entry of provenance.ledger) {
+    searchParts.push(entry.actor, entry.action, entry.notes, entry.timestamp);
+  }
+
+  return {
+    id,
+    name,
+    rarity,
+    type,
+    tags,
+    tagsLower,
+    quests,
+    questsLower,
+    attunement,
+    charges,
+    durability,
+    provenance,
+    description,
+    notes,
+    ownerId,
+    containerId,
+    locationId,
+    weight,
+    createdAt,
+    updatedAt,
+    searchText: searchParts
+      .filter(Boolean)
+      .join(' ')
+      .toLowerCase(),
+    sortKey: `${name}`.toLowerCase(),
+  };
+}
+
+function normalizeEntity(raw, prefix) {
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
+  const id = ensureStableId(prefix, raw, raw?.name ?? raw?.title ?? raw?.label ?? prefix);
+  const name = raw?.name || raw?.title || raw?.label || id;
+  const summary = raw?.summary || raw?.description || '';
+  const tags = uniqueStrings(raw?.tags || []);
+  const quests = uniqueStrings(raw?.quests || []);
+  return {
+    id,
+    name,
+    summary: String(summary || ''),
+    tags,
+    tagsLower: tags.map((tag) => tag.toLowerCase()),
+    quests,
+    questsLower: quests.map((quest) => quest.toLowerCase()),
+    type: raw?.type ? String(raw.type) : '',
+    locationId: normalizeLink(raw?.locationId ?? raw?.location?.id, 'location'),
+  };
+}
+
+function buildCollection(list, prefix, normalizer) {
+  const byId = Object.create(null);
+  const ids = [];
+  if (Array.isArray(list)) {
+    for (const entry of list) {
+      const normalized = normalizer(entry, prefix);
+      if (!normalized || !normalized.id) continue;
+      if (!byId[normalized.id]) {
+        ids.push(normalized.id);
+      }
+      byId[normalized.id] = normalized;
+    }
+  }
+  ids.sort((a, b) => {
+    const itemA = byId[a];
+    const itemB = byId[b];
+    const nameA = itemA?.name ? itemA.name.toLowerCase() : '';
+    const nameB = itemB?.name ? itemB.name.toLowerCase() : '';
+    if (nameA !== nameB) return nameA.localeCompare(nameB);
+    return a.localeCompare(b);
+  });
+  return { byId, allIds: ids };
+}
+
+function buildItemCollection(list) {
+  const byId = Object.create(null);
+  const ids = [];
+  if (Array.isArray(list)) {
+    for (const entry of list) {
+      const normalized = normalizeItem(entry);
+      if (!normalized?.id) continue;
+      if (!byId[normalized.id]) {
+        ids.push(normalized.id);
+      }
+      byId[normalized.id] = normalized;
+    }
+  }
+  ids.sort((a, b) => {
+    const itemA = byId[a];
+    const itemB = byId[b];
+    const nameA = itemA?.sortKey ?? '';
+    const nameB = itemB?.sortKey ?? '';
+    if (nameA !== nameB) return nameA.localeCompare(nameB);
+    return a.localeCompare(b);
+  });
+  return { byId, allIds: ids };
+}
+
+function upsertItemCollection(collection, item) {
+  const byId = { ...collection.byId, [item.id]: item };
+  const ids = collection.allIds.includes(item.id)
+    ? collection.allIds.slice()
+    : [...collection.allIds, item.id];
+  ids.sort((a, b) => {
+    const itemA = byId[a];
+    const itemB = byId[b];
+    const nameA = itemA?.sortKey ?? '';
+    const nameB = itemB?.sortKey ?? '';
+    if (nameA !== nameB) return nameA.localeCompare(nameB);
+    return a.localeCompare(b);
+  });
+  return { byId, allIds: ids };
+}
+
+function upsertCollection(collection, entity) {
+  const byId = { ...collection.byId, [entity.id]: entity };
+  const ids = collection.allIds.includes(entity.id)
+    ? collection.allIds.slice()
+    : [...collection.allIds, entity.id];
+  ids.sort((a, b) => {
+    const entityA = byId[a];
+    const entityB = byId[b];
+    const nameA = entityA?.name ? entityA.name.toLowerCase() : '';
+    const nameB = entityB?.name ? entityB.name.toLowerCase() : '';
+    if (nameA !== nameB) return nameA.localeCompare(nameB);
+    return a.localeCompare(b);
+  });
+  return { byId, allIds: ids };
+}
+
+function normalizeSnapshot(snapshot) {
+  const safe = snapshot && typeof snapshot === 'object' ? snapshot : {};
+  return {
+    items: buildItemCollection(safe.items || []),
+    containers: buildCollection(safe.containers || [], 'container', normalizeEntity),
+    owners: buildCollection(safe.owners || [], 'owner', normalizeEntity),
+    locations: buildCollection(safe.locations || [], 'location', normalizeEntity),
+  };
+}
+
+function createInitialState() {
+  return {
+    loading: false,
+    loaded: false,
+    error: '',
+    items: { byId: Object.create(null), allIds: [] },
+    containers: { byId: Object.create(null), allIds: [] },
+    owners: { byId: Object.create(null), allIds: [] },
+    locations: { byId: Object.create(null), allIds: [] },
+    filters: {
+      search: '',
+      tags: [],
+      rarities: [],
+      quests: [],
+    },
+    selectedItemId: '',
+    pendingItems: {},
+  };
+}
+
+function worldInventoryReducer(state, action) {
+  switch (action.type) {
+    case 'loadStart':
+      return { ...state, loading: true, error: '' };
+    case 'loadSuccess': {
+      const normalized = normalizeSnapshot(action.snapshot);
+      let selectedItemId = state.selectedItemId;
+      if (!selectedItemId || !normalized.items.byId[selectedItemId]) {
+        selectedItemId = normalized.items.allIds[0] || '';
+      }
+      return {
+        ...state,
+        loading: false,
+        loaded: true,
+        error: '',
+        items: normalized.items,
+        containers: normalized.containers,
+        owners: normalized.owners,
+        locations: normalized.locations,
+        selectedItemId,
+      };
+    }
+    case 'loadError':
+      return { ...state, loading: false, error: action.error || 'Unable to load world inventory.' };
+    case 'selectItem':
+      return { ...state, selectedItemId: action.itemId };
+    case 'setFilters': {
+      const nextFilters = { ...state.filters };
+      if (action.filters.search !== undefined) {
+        nextFilters.search = String(action.filters.search || '');
+      }
+      if (action.filters.tags !== undefined) {
+        nextFilters.tags = uniqueStrings(action.filters.tags).map((tag) =>
+          tag.toLowerCase()
+        );
+      }
+      if (action.filters.rarities !== undefined) {
+        const rarities = uniqueStrings(action.filters.rarities);
+        nextFilters.rarities = rarities.map((rarity) => rarity.toLowerCase());
+      }
+      if (action.filters.quests !== undefined) {
+        nextFilters.quests = uniqueStrings(action.filters.quests).map((quest) =>
+          quest.toLowerCase()
+        );
+      }
+      return { ...state, filters: nextFilters };
+    }
+    case 'upsertItem': {
+      const normalizedItem = normalizeItem(action.item);
+      const items = upsertItemCollection(state.items, normalizedItem);
+      const selectedItemId = action.select ? normalizedItem.id : state.selectedItemId;
+      return {
+        ...state,
+        items,
+        selectedItemId: selectedItemId && items.byId[selectedItemId] ? selectedItemId : items.allIds[0] || '',
+      };
+    }
+    case 'setCollections': {
+      return {
+        ...state,
+        containers:
+          action.containers !== undefined
+            ? buildCollection(action.containers, 'container', normalizeEntity)
+            : state.containers,
+        owners:
+          action.owners !== undefined
+            ? buildCollection(action.owners, 'owner', normalizeEntity)
+            : state.owners,
+        locations:
+          action.locations !== undefined
+            ? buildCollection(action.locations, 'location', normalizeEntity)
+            : state.locations,
+      };
+    }
+    case 'setPending': {
+      const next = { ...state.pendingItems };
+      if (action.pending) {
+        next[action.itemId] = true;
+      } else {
+        delete next[action.itemId];
+      }
+      return { ...state, pendingItems: next };
+    }
+    case 'setError':
+      return { ...state, error: action.error || '' };
+    case 'clearError':
+      return { ...state, error: '' };
+    default:
+      return state;
+  }
+}
+
+function filterItems(itemsCollection, filters, lookups = {}) {
+  const owners = lookups.owners || { byId: {} };
+  const containers = lookups.containers || { byId: {} };
+  const locations = lookups.locations || { byId: {} };
+  const search = (filters.search || '').trim().toLowerCase();
+  const tagFilters = Array.isArray(filters.tags)
+    ? filters.tags.map((tag) => String(tag).toLowerCase())
+    : [];
+  const rarityFilters = Array.isArray(filters.rarities)
+    ? filters.rarities.map((rarity) => String(rarity).toLowerCase())
+    : [];
+  const questFilters = Array.isArray(filters.quests)
+    ? filters.quests.map((quest) => String(quest).toLowerCase())
+    : [];
+  const tagSet = new Set(tagFilters);
+  const raritySet = new Set(rarityFilters);
+  const questSet = new Set(questFilters);
+
+  return itemsCollection.allIds
+    .map((id) => itemsCollection.byId[id])
+    .filter(Boolean)
+    .filter((item) => {
+      if (search) {
+        const ownerName = owners.byId[item.ownerId]?.name ?? '';
+        const containerName = containers.byId[item.containerId]?.name ?? '';
+        const locationName = locations.byId[item.locationId]?.name ?? '';
+        const haystack = `${item.searchText} ${ownerName} ${containerName} ${locationName}`;
+        if (!haystack.toLowerCase().includes(search)) {
+          return false;
+        }
+      }
+      if (tagSet.size) {
+        for (const tag of tagSet) {
+          if (!item.tagsLower.includes(tag)) {
+            return false;
+          }
+        }
+      }
+      if (raritySet.size && !raritySet.has(item.rarity.toLowerCase())) {
+        return false;
+      }
+      if (questSet.size) {
+        for (const quest of questSet) {
+          if (!item.questsLower.includes(quest)) {
+            return false;
+          }
+        }
+      }
+      return true;
+    });
+}
+
+const WorldInventoryContext = createContext(null);
+
+const defaultApi = {
+  fetchSnapshot: fetchWorldInventorySnapshot,
+  updateItem: persistWorldInventoryItem,
+  moveItem: moveWorldInventoryItem,
+  createLedgerEntry: createWorldInventoryLedgerEntry,
+  updateLedgerEntry: updateWorldInventoryLedgerEntry,
+  deleteLedgerEntry: deleteWorldInventoryLedgerEntry,
+};
+
+function extractItemFromResponse(payload) {
+  if (!payload) return null;
+  if (payload.item) return payload.item;
+  if (payload.data?.item) return payload.data.item;
+  if (Array.isArray(payload.items)) {
+    return payload.items[0];
+  }
+  return payload;
+}
+
+export function WorldInventoryProvider({ children, api: apiOverride }) {
+  const [state, dispatch] = useReducer(worldInventoryReducer, undefined, createInitialState);
+
+  const api = useMemo(() => ({ ...defaultApi, ...(apiOverride || {}) }), [apiOverride]);
+
+  useEffect(() => {
+    let cancelled = false;
+    dispatch({ type: 'loadStart' });
+    api.fetchSnapshot()
+      .then((snapshot) => {
+        if (cancelled) return;
+        dispatch({ type: 'loadSuccess', snapshot });
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        console.warn('Failed to load world inventory', error);
+        dispatch({
+          type: 'loadError',
+          error:
+            (error && typeof error.message === 'string' && error.message) ||
+            'Unable to load world inventory.',
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [api]);
+
+  const actions = useMemo(() => {
+    const handleItemResponse = (response, options = {}) => {
+      if (response && response.containers) {
+        dispatch({ type: 'setCollections', containers: response.containers });
+      }
+      if (response && response.owners) {
+        dispatch({ type: 'setCollections', owners: response.owners });
+      }
+      if (response && response.locations) {
+        dispatch({ type: 'setCollections', locations: response.locations });
+      }
+      const item = extractItemFromResponse(response);
+      if (item) {
+        dispatch({ type: 'upsertItem', item, select: options.select });
+      }
+      return item;
+    };
+
+    const wrapMutation = async (itemId, mutate, options = {}) => {
+      dispatch({ type: 'clearError' });
+      if (itemId) {
+        dispatch({ type: 'setPending', itemId, pending: true });
+      }
+      try {
+        const result = await mutate();
+        return handleItemResponse(result, options);
+      } catch (error) {
+        console.warn('World inventory mutation failed', error);
+        dispatch({
+          type: 'setError',
+          error:
+            (error && typeof error.message === 'string' && error.message) ||
+            'Unable to update item.',
+        });
+        throw error;
+      } finally {
+        if (itemId) {
+          dispatch({ type: 'setPending', itemId, pending: false });
+        }
+      }
+    };
+
+    return {
+      refresh: async () => {
+        dispatch({ type: 'loadStart' });
+        try {
+          const snapshot = await api.fetchSnapshot();
+          dispatch({ type: 'loadSuccess', snapshot });
+        } catch (error) {
+          console.warn('Failed to refresh world inventory', error);
+          dispatch({
+            type: 'loadError',
+            error:
+              (error && typeof error.message === 'string' && error.message) ||
+              'Unable to load world inventory.',
+          });
+          throw error;
+        }
+      },
+      selectItem: (itemId) => dispatch({ type: 'selectItem', itemId }),
+      setFilters: (filters) => dispatch({ type: 'setFilters', filters }),
+      updateItem: (itemId, changes) =>
+        wrapMutation(itemId, () => api.updateItem(itemId, changes), { select: true }),
+      adjustCharges: (itemId, charges) =>
+        wrapMutation(itemId, () => api.updateItem(itemId, { charges }), { select: true }),
+      adjustDurability: (itemId, durability) =>
+        wrapMutation(itemId, () => api.updateItem(itemId, { durability }), { select: true }),
+      moveItem: (itemId, targets) =>
+        wrapMutation(itemId, () => api.moveItem(itemId, targets), { select: true }),
+      addLedgerEntry: (itemId, entry) =>
+        wrapMutation(itemId, () => api.createLedgerEntry(itemId, entry), { select: true }),
+      updateLedgerEntry: (itemId, entryId, entry) =>
+        wrapMutation(itemId, () => api.updateLedgerEntry(itemId, entryId, entry), {
+          select: true,
+        }),
+      deleteLedgerEntry: (itemId, entryId) =>
+        wrapMutation(itemId, () => api.deleteLedgerEntry(itemId, entryId), { select: true }),
+    };
+  }, [api]);
+
+  const value = useMemo(
+    () => ({
+      state,
+      actions,
+    }),
+    [state, actions]
+  );
+
+  return createElement(WorldInventoryContext.Provider, { value }, children);
+}
+
+export function useWorldInventory() {
+  const ctx = useContext(WorldInventoryContext);
+  if (!ctx) {
+    throw new Error('useWorldInventory must be used within a WorldInventoryProvider');
+  }
+  return ctx;
+}
+
+export {
+  createInitialState as createWorldInventoryInitialState,
+  worldInventoryReducer,
+  normalizeItem,
+  normalizeEntity,
+  normalizeSnapshot,
+  ensureStableId,
+  filterItems,
+};
+

--- a/ui/src/pages/DndDmWorldInventory.css
+++ b/ui/src/pages/DndDmWorldInventory.css
@@ -1,0 +1,424 @@
+.world-inventory-layout {
+  margin-top: var(--space-xl);
+  display: grid;
+  grid-template-columns: minmax(320px, 360px) minmax(460px, 1fr) minmax(240px, 300px);
+  gap: var(--space-xl);
+  align-items: flex-start;
+}
+
+@media (max-width: 1200px) {
+  .world-inventory-layout {
+    grid-template-columns: minmax(280px, 320px) minmax(420px, 1fr);
+    grid-template-areas:
+      'list detail'
+      'sidebar sidebar';
+  }
+  .world-inventory-layout > .wi-sidebar {
+    grid-column: 1 / -1;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: var(--space-lg);
+  }
+}
+
+@media (max-width: 900px) {
+  .world-inventory-layout {
+    grid-template-columns: 1fr;
+  }
+  .world-inventory-layout > .wi-sidebar {
+    grid-template-columns: 1fr;
+  }
+}
+
+.wi-panel,
+.wi-detail,
+.wi-entity-section {
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 16px;
+  padding: var(--space-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  color: var(--text);
+}
+
+.wi-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+}
+
+.wi-panel-header h2,
+.wi-panel-header h3 {
+  margin: 0;
+}
+
+.wi-panel-header button {
+  align-self: flex-start;
+}
+
+.wi-filter-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.wi-filter-panel label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.wi-filter-panel input,
+.wi-filter-panel select,
+.wi-panel select,
+.wi-panel input,
+.wi-panel textarea {
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 12px;
+  padding: 0.5rem 0.75rem;
+  color: var(--text);
+  font: inherit;
+}
+
+.wi-filter-panel input:focus,
+.wi-filter-panel select:focus,
+.wi-panel select:focus,
+.wi-panel input:focus,
+.wi-panel textarea:focus {
+  outline: none;
+  border-color: rgba(96, 165, 250, 0.6);
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.25);
+}
+
+.wi-filter-chips {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.wi-filter-label {
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.wi-chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.wi-chip {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.6);
+  color: rgba(226, 232, 240, 0.9);
+  padding: 0.35rem 0.75rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.wi-chip.is-selected {
+  background: rgba(37, 99, 235, 0.25);
+  border-color: rgba(96, 165, 250, 0.6);
+}
+
+.wi-chip:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.45);
+}
+
+.wi-item-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.wi-item {
+  width: 100%;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 14px;
+  padding: 0.75rem 1rem;
+  background: rgba(15, 23, 42, 0.55);
+  color: var(--text);
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
+}
+
+.wi-item:hover,
+.wi-item:focus-visible {
+  outline: none;
+  border-color: rgba(96, 165, 250, 0.45);
+  background: rgba(37, 99, 235, 0.18);
+  transform: translateY(-1px);
+}
+
+.wi-item.is-selected {
+  border-color: rgba(129, 140, 248, 0.65);
+  background: rgba(99, 102, 241, 0.25);
+}
+
+.wi-item-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.wi-item-name {
+  font-weight: 600;
+}
+
+.wi-item-rarity {
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.75);
+  text-transform: capitalize;
+}
+
+.wi-item-sub {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.wi-item-tags,
+.wi-entity-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.wi-tag {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 12px;
+  padding: 0.15rem 0.5rem;
+  font-size: 0.75rem;
+  text-transform: capitalize;
+}
+
+.wi-detail {
+  gap: var(--space-lg);
+}
+
+.wi-detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+}
+
+.wi-detail-header h2 {
+  margin: 0;
+}
+
+.wi-detail-sub {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.wi-detail-description,
+.wi-detail-attunement,
+.wi-detail-attuned,
+.wi-detail-notes {
+  margin: 0;
+  line-height: 1.6;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.wi-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-lg);
+}
+
+.wi-panel label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.wi-panel textarea {
+  resize: vertical;
+}
+
+.wi-status {
+  font-size: 0.85rem;
+  color: rgba(96, 165, 250, 0.85);
+}
+
+.wi-error {
+  margin: 0;
+  padding: 0.5rem 0.75rem;
+  border-radius: 12px;
+  background: rgba(248, 113, 113, 0.15);
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  color: #fecaca;
+}
+
+.wi-empty {
+  margin: 0;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.wi-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.wi-entity-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.wi-entity-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.wi-entity-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.35rem;
+}
+
+.wi-entity-name {
+  font-weight: 600;
+}
+
+.wi-entity-type {
+  font-size: 0.8rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.wi-entity-summary {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.7);
+  line-height: 1.5;
+}
+
+.wi-ledger-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.wi-ledger-entry {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 12px;
+  padding: 0.75rem;
+  background: rgba(15, 23, 42, 0.55);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.wi-ledger-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.wi-ledger-action {
+  font-weight: 600;
+}
+
+.wi-ledger-notes {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.wi-ledger-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.wi-ledger-actions button,
+.wi-panel button,
+.wi-ledger-buttons button {
+  background: rgba(37, 99, 235, 0.18);
+  border: 1px solid rgba(96, 165, 250, 0.35);
+  border-radius: 10px;
+  padding: 0.4rem 0.9rem;
+  color: rgba(226, 232, 240, 0.95);
+  font: inherit;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
+}
+
+.wi-ledger-actions button:hover,
+.wi-panel button:hover,
+.wi-ledger-buttons button:hover {
+  border-color: rgba(147, 197, 253, 0.75);
+  background: rgba(37, 99, 235, 0.28);
+  transform: translateY(-1px);
+}
+
+.wi-ledger-buttons {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.wi-provenance-origin {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.wi-detail-column {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.wi-detail textarea,
+.wi-panel textarea,
+.wi-ledger-form textarea {
+  font-family: inherit;
+}
+
+.wi-ledger-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.wi-ledger-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.wi-ledger-time {
+  font-weight: 600;
+}
+
+.wi-ledger-actor {
+  font-style: italic;
+}

--- a/ui/src/pages/DndDmWorldInventory.jsx
+++ b/ui/src/pages/DndDmWorldInventory.jsx
@@ -1,24 +1,701 @@
+import React, { useEffect, useMemo, useState } from 'react';
 import BackButton from '../components/BackButton.jsx';
+import {
+  WorldInventoryProvider,
+  useWorldInventory,
+  filterItems,
+} from '../lib/worldInventoryState.js';
 import './Dnd.css';
+import './DndDmWorldInventory.css';
 
-export default function DndDmWorldInventory() {
+function computeFacets(itemsCollection) {
+  const tagMap = new Map();
+  const rarityMap = new Map();
+  const questMap = new Map();
+  for (const id of itemsCollection.allIds) {
+    const item = itemsCollection.byId[id];
+    if (!item) continue;
+    for (const tag of item.tags) {
+      const key = tag.toLowerCase();
+      const entry = tagMap.get(key) || { value: key, label: tag, count: 0 };
+      if (entry.count === 0) {
+        entry.label = tag;
+      }
+      entry.count += 1;
+      tagMap.set(key, entry);
+    }
+    const rarityKey = (item.rarity || 'common').toLowerCase();
+    const rarityEntry =
+      rarityMap.get(rarityKey) || {
+        value: rarityKey,
+        label: item.rarity || 'common',
+        count: 0,
+      };
+    if (rarityEntry.count === 0) {
+      rarityEntry.label = item.rarity || 'common';
+    }
+    rarityEntry.count += 1;
+    rarityMap.set(rarityKey, rarityEntry);
+    for (const quest of item.quests) {
+      const key = quest.toLowerCase();
+      const entry = questMap.get(key) || { value: key, label: quest, count: 0 };
+      if (entry.count === 0) {
+        entry.label = quest;
+      }
+      entry.count += 1;
+      questMap.set(key, entry);
+    }
+  }
+  const sortByLabel = (a, b) => a.label.toLowerCase().localeCompare(b.label.toLowerCase());
+  return {
+    tags: Array.from(tagMap.values()).sort(sortByLabel),
+    rarities: Array.from(rarityMap.values()).sort(sortByLabel),
+    quests: Array.from(questMap.values()).sort(sortByLabel),
+  };
+}
+
+function formatTimestamp(value) {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime()) || value.length <= 12) {
+    return value;
+  }
+  return date.toLocaleString();
+}
+
+function FilterChip({ label, selected, onToggle }) {
+  return (
+    <button
+      type="button"
+      className={`wi-chip${selected ? ' is-selected' : ''}`}
+      onClick={onToggle}
+    >
+      {label}
+    </button>
+  );
+}
+
+function WorldInventoryFilters({ facets, filters, onFiltersChange }) {
+  const handleSearch = (event) => {
+    onFiltersChange({ search: event.target.value });
+  };
+
+  const handleRarityChange = (event) => {
+    const value = event.target.value;
+    if (value === 'all') {
+      onFiltersChange({ rarities: [] });
+    } else {
+      onFiltersChange({ rarities: [value] });
+    }
+  };
+
+  const toggleTag = (value) => {
+    const selected = filters.tags.includes(value);
+    const next = selected
+      ? filters.tags.filter((existing) => existing !== value)
+      : [...filters.tags, value];
+    onFiltersChange({ tags: next });
+  };
+
+  const toggleQuest = (value) => {
+    const selected = filters.quests.includes(value);
+    const next = selected
+      ? filters.quests.filter((existing) => existing !== value)
+      : [...filters.quests, value];
+    onFiltersChange({ quests: next });
+  };
+
+  return (
+    <div className="wi-filter-panel">
+      <label className="wi-filter-search">
+        <span>Search</span>
+        <input
+          type="search"
+          placeholder="Name, tag, or keyword"
+          value={filters.search}
+          onChange={handleSearch}
+        />
+      </label>
+      <label className="wi-filter-select">
+        <span>Rarity</span>
+        <select value={filters.rarities[0] || 'all'} onChange={handleRarityChange}>
+          <option value="all">All rarities</option>
+          {facets.rarities.map((rarity) => (
+            <option key={rarity.value} value={rarity.value}>
+              {rarity.label} ({rarity.count})
+            </option>
+          ))}
+        </select>
+      </label>
+      <div className="wi-filter-chips">
+        <span className="wi-filter-label">Tags</span>
+        <div className="wi-chip-group">
+          {facets.tags.length === 0 && <p className="wi-empty">No tags recorded.</p>}
+          {facets.tags.map((tag) => (
+            <FilterChip
+              key={tag.value}
+              label={`${tag.label} (${tag.count})`}
+              selected={filters.tags.includes(tag.value)}
+              onToggle={() => toggleTag(tag.value)}
+            />
+          ))}
+        </div>
+      </div>
+      <div className="wi-filter-chips">
+        <span className="wi-filter-label">Quests</span>
+        <div className="wi-chip-group">
+          {facets.quests.length === 0 && <p className="wi-empty">No quests linked.</p>}
+          {facets.quests.map((quest) => (
+            <FilterChip
+              key={quest.value}
+              label={`${quest.label} (${quest.count})`}
+              selected={filters.quests.includes(quest.value)}
+              onToggle={() => toggleQuest(quest.value)}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function WorldInventoryItemList({ items, selectedId, onSelect, lookups }) {
+  if (items.length === 0) {
+    return <p className="wi-empty">No items match the current filters.</p>;
+  }
+  return (
+    <ul className="wi-item-list">
+      {items.map((item) => {
+        const owner = lookups.owners.byId[item.ownerId];
+        const container = lookups.containers.byId[item.containerId];
+        const location = lookups.locations.byId[item.locationId];
+        return (
+          <li key={item.id}>
+            <button
+              type="button"
+              className={`wi-item${selectedId === item.id ? ' is-selected' : ''}`}
+              onClick={() => onSelect(item.id)}
+            >
+              <div className="wi-item-header">
+                <span className="wi-item-name">{item.name}</span>
+                <span className="wi-item-rarity">{item.rarity}</span>
+              </div>
+              <div className="wi-item-sub">
+                {item.type && <span>{item.type}</span>}
+                {owner && <span>Owner: {owner.name}</span>}
+                {container && <span>Container: {container.name}</span>}
+                {location && <span>Location: {location.name}</span>}
+              </div>
+              <div className="wi-item-tags">
+                {item.tags.map((tag) => (
+                  <span key={tag} className="wi-tag">
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function InventoryEntitySection({ title, collection }) {
+  const entries = collection.allIds.map((id) => collection.byId[id]).filter(Boolean);
+  return (
+    <section className="wi-entity-section">
+      <h2>{title}</h2>
+      {entries.length === 0 && <p className="wi-empty">No records yet.</p>}
+      <ul className="wi-entity-list">
+        {entries.map((entry) => (
+          <li key={entry.id} className="wi-entity-item">
+            <div className="wi-entity-head">
+              <span className="wi-entity-name">{entry.name}</span>
+              {entry.type && <span className="wi-entity-type">{entry.type}</span>}
+            </div>
+            {entry.summary && <p className="wi-entity-summary">{entry.summary}</p>}
+            {entry.tags.length > 0 && (
+              <div className="wi-entity-tags">
+                {entry.tags.map((tag) => (
+                  <span key={tag} className="wi-tag">
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function ProvenanceLedger({ item, pending, onCreate, onUpdate, onDelete }) {
+  const [mode, setMode] = useState('view');
+  const [editingId, setEditingId] = useState('');
+  const [form, setForm] = useState({ timestamp: '', actor: '', action: '', notes: '' });
+
+  useEffect(() => {
+    setMode('view');
+    setEditingId('');
+    setForm({ timestamp: '', actor: '', action: '', notes: '' });
+  }, [item.id]);
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const beginNew = () => {
+    setMode('new');
+    setEditingId('');
+    setForm({ timestamp: new Date().toISOString().slice(0, 16), actor: '', action: '', notes: '' });
+  };
+
+  const beginEdit = (entry) => {
+    setMode('edit');
+    setEditingId(entry.id);
+    setForm({
+      timestamp: entry.timestamp ? entry.timestamp.slice(0, 16) : '',
+      actor: entry.actor,
+      action: entry.action,
+      notes: entry.notes,
+    });
+  };
+
+  const resetForm = () => {
+    setMode('view');
+    setEditingId('');
+    setForm({ timestamp: '', actor: '', action: '', notes: '' });
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    const payload = {
+      timestamp: form.timestamp ? new Date(form.timestamp).toISOString() : '',
+      actor: form.actor,
+      action: form.action,
+      notes: form.notes,
+    };
+    if (mode === 'edit' && editingId) {
+      await onUpdate(editingId, payload);
+    } else {
+      await onCreate(payload);
+    }
+    resetForm();
+  };
+
+  const handleDelete = async (entryId) => {
+    await onDelete(entryId);
+    if (editingId === entryId) {
+      resetForm();
+    }
+  };
+
+  return (
+    <section className="wi-panel">
+      <div className="wi-panel-header">
+        <h3>Provenance Ledger</h3>
+        <button type="button" onClick={beginNew} disabled={pending}>
+          Add entry
+        </button>
+      </div>
+      {item.provenance.origin && (
+        <p className="wi-provenance-origin">Origin: {item.provenance.origin}</p>
+      )}
+      <ul className="wi-ledger-list">
+        {item.provenance.ledger.length === 0 && (
+          <li className="wi-empty">No provenance entries yet.</li>
+        )}
+        {item.provenance.ledger.map((entry) => (
+          <li key={entry.id} className="wi-ledger-entry">
+            <div className="wi-ledger-meta">
+              <span className="wi-ledger-time">{formatTimestamp(entry.timestamp)}</span>
+              {entry.actor && <span className="wi-ledger-actor">{entry.actor}</span>}
+            </div>
+            {entry.action && <div className="wi-ledger-action">{entry.action}</div>}
+            {entry.notes && <p className="wi-ledger-notes">{entry.notes}</p>}
+            <div className="wi-ledger-actions">
+              <button type="button" onClick={() => beginEdit(entry)} disabled={pending}>
+                Edit
+              </button>
+              <button type="button" onClick={() => handleDelete(entry.id)} disabled={pending}>
+                Delete
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+      {(mode === 'new' || mode === 'edit') && (
+        <form className="wi-ledger-form" onSubmit={handleSubmit}>
+          <label>
+            <span>When</span>
+            <input
+              type="datetime-local"
+              name="timestamp"
+              value={form.timestamp}
+              onChange={handleChange}
+              disabled={pending}
+            />
+          </label>
+          <label>
+            <span>Actor</span>
+            <input
+              type="text"
+              name="actor"
+              value={form.actor}
+              onChange={handleChange}
+              disabled={pending}
+            />
+          </label>
+          <label>
+            <span>Action</span>
+            <input
+              type="text"
+              name="action"
+              value={form.action}
+              onChange={handleChange}
+              disabled={pending}
+            />
+          </label>
+          <label>
+            <span>Notes</span>
+            <textarea
+              name="notes"
+              value={form.notes}
+              onChange={handleChange}
+              disabled={pending}
+              rows={3}
+            />
+          </label>
+          <div className="wi-ledger-buttons">
+            <button type="submit" disabled={pending}>
+              {mode === 'edit' ? 'Save changes' : 'Add entry'}
+            </button>
+            <button type="button" onClick={resetForm} disabled={pending}>
+              Cancel
+            </button>
+          </div>
+        </form>
+      )}
+    </section>
+  );
+}
+
+function WorldInventoryDetail({ item, lookups, pending, actions }) {
+  const [chargesForm, setChargesForm] = useState({ current: 0, maximum: 0, recharge: '' });
+  const [durabilityForm, setDurabilityForm] = useState({ current: 0, maximum: 0, state: '', notes: '' });
+  const [origin, setOrigin] = useState('');
+
+  useEffect(() => {
+    setChargesForm({ ...item.charges });
+    setDurabilityForm({ ...item.durability });
+    setOrigin(item.provenance.origin || '');
+  }, [item.id, item.charges, item.durability, item.provenance.origin]);
+
+  const ownerOptions = useMemo(
+    () => lookups.owners.allIds.map((id) => lookups.owners.byId[id]).filter(Boolean),
+    [lookups.owners]
+  );
+  const containerOptions = useMemo(
+    () => lookups.containers.allIds.map((id) => lookups.containers.byId[id]).filter(Boolean),
+    [lookups.containers]
+  );
+  const locationOptions = useMemo(
+    () => lookups.locations.allIds.map((id) => lookups.locations.byId[id]).filter(Boolean),
+    [lookups.locations]
+  );
+
+  const handleChargesChange = (event) => {
+    const { name, value } = event.target;
+    setChargesForm((prev) => ({ ...prev, [name]: name === 'recharge' ? value : Number(value) }));
+  };
+
+  const handleDurabilityChange = (event) => {
+    const { name, value } = event.target;
+    setDurabilityForm((prev) => ({
+      ...prev,
+      [name]: name === 'state' || name === 'notes' ? value : Number(value),
+    }));
+  };
+
+  const submitCharges = async (event) => {
+    event.preventDefault();
+    await actions.adjustCharges(item.id, chargesForm);
+  };
+
+  const submitDurability = async (event) => {
+    event.preventDefault();
+    await actions.adjustDurability(item.id, durabilityForm);
+  };
+
+  const handleMoveChange = async (field, value) => {
+    await actions.moveItem(item.id, {
+      ownerId: field === 'ownerId' ? value : item.ownerId,
+      containerId: field === 'containerId' ? value : item.containerId,
+      locationId: field === 'locationId' ? value : item.locationId,
+    });
+  };
+
+  const updateOrigin = async (event) => {
+    event.preventDefault();
+    await actions.updateItem(item.id, { provenance: { origin } });
+  };
+
+  return (
+    <section className="wi-detail">
+      <header className="wi-detail-header">
+        <div>
+          <h2>{item.name}</h2>
+          <p className="wi-detail-sub">{item.type || 'Item'} · {item.rarity}</p>
+        </div>
+        {pending && <span className="wi-status">Saving…</span>}
+      </header>
+      {item.description && <p className="wi-detail-description">{item.description}</p>}
+      {item.attunement.required && (
+        <p className="wi-detail-attunement">
+          Requires attunement
+          {item.attunement.restrictions.length > 0 &&
+            ` (${item.attunement.restrictions.join(', ')})`}
+        </p>
+      )}
+      {item.attunement.attunedTo.length > 0 && (
+        <p className="wi-detail-attuned">Attuned to: {item.attunement.attunedTo.join(', ')}</p>
+      )}
+      {item.notes && <p className="wi-detail-notes">{item.notes}</p>}
+
+      <div className="wi-detail-grid">
+        <form className="wi-panel" onSubmit={submitCharges}>
+          <div className="wi-panel-header">
+            <h3>Charges</h3>
+            <button type="submit" disabled={pending}>
+              Update
+            </button>
+          </div>
+          <label>
+            <span>Current</span>
+            <input
+              type="number"
+              min="0"
+              name="current"
+              value={chargesForm.current}
+              onChange={handleChargesChange}
+              disabled={pending}
+            />
+          </label>
+          <label>
+            <span>Maximum</span>
+            <input
+              type="number"
+              min="0"
+              name="maximum"
+              value={chargesForm.maximum}
+              onChange={handleChargesChange}
+              disabled={pending}
+            />
+          </label>
+          <label>
+            <span>Recharge</span>
+            <input
+              type="text"
+              name="recharge"
+              value={chargesForm.recharge}
+              onChange={handleChargesChange}
+              disabled={pending}
+            />
+          </label>
+        </form>
+
+        <form className="wi-panel" onSubmit={submitDurability}>
+          <div className="wi-panel-header">
+            <h3>Durability</h3>
+            <button type="submit" disabled={pending}>
+              Update
+            </button>
+          </div>
+          <label>
+            <span>Current</span>
+            <input
+              type="number"
+              min="0"
+              name="current"
+              value={durabilityForm.current}
+              onChange={handleDurabilityChange}
+              disabled={pending}
+            />
+          </label>
+          <label>
+            <span>Maximum</span>
+            <input
+              type="number"
+              min="0"
+              name="maximum"
+              value={durabilityForm.maximum}
+              onChange={handleDurabilityChange}
+              disabled={pending}
+            />
+          </label>
+          <label>
+            <span>Status</span>
+            <input
+              type="text"
+              name="state"
+              value={durabilityForm.state}
+              onChange={handleDurabilityChange}
+              disabled={pending}
+            />
+          </label>
+          <label>
+            <span>Notes</span>
+            <textarea
+              name="notes"
+              value={durabilityForm.notes}
+              rows={3}
+              onChange={handleDurabilityChange}
+              disabled={pending}
+            />
+          </label>
+        </form>
+      </div>
+
+      <section className="wi-panel">
+        <div className="wi-panel-header">
+          <h3>Ownership & Placement</h3>
+        </div>
+        <label>
+          <span>Owner</span>
+          <select
+            value={item.ownerId}
+            onChange={(event) => handleMoveChange('ownerId', event.target.value)}
+            disabled={pending}
+          >
+            <option value="">Unassigned</option>
+            {ownerOptions.map((owner) => (
+              <option key={owner.id} value={owner.id}>
+                {owner.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          <span>Container</span>
+          <select
+            value={item.containerId}
+            onChange={(event) => handleMoveChange('containerId', event.target.value)}
+            disabled={pending}
+          >
+            <option value="">Unassigned</option>
+            {containerOptions.map((container) => (
+              <option key={container.id} value={container.id}>
+                {container.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          <span>Location</span>
+          <select
+            value={item.locationId}
+            onChange={(event) => handleMoveChange('locationId', event.target.value)}
+            disabled={pending}
+          >
+            <option value="">Unassigned</option>
+            {locationOptions.map((location) => (
+              <option key={location.id} value={location.id}>
+                {location.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      </section>
+
+      <section className="wi-panel">
+        <div className="wi-panel-header">
+          <h3>Origin</h3>
+          <button type="button" onClick={updateOrigin} disabled={pending}>
+            Save origin
+          </button>
+        </div>
+        <textarea
+          value={origin}
+          onChange={(event) => setOrigin(event.target.value)}
+          placeholder="Recorded origin or acquisition notes"
+          rows={3}
+          disabled={pending}
+        />
+      </section>
+
+      <ProvenanceLedger
+        item={item}
+        pending={pending}
+        onCreate={(entry) => actions.addLedgerEntry(item.id, entry)}
+        onUpdate={(entryId, entry) => actions.updateLedgerEntry(item.id, entryId, entry)}
+        onDelete={(entryId) => actions.deleteLedgerEntry(item.id, entryId)}
+      />
+    </section>
+  );
+}
+
+export function WorldInventoryView() {
+  const { state, actions } = useWorldInventory();
+  const { loading, error, items, owners, containers, locations, filters, selectedItemId, pendingItems } =
+    state;
+
+  const facets = useMemo(() => computeFacets(items), [items]);
+
+  const filteredItems = useMemo(
+    () => filterItems(items, filters, { owners, containers, locations }),
+    [items, filters, owners, containers, locations]
+  );
+
+  const selectedItem = selectedItemId ? items.byId[selectedItemId] : null;
+  const pending = selectedItem ? Boolean(pendingItems[selectedItem.id]) : false;
+
+  return (
+    <main className="world-inventory-layout">
+      <section className="wi-panel">
+        <div className="wi-panel-header">
+          <h2>Items</h2>
+        </div>
+        <WorldInventoryFilters facets={facets} filters={filters} onFiltersChange={actions.setFilters} />
+        {loading && !state.loaded && <p className="wi-status">Loading inventory…</p>}
+        {error && <p className="wi-error">{error}</p>}
+        <WorldInventoryItemList
+          items={filteredItems}
+          selectedId={selectedItemId}
+          onSelect={actions.selectItem}
+          lookups={{ owners, containers, locations }}
+        />
+      </section>
+      <section className="wi-detail-column">
+        {!selectedItem && <p className="wi-empty">Select an item to review its details.</p>}
+        {selectedItem && (
+          <WorldInventoryDetail
+            item={selectedItem}
+            lookups={{ owners, containers, locations }}
+            pending={pending}
+            actions={actions}
+          />
+        )}
+      </section>
+      <aside className="wi-sidebar">
+        <InventoryEntitySection title="Containers" collection={containers} />
+        <InventoryEntitySection title="Owners" collection={owners} />
+        <InventoryEntitySection title="Locations" collection={locations} />
+      </aside>
+    </main>
+  );
+}
+
+export default function DndDmWorldInventory({ api }) {
   return (
     <>
       <BackButton />
       <h1>Dungeons & Dragons · World Inventory</h1>
-      <main className="dashboard" style={{ padding: '1rem' }}>
-        <div
-          style={{
-            background: 'var(--card-bg)',
-            color: 'var(--text)',
-            border: '1px solid var(--border)',
-            borderRadius: 8,
-            padding: '1rem',
-          }}
-        >
-          Under construction
-        </div>
-      </main>
+      <WorldInventoryProvider api={api}>
+        <WorldInventoryView />
+      </WorldInventoryProvider>
     </>
   );
 }

--- a/ui/src/pages/DndDungeonMaster.jsx
+++ b/ui/src/pages/DndDungeonMaster.jsx
@@ -44,7 +44,8 @@ const sections = [
     to: '/dnd/dungeon-master/world-inventory',
     icon: 'Boxes',
     title: 'World Inventory',
-    description: 'Under construction',
+    description:
+      'Audit magical loot, provenance, attunement, and placement across the world.',
   },
   {
     to: '/dnd/dungeon-master/tag-manager',

--- a/ui/tests/jsx-loader.mjs
+++ b/ui/tests/jsx-loader.mjs
@@ -2,6 +2,13 @@ import { readFile } from 'node:fs/promises';
 import { transform } from 'esbuild';
 
 export async function load(url, context, defaultLoad) {
+  if (url.endsWith('.css')) {
+    return {
+      format: 'module',
+      source: 'export default {};',
+      shortCircuit: true,
+    };
+  }
   if (url.endsWith('.jsx')) {
     const source = await readFile(new URL(url), 'utf8');
     const { code } = await transform(source, {

--- a/ui/tests/worldInventoryState.test.js
+++ b/ui/tests/worldInventoryState.test.js
@@ -1,0 +1,102 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  createWorldInventoryInitialState,
+  ensureStableId,
+  filterItems,
+  normalizeItem,
+  worldInventoryReducer,
+} from '../src/lib/worldInventoryState.js';
+
+const BASE_ITEM = {
+  name: 'Sunblade',
+  type: 'Weapon',
+  rarity: 'Legendary',
+  tags: ['Radiant', 'Sword'],
+  quests: ['Vault of Dawn'],
+  attunement: { required: true, restrictions: ['Paladin'] },
+  charges: { current: 3, maximum: 5, recharge: 'dawn' },
+  durability: { current: 5, maximum: 5, state: 'pristine' },
+  provenance: {
+    origin: 'Recovered from the Dawnspire',
+    ledger: [
+      {
+        actor: 'Archivist Lysa',
+        action: 'Catalogued relic',
+        notes: 'Certified authentic',
+        timestamp: '2024-05-01T10:00:00Z',
+      },
+    ],
+  },
+};
+
+test('normalizeItem produces deterministic identifiers and searchable text', () => {
+  const first = normalizeItem(BASE_ITEM);
+  const second = normalizeItem(BASE_ITEM);
+  assert.equal(first.id, second.id, 'IDs should be deterministic across normalizations');
+  assert.equal(first.tagsLower.includes('radiant'), true, 'tagsLower should normalize casing');
+  assert.equal(first.questsLower.includes('vault of dawn'), true);
+  assert.match(first.searchText, /archivist/, 'searchText should index provenance ledger');
+  assert.equal(first.attunement.required, true);
+});
+
+test('ensureStableId falls back to hashed slug when no identifier is provided', () => {
+  const idA = ensureStableId('item', { name: 'Echo Shard' });
+  const idB = ensureStableId('item', { name: 'Echo Shard' });
+  assert.equal(idA, idB);
+  assert.match(idA, /^item-/, 'fallback identifiers should include the prefix');
+});
+
+test('filterItems applies search, tag, rarity, and quest filters', () => {
+  const moonBlade = normalizeItem({ ...BASE_ITEM, name: 'Moon Blade', rarity: 'Rare', tags: ['Fey'], quests: ['Autumn Court'] });
+  const stormAmulet = normalizeItem({
+    ...BASE_ITEM,
+    name: 'Storm Amulet',
+    rarity: 'Uncommon',
+    tags: ['Storm'],
+    quests: ['Sky Trial'],
+    provenance: { origin: 'Sky Citadel', ledger: [] },
+  });
+  const items = {
+    byId: { [moonBlade.id]: moonBlade, [stormAmulet.id]: stormAmulet },
+    allIds: [moonBlade.id, stormAmulet.id],
+  };
+  let results = filterItems(items, { search: '', tags: ['fey'], rarities: [], quests: [] });
+  assert.equal(results.length, 1);
+  assert.equal(results[0].id, moonBlade.id, 'tag filter should pick Fey items');
+  results = filterItems(items, { search: '', tags: [], rarities: ['rare'], quests: [] });
+  assert.equal(results[0].id, moonBlade.id, 'rarity filter should match Rare items');
+  results = filterItems(items, { search: '', tags: [], rarities: [], quests: ['sky trial'] });
+  assert.equal(results[0].id, stormAmulet.id, 'quest filter should match quest entries');
+  results = filterItems(items, { search: 'storm', tags: [], rarities: [], quests: [] });
+  assert.equal(results[0].id, stormAmulet.id, 'search text should match item name');
+});
+
+test('worldInventoryReducer loads snapshots and maintains selection', () => {
+  const initial = createWorldInventoryInitialState();
+  const state = worldInventoryReducer(initial, {
+    type: 'loadSuccess',
+    snapshot: {
+      items: [
+        { id: 'item-alpha', name: 'Alpha Relic' },
+        { id: 'item-beta', name: 'Beta Relic' },
+      ],
+      owners: [{ id: 'owner-1', name: 'Caretaker' }],
+      containers: [],
+      locations: [],
+    },
+  });
+  assert.equal(state.items.allIds.length, 2);
+  assert.equal(state.selectedItemId, 'item-alpha', 'first item should be selected by default');
+  const next = worldInventoryReducer(state, {
+    type: 'selectItem',
+    itemId: 'item-beta',
+  });
+  assert.equal(next.selectedItemId, 'item-beta');
+  const updated = worldInventoryReducer(next, {
+    type: 'upsertItem',
+    item: { id: 'item-beta', name: 'Beta Relic', rarity: 'rare' },
+  });
+  assert.equal(updated.items.byId['item-beta'].rarity, 'rare');
+});

--- a/ui/tests/worldInventoryView.test.js
+++ b/ui/tests/worldInventoryView.test.js
@@ -1,0 +1,689 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+
+import { WorldInventoryProvider } from '../src/lib/worldInventoryState.js';
+import { WorldInventoryView } from '../src/pages/DndDmWorldInventory.jsx';
+
+class FakeNode {
+  constructor(nodeType) {
+    this.nodeType = nodeType;
+    this.parentNode = null;
+    this.ownerDocument = null;
+    this.childNodes = [];
+    this._listeners = Object.create(null);
+  }
+
+  appendChild(node) {
+    if (!node) return null;
+    if (node.parentNode) {
+      node.parentNode.removeChild(node);
+    }
+    this.childNodes.push(node);
+    node.parentNode = this;
+    const doc = this.nodeType === 9 ? this : this.ownerDocument;
+    if (doc) {
+      node.ownerDocument = doc;
+      if (typeof node.propagateOwnerDocument === 'function') {
+        node.propagateOwnerDocument(doc);
+      }
+    }
+    return node;
+  }
+
+  insertBefore(node, reference) {
+    if (reference === null || reference === undefined) {
+      return this.appendChild(node);
+    }
+    const index = this.childNodes.indexOf(reference);
+    if (index === -1) {
+      throw new Error('Reference node is not a child of this node.');
+    }
+    if (node.parentNode) {
+      node.parentNode.removeChild(node);
+    }
+    this.childNodes.splice(index, 0, node);
+    node.parentNode = this;
+    const doc = this.nodeType === 9 ? this : this.ownerDocument;
+    if (doc) {
+      node.ownerDocument = doc;
+      if (typeof node.propagateOwnerDocument === 'function') {
+        node.propagateOwnerDocument(doc);
+      }
+    }
+    return node;
+  }
+
+  removeChild(node) {
+    const index = this.childNodes.indexOf(node);
+    if (index === -1) {
+      throw new Error('Node is not a child of this parent.');
+    }
+    this.childNodes.splice(index, 1);
+    node.parentNode = null;
+    return node;
+  }
+
+  replaceChild(newNode, oldNode) {
+    this.insertBefore(newNode, oldNode);
+    this.removeChild(oldNode);
+    return oldNode;
+  }
+
+  get firstChild() {
+    return this.childNodes[0] || null;
+  }
+
+  get lastChild() {
+    return this.childNodes[this.childNodes.length - 1] || null;
+  }
+
+  addEventListener(type, handler) {
+    if (!this._listeners[type]) {
+      this._listeners[type] = new Set();
+    }
+    this._listeners[type].add(handler);
+  }
+
+  removeEventListener(type, handler) {
+    this._listeners[type]?.delete(handler);
+  }
+
+  dispatchEvent(event) {
+    if (!event || typeof event.type !== 'string') {
+      throw new TypeError('Event object with type is required');
+    }
+    if (event.target === undefined) {
+      Object.defineProperty(event, 'target', { value: this, configurable: true });
+    }
+    Object.defineProperty(event, 'currentTarget', { value: this, configurable: true });
+    if (event.bubbles === undefined) {
+      event.bubbles = true;
+    }
+    if (event.cancelBubble === undefined) {
+      event.cancelBubble = false;
+    }
+    if (typeof event.preventDefault !== 'function') {
+      event.defaultPrevented = false;
+      event.preventDefault = function () {
+        this.defaultPrevented = true;
+      };
+    }
+    if (typeof event.stopPropagation !== 'function') {
+      event.stopPropagation = function () {
+        this.cancelBubble = true;
+      };
+    }
+    const listeners = this._listeners[event.type];
+    if (listeners) {
+      for (const listener of Array.from(listeners)) {
+        listener.call(this, event);
+        if (event.cancelBubble) {
+          break;
+        }
+      }
+    }
+    if (event.bubbles && !event.cancelBubble && this.parentNode) {
+      return this.parentNode.dispatchEvent(event);
+    }
+    return !event.defaultPrevented;
+  }
+
+  contains(node) {
+    if (node === this) return true;
+    for (const child of this.childNodes) {
+      if (child.contains && child.contains(node)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}
+
+class FakeText extends FakeNode {
+  constructor(text) {
+    super(3);
+    this.nodeValue = String(text ?? '');
+    this.textContent = this.nodeValue;
+    this.nodeName = '#text';
+  }
+
+  get textContent() {
+    return this.nodeValue;
+  }
+
+  set textContent(value) {
+    this.nodeValue = String(value ?? '');
+  }
+}
+
+class FakeComment extends FakeNode {
+  constructor(text) {
+    super(8);
+    this.nodeValue = String(text ?? '');
+    this.nodeName = '#comment';
+  }
+
+  get textContent() {
+    return this.nodeValue;
+  }
+
+  set textContent(value) {
+    this.nodeValue = String(value ?? '');
+  }
+}
+
+class FakeElement extends FakeNode {
+  constructor(tagName) {
+    super(1);
+    this.tagName = String(tagName || 'div').toUpperCase();
+    this.nodeName = this.tagName;
+    this.attributes = Object.create(null);
+    this.style = {};
+    this.dataset = {};
+    this.value = '';
+    this.checked = false;
+    this.type = '';
+    this.id = '';
+    this.name = '';
+    this.disabled = false;
+    this.options = [];
+  }
+
+  appendChild(node) {
+    const appended = super.appendChild(node);
+    if (this.tagName === 'SELECT' && appended && appended.tagName === 'OPTION') {
+      this.options.push(appended);
+      if (appended.selected || this.value === '') {
+        this.value = appended.value || appended.getAttribute('value') || this.value;
+      }
+    }
+    return appended;
+  }
+
+  propagateOwnerDocument(doc) {
+    for (const child of this.childNodes) {
+      child.ownerDocument = doc;
+      if (typeof child.propagateOwnerDocument === 'function') {
+        child.propagateOwnerDocument(doc);
+      }
+    }
+  }
+
+  setAttribute(name, value) {
+    const normalized = String(value);
+    this.attributes[name] = normalized;
+    if (name === 'value') {
+      this.value = normalized;
+    } else if (name === 'checked') {
+      this.checked = normalized !== 'false';
+    } else if (name === 'id') {
+      this.id = normalized;
+    } else if (name === 'name') {
+      this.name = normalized;
+    } else if (name === 'type') {
+      this.type = normalized;
+    }
+  }
+
+  getAttribute(name) {
+    return Object.prototype.hasOwnProperty.call(this.attributes, name)
+      ? this.attributes[name]
+      : null;
+  }
+
+  removeAttribute(name) {
+    delete this.attributes[name];
+  }
+
+  get textContent() {
+    return this.childNodes.map((child) => child.textContent || '').join('');
+  }
+
+  set textContent(value) {
+    this.childNodes = [];
+    if (value !== undefined && value !== null && value !== '') {
+      super.appendChild(new FakeText(value));
+    }
+  }
+
+  get innerHTML() {
+    return this.textContent;
+  }
+
+  set innerHTML(value) {
+    this.textContent = value;
+  }
+
+  get children() {
+    return this.childNodes.filter((child) => child.nodeType === 1);
+  }
+
+  focus() {
+    if (this.ownerDocument) {
+      this.ownerDocument._activeElement = this;
+    }
+  }
+
+  blur() {
+    if (this.ownerDocument && this.ownerDocument._activeElement === this) {
+      this.ownerDocument._activeElement = this.ownerDocument.body;
+    }
+  }
+
+  getBoundingClientRect() {
+    return { x: 0, y: 0, width: 0, height: 0, top: 0, left: 0, right: 0, bottom: 0 };
+  }
+}
+
+class FakeDocument extends FakeNode {
+  constructor() {
+    super(9);
+    this.nodeName = '#document';
+    this.documentElement = new FakeElement('html');
+    this.body = new FakeElement('body');
+    this.documentElement.ownerDocument = this;
+    this.body.ownerDocument = this;
+    this.documentElement.appendChild(this.body);
+    super.appendChild(this.documentElement);
+    this._listeners = Object.create(null);
+    this._activeElement = this.body;
+  }
+
+  createElement(tagName) {
+    const element = new FakeElement(tagName);
+    element.ownerDocument = this;
+    return element;
+  }
+
+  createElementNS(namespace, tagName) {
+    return this.createElement(tagName);
+  }
+
+  createTextNode(text) {
+    const node = new FakeText(text);
+    node.ownerDocument = this;
+    return node;
+  }
+
+  createComment(text) {
+    const comment = new FakeComment(text);
+    comment.ownerDocument = this;
+    return comment;
+  }
+
+  addEventListener(type, handler) {
+    if (!this._listeners[type]) {
+      this._listeners[type] = new Set();
+    }
+    this._listeners[type].add(handler);
+  }
+
+  removeEventListener(type, handler) {
+    this._listeners[type]?.delete(handler);
+  }
+
+  dispatchEvent(event) {
+    if (!event || typeof event.type !== 'string') {
+      return false;
+    }
+    if (event.target === undefined) {
+      Object.defineProperty(event, 'target', { value: this, configurable: true });
+    }
+    Object.defineProperty(event, 'currentTarget', { value: this, configurable: true });
+    const listeners = this._listeners[event.type];
+    if (listeners) {
+      for (const listener of Array.from(listeners)) {
+        listener.call(this, event);
+      }
+    }
+    return true;
+  }
+
+  get activeElement() {
+    return this._activeElement || this.body;
+  }
+
+  getElementById(id) {
+    return findElement(this, (node) => node.id === id);
+  }
+}
+
+function ensureDom() {
+  if (globalThis.document) return;
+  const document = new FakeDocument();
+  const window = {
+    document,
+    navigator: { userAgent: 'node' },
+    requestAnimationFrame: (cb) => setTimeout(cb, 0),
+    cancelAnimationFrame: (id) => clearTimeout(id),
+    getComputedStyle: () => ({ getPropertyValue: () => '' }),
+  };
+  globalThis.window = window;
+  globalThis.document = document;
+  globalThis.navigator = window.navigator;
+  document.defaultView = window;
+  globalThis.HTMLElement = FakeElement;
+  globalThis.Node = FakeNode;
+  window.HTMLElement = FakeElement;
+  window.Node = FakeNode;
+  window.HTMLInputElement = FakeElement;
+  window.HTMLSelectElement = FakeElement;
+  window.HTMLTextAreaElement = FakeElement;
+  window.HTMLButtonElement = FakeElement;
+  window.HTMLLabelElement = FakeElement;
+  window.HTMLIFrameElement = FakeElement;
+  globalThis.requestAnimationFrame = window.requestAnimationFrame;
+  globalThis.cancelAnimationFrame = window.cancelAnimationFrame;
+  globalThis.MutationObserver = class {
+    disconnect() {}
+    observe() {}
+    takeRecords() {
+      return [];
+    }
+  };
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+}
+
+ensureDom();
+
+function findElement(node, predicate) {
+  if (!node) return null;
+  if (predicate(node)) return node;
+  if (!node.childNodes) return null;
+  for (const child of node.childNodes) {
+    const result = findElement(child, predicate);
+    if (result) return result;
+  }
+  return null;
+}
+
+function findAllElements(node, predicate, out = []) {
+  if (!node) return out;
+  if (predicate(node)) out.push(node);
+  if (node.childNodes) {
+    for (const child of node.childNodes) {
+      findAllElements(child, predicate, out);
+    }
+  }
+  return out;
+}
+
+function findButtonByText(root, text) {
+  return findElement(
+    root,
+    (node) => node.nodeType === 1 && node.tagName === 'BUTTON' && node.textContent.includes(text)
+  );
+}
+
+function findAllButtonsByText(root, text) {
+  return findAllElements(
+    root,
+    (node) => node.nodeType === 1 && node.tagName === 'BUTTON' && node.textContent.includes(text)
+  );
+}
+
+function findLabelByText(root, text) {
+  return findElement(
+    root,
+    (node) => node.nodeType === 1 && node.tagName === 'LABEL' && node.textContent.includes(text)
+  );
+}
+
+function findSelectByLabel(root, text) {
+  const label = findLabelByText(root, text);
+  if (!label) return null;
+  return label.childNodes.find((child) => child.nodeType === 1 && child.tagName === 'SELECT') || null;
+}
+
+function findInputByLabel(root, text) {
+  const label = findLabelByText(root, text);
+  if (!label) return null;
+  return label.childNodes.find((child) => child.nodeType === 1 && child.tagName === 'INPUT') || null;
+}
+
+function findTextareaByLabel(root, text) {
+  const label = findLabelByText(root, text);
+  if (!label) return null;
+  return label.childNodes.find((child) => child.nodeType === 1 && child.tagName === 'TEXTAREA') || null;
+}
+
+function findFormByField(root, text) {
+  return findElement(
+    root,
+    (node) =>
+      node.nodeType === 1 &&
+      node.tagName === 'FORM' &&
+      !!findLabelByText(node, text)
+  );
+}
+
+function fireEvent(target, type, overrides = {}) {
+  if (!target) {
+    throw new Error(`Unable to fire ${type} event on undefined target`);
+  }
+  const event = {
+    type,
+    bubbles: overrides.bubbles !== undefined ? overrides.bubbles : true,
+    cancelable: overrides.cancelable !== undefined ? overrides.cancelable : true,
+    cancelBubble: false,
+    defaultPrevented: false,
+    target,
+    ...overrides,
+    preventDefault() {
+      this.defaultPrevented = true;
+    },
+    stopPropagation() {
+      this.cancelBubble = true;
+    },
+  };
+  target.dispatchEvent(event);
+  return event;
+}
+
+function renderWithApi(api) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  return {
+    container,
+    root,
+    cleanup: async () => {
+      await act(async () => {
+        root.unmount();
+      });
+      if (container.parentNode) {
+        container.parentNode.removeChild(container);
+      }
+    },
+    render: async () => {
+      await act(async () => {
+        root.render(
+          React.createElement(
+            WorldInventoryProvider,
+            { api },
+            React.createElement(WorldInventoryView)
+          )
+        );
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+    },
+  };
+}
+
+function createFakeApi() {
+  let ledgerCounter = 0;
+  const owners = [
+    { id: 'owner-1', name: 'Thalia' },
+    { id: 'owner-2', name: 'Kara' },
+  ];
+  const containers = [{ id: 'container-1', name: 'Vault Locker' }];
+  const locations = [{ id: 'location-1', name: 'Skyhold' }];
+  let currentItem = {
+    id: 'item-1',
+    name: 'Moon Dagger',
+    type: 'Weapon',
+    rarity: 'Rare',
+    tags: ['Fey'],
+    quests: ['Autumn Court'],
+    ownerId: '',
+    containerId: '',
+    locationId: 'location-1',
+    attunement: { required: false, restrictions: [], notes: '', attunedTo: [] },
+    charges: { current: 2, maximum: 3, recharge: 'dawn' },
+    durability: { current: 3, maximum: 3, state: 'polished', notes: '' },
+    provenance: { origin: 'Recovered from the Autumn Court', ledger: [] },
+    description: 'A crescent blade that hums under moonlight.',
+    notes: '',
+  };
+  const calls = {
+    moveItem: [],
+    createLedgerEntry: [],
+    updateLedgerEntry: [],
+    deleteLedgerEntry: [],
+    updateItem: [],
+  };
+  return {
+    api: {
+      fetchSnapshot: async () => ({
+        items: [currentItem],
+        owners,
+        containers,
+        locations,
+      }),
+      moveItem: async (itemId, targets) => {
+        calls.moveItem.push([itemId, targets]);
+        currentItem = { ...currentItem, ...targets };
+        return { item: currentItem };
+      },
+      createLedgerEntry: async (itemId, entry) => {
+        calls.createLedgerEntry.push([itemId, entry]);
+        ledgerCounter += 1;
+        const ledgerEntry = { id: `ledger-${ledgerCounter}`, ...entry };
+        currentItem = {
+          ...currentItem,
+          provenance: {
+            ...currentItem.provenance,
+            ledger: [...currentItem.provenance.ledger, ledgerEntry],
+          },
+        };
+        return { item: currentItem };
+      },
+      updateLedgerEntry: async (itemId, entryId, entry) => {
+        calls.updateLedgerEntry.push([itemId, entryId, entry]);
+        currentItem = {
+          ...currentItem,
+          provenance: {
+            ...currentItem.provenance,
+            ledger: currentItem.provenance.ledger.map((item) =>
+              item.id === entryId ? { ...item, ...entry } : item
+            ),
+          },
+        };
+        return { item: currentItem };
+      },
+      deleteLedgerEntry: async (itemId, entryId) => {
+        calls.deleteLedgerEntry.push([itemId, entryId]);
+        currentItem = {
+          ...currentItem,
+          provenance: {
+            ...currentItem.provenance,
+            ledger: currentItem.provenance.ledger.filter((item) => item.id !== entryId),
+          },
+        };
+        return { item: currentItem };
+      },
+      updateItem: async (itemId, changes) => {
+        calls.updateItem.push([itemId, changes]);
+        currentItem = {
+          ...currentItem,
+          ...(changes.charges ? { charges: { ...currentItem.charges, ...changes.charges } } : {}),
+          ...(changes.durability
+            ? { durability: { ...currentItem.durability, ...changes.durability } }
+            : {}),
+          provenance: {
+            ...currentItem.provenance,
+            ...(changes.provenance || {}),
+          },
+        };
+        return { item: currentItem };
+      },
+    },
+    calls,
+    getItem: () => currentItem,
+  };
+}
+
+function findElementByText(root, text) {
+  return findElement(
+    root,
+    (node) => node.nodeType === 1 && node.textContent.includes(text)
+  );
+}
+
+test('moving an item updates assignment through the API', async () => {
+  const { api, calls } = createFakeApi();
+  const { container, render, cleanup } = renderWithApi(api);
+  await render();
+  const ownerSelect = findSelectByLabel(container, 'Owner');
+  assert.ok(ownerSelect, 'owner select should render');
+  await act(async () => {
+    ownerSelect.value = 'owner-2';
+    fireEvent(ownerSelect, 'change');
+    await Promise.resolve();
+  });
+  assert.equal(calls.moveItem.length, 1, 'moveItem API should be invoked once');
+  assert.deepEqual(calls.moveItem[0][1], {
+    ownerId: 'owner-2',
+    containerId: '',
+    locationId: 'location-1',
+  });
+  assert.equal(ownerSelect.value, 'owner-2');
+  await cleanup();
+});
+
+test('adding a provenance entry persists via the API and renders in the ledger', async () => {
+  const { api, calls } = createFakeApi();
+  const { container, render, cleanup } = renderWithApi(api);
+  await render();
+  const addButton = findButtonByText(container, 'Add entry');
+  assert.ok(addButton, 'Add entry button should render');
+  await act(async () => {
+    fireEvent(addButton, 'click');
+    await Promise.resolve();
+  });
+  const whenInput = findInputByLabel(container, 'When');
+  const actorInput = findInputByLabel(container, 'Actor');
+  const actionInput = findInputByLabel(container, 'Action');
+  const notesTextarea = findTextareaByLabel(container, 'Notes');
+  assert.ok(whenInput && actorInput && actionInput && notesTextarea, 'ledger form should render');
+  await act(async () => {
+    whenInput.value = '2024-06-01T10:00';
+    fireEvent(whenInput, 'change');
+    actorInput.value = 'Archivist';
+    fireEvent(actorInput, 'change');
+    actionInput.value = 'Recorded transfer';
+    fireEvent(actionInput, 'change');
+    notesTextarea.value = 'Moved to the Shadowfell vault';
+    fireEvent(notesTextarea, 'change');
+  });
+  const buttons = findAllButtonsByText(container, 'Add entry');
+  const submitButton = buttons[buttons.length - 1];
+  const ledgerForm = findFormByField(container, 'When');
+  await act(async () => {
+    fireEvent(submitButton, 'click');
+    if (ledgerForm) {
+      fireEvent(ledgerForm, 'submit');
+    }
+    await Promise.resolve();
+  });
+  assert.equal(calls.createLedgerEntry.length, 1, 'createLedgerEntry should be called');
+  const entry = calls.createLedgerEntry[0][1];
+  const deleteButton = findButtonByText(container, 'Delete');
+  assert.ok(deleteButton, 'ledger entry delete action should render after creation');
+  await cleanup();
+});


### PR DESCRIPTION
## Summary
- implement a world-inventory data store with Tauri API bindings and normalized entities
- build the Dungeon Master world inventory dashboard with item filters, detail controls, and provenance editing
- add styling updates, dashboard copy, and unit/component tests for the new store and UI harness

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3733cb13c8325a31e63c77050f7e7