### PR TITLE
Extract world inventory detail forms into dedicated components

### DIFF
--- a/ui/src/components/inventory/ChargesForm.jsx
+++ b/ui/src/components/inventory/ChargesForm.jsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useRef } from 'react';
+
+function parseNumber(value) {
+  const numeric = Number(value);
+  return Number.isNaN(numeric) ? 0 : numeric;
+}
+
+export default function ChargesForm({ values, pending, onSubmit }) {
+  const currentRef = useRef(null);
+  const maximumRef = useRef(null);
+  const rechargeRef = useRef(null);
+
+  useEffect(() => {
+    if (currentRef.current) {
+      currentRef.current.value = values?.current ?? 0;
+    }
+    if (maximumRef.current) {
+      maximumRef.current.value = values?.maximum ?? 0;
+    }
+    if (rechargeRef.current) {
+      rechargeRef.current.value = values?.recharge ?? '';
+    }
+  }, [values?.current, values?.maximum, values?.recharge]);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    const next = {
+      current: parseNumber(currentRef.current?.value ?? 0),
+      maximum: parseNumber(maximumRef.current?.value ?? 0),
+      recharge: rechargeRef.current?.value ?? '',
+    };
+    await onSubmit?.(next);
+  };
+
+  return (
+    <form className="wi-panel" onSubmit={handleSubmit}>
+      <div className="wi-panel-header">
+        <h3>Charges</h3>
+        <button type="submit" disabled={pending}>
+          Update
+        </button>
+      </div>
+      <label>
+        <span>Current</span>
+        <input
+          ref={currentRef}
+          type="number"
+          min="0"
+          name="current"
+          defaultValue={values?.current ?? 0}
+          disabled={pending}
+        />
+      </label>
+      <label>
+        <span>Maximum</span>
+        <input
+          ref={maximumRef}
+          type="number"
+          min="0"
+          name="maximum"
+          defaultValue={values?.maximum ?? 0}
+          disabled={pending}
+        />
+      </label>
+      <label>
+        <span>Recharge</span>
+        <input
+          ref={rechargeRef}
+          type="text"
+          name="recharge"
+          defaultValue={values?.recharge ?? ''}
+          disabled={pending}
+        />
+      </label>
+    </form>
+  );
+}

--- a/ui/src/components/inventory/DurabilityForm.jsx
+++ b/ui/src/components/inventory/DurabilityForm.jsx
@@ -1,0 +1,92 @@
+import React, { useEffect, useRef } from 'react';
+
+function parseNumber(value) {
+  const numeric = Number(value);
+  return Number.isNaN(numeric) ? 0 : numeric;
+}
+
+export default function DurabilityForm({ values, pending, onSubmit }) {
+  const currentRef = useRef(null);
+  const maximumRef = useRef(null);
+  const stateRef = useRef(null);
+  const notesRef = useRef(null);
+
+  useEffect(() => {
+    if (currentRef.current) {
+      currentRef.current.value = values?.current ?? 0;
+    }
+    if (maximumRef.current) {
+      maximumRef.current.value = values?.maximum ?? 0;
+    }
+    if (stateRef.current) {
+      stateRef.current.value = values?.state ?? '';
+    }
+    if (notesRef.current) {
+      notesRef.current.value = values?.notes ?? '';
+    }
+  }, [values?.current, values?.maximum, values?.state, values?.notes]);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    const next = {
+      current: parseNumber(currentRef.current?.value ?? 0),
+      maximum: parseNumber(maximumRef.current?.value ?? 0),
+      state: stateRef.current?.value ?? '',
+      notes: notesRef.current?.value ?? '',
+    };
+    await onSubmit?.(next);
+  };
+
+  return (
+    <form className="wi-panel" onSubmit={handleSubmit}>
+      <div className="wi-panel-header">
+        <h3>Durability</h3>
+        <button type="submit" disabled={pending}>
+          Update
+        </button>
+      </div>
+      <label>
+        <span>Current</span>
+        <input
+          ref={currentRef}
+          type="number"
+          min="0"
+          name="current"
+          defaultValue={values?.current ?? 0}
+          disabled={pending}
+        />
+      </label>
+      <label>
+        <span>Maximum</span>
+        <input
+          ref={maximumRef}
+          type="number"
+          min="0"
+          name="maximum"
+          defaultValue={values?.maximum ?? 0}
+          disabled={pending}
+        />
+      </label>
+      <label>
+        <span>Status</span>
+        <input
+          ref={stateRef}
+          type="text"
+          name="state"
+          defaultValue={values?.state ?? ''}
+          disabled={pending}
+        />
+      </label>
+      <label>
+        <span>Notes</span>
+        <textarea
+          ref={notesRef}
+          name="notes"
+          rows={3}
+          defaultValue={values?.notes ?? ''}
+          disabled={pending}
+        />
+      </label>
+    </form>
+  );
+}

--- a/ui/src/components/inventory/OriginForm.jsx
+++ b/ui/src/components/inventory/OriginForm.jsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useRef } from 'react';
+
+export default function OriginForm({ origin, pending, onSubmit }) {
+  const textareaRef = useRef(null);
+
+  useEffect(() => {
+    if (textareaRef.current) {
+      textareaRef.current.value = origin || '';
+    }
+  }, [origin]);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    const value = textareaRef.current?.value ?? '';
+    await onSubmit?.(value);
+  };
+
+  return (
+    <section className="wi-panel">
+      <div className="wi-panel-header">
+        <h3>Origin</h3>
+        <button type="button" onClick={handleSubmit} disabled={pending}>
+          Save origin
+        </button>
+      </div>
+      <textarea
+        ref={textareaRef}
+        defaultValue={origin || ''}
+        placeholder="Recorded origin or acquisition notes"
+        rows={3}
+        disabled={pending}
+      />
+    </section>
+  );
+}

--- a/ui/src/components/inventory/PlacementForm.jsx
+++ b/ui/src/components/inventory/PlacementForm.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+export default function PlacementForm({
+  ownerId,
+  containerId,
+  locationId,
+  ownerOptions = [],
+  containerOptions = [],
+  locationOptions = [],
+  pending,
+  onChange,
+}) {
+  const handleChange = (field) => (event) => {
+    onChange?.(field, event.target.value);
+  };
+
+  return (
+    <section className="wi-panel">
+      <div className="wi-panel-header">
+        <h3>Ownership & Placement</h3>
+      </div>
+      <label>
+        <span>Owner</span>
+        <select value={ownerId || ''} onChange={handleChange('ownerId')} disabled={pending}>
+          <option value="">Unassigned</option>
+          {ownerOptions.map((owner) => (
+            <option key={owner.id} value={owner.id}>
+              {owner.name}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label>
+        <span>Container</span>
+        <select value={containerId || ''} onChange={handleChange('containerId')} disabled={pending}>
+          <option value="">Unassigned</option>
+          {containerOptions.map((container) => (
+            <option key={container.id} value={container.id}>
+              {container.name}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label>
+        <span>Location</span>
+        <select value={locationId || ''} onChange={handleChange('locationId')} disabled={pending}>
+          <option value="">Unassigned</option>
+          {locationOptions.map((location) => (
+            <option key={location.id} value={location.id}>
+              {location.name}
+            </option>
+          ))}
+        </select>
+      </label>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- extract the charges, durability, placement, and origin panels into dedicated inventory form components
- wire WorldInventoryDetail to render the new components while delegating provider actions
- expand world inventory view tests to cover the refactored forms and origin updates

## Testing
- npm test -- tests/worldInventoryView.test.js

------
https://chatgpt.com/codex/tasks/task_e_68daa7ee44008325a34dfe6abd2d315f