### PR TITLE
Add Sand Blocks falling sand game

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -55,6 +55,7 @@ import LoopMaker from './pages/LoopMaker.jsx';
 import BeatMaker from './pages/BeatMaker.jsx';
 import Games from './pages/Games.jsx';
 import RainBlocks from './pages/RainBlocks.jsx';
+import SandBlocks from './pages/SandBlocks.jsx';
 import Snake from './pages/Snake.jsx';
 import BrickBreaker from './pages/BrickBreaker.jsx';
 import AlbumMaker from './pages/AlbumMaker.jsx';
@@ -325,6 +326,7 @@ export default function App() {
         <Route path="/album" element={<AlbumMaker />} />
         <Route path="/games" element={<Games />} />
         <Route path="/games/rain-blocks" element={<RainBlocks />} />
+        <Route path="/games/sand-blocks" element={<SandBlocks />} />
         <Route path="/games/brick-breaker" element={<BrickBreaker />} />
         <Route path="/games/snake" element={<Snake />} />
       </Routes>

--- a/ui/src/pages/Games.jsx
+++ b/ui/src/pages/Games.jsx
@@ -8,6 +8,12 @@ export default function Games() {
       <h1>Games</h1>
       <main className="dashboard">
         <Card to="/games/rain-blocks" icon="Blocks" title="Rain Blocks" />
+        <Card
+          to="/games/sand-blocks"
+          icon="Waves"
+          title="Sand Blocks"
+          caption="Experiment with falling sand"
+        />
         <Card to="/games/brick-breaker" icon="Gamepad2" title="Brick Breaker" />
         <Card to="/games/snake" icon="Worm" title="Snake" />
       </main>

--- a/ui/src/pages/SandBlocks.css
+++ b/ui/src/pages/SandBlocks.css
@@ -1,0 +1,167 @@
+.sand-page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  align-items: center;
+  padding: clamp(var(--space-md), 3vw, var(--space-xl));
+}
+
+.sand-game-container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  align-items: stretch;
+  width: min(960px, 100%);
+  margin: 0 auto;
+  padding: clamp(var(--space-md), 3vw, var(--space-xl));
+  background: var(--card-bg);
+  border: 2px solid var(--accent);
+  border-radius: var(--space-md);
+  box-shadow: var(--card-shadow);
+}
+
+.sand-game-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  text-align: center;
+}
+
+.sand-game-header h1 {
+  margin: 0;
+  font-size: clamp(1.75rem, 3vw, 2.5rem);
+  color: var(--text);
+}
+
+.sand-game-subtitle {
+  margin: 0;
+  font-size: clamp(0.95rem, 2vw, 1.1rem);
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.sand-game-hud {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: var(--space-md);
+  align-items: stretch;
+}
+
+.sand-game-scoreboard {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: var(--space-xs);
+  padding: var(--space-sm);
+  border-radius: var(--space-sm);
+  background: rgba(15, 23, 42, 0.85);
+  color: var(--text);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.sand-game-scoreboard span {
+  display: block;
+  padding: var(--space-xs);
+  border-radius: var(--space-xs);
+  background: rgba(255, 255, 255, 0.06);
+  text-align: center;
+}
+
+.sand-game-controls {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--space-sm);
+  align-items: center;
+}
+
+.sand-button {
+  padding: var(--space-sm) var(--space-md);
+  border: 2px solid var(--accent);
+  border-radius: var(--space-xs);
+  background: var(--button-bg);
+  color: var(--text);
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.1s ease;
+}
+
+.sand-button:hover {
+  background: var(--button-hover-bg);
+}
+
+.sand-button:active {
+  transform: translateY(1px);
+}
+
+.sand-game-board {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.sand-game-canvas {
+  width: min(100%, 720px);
+  height: auto;
+  border: 2px solid var(--accent);
+  border-radius: var(--space-sm);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.45);
+  background: var(--panel-bg);
+  image-rendering: pixelated;
+}
+
+.sand-game-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-lg);
+  background: var(--overlay-bg);
+  border-radius: var(--space-sm);
+  text-align: center;
+  z-index: 2;
+}
+
+.sand-game-overlay-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  align-items: center;
+  color: var(--text);
+}
+
+.sand-game-overlay-title {
+  margin: 0;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  font-weight: 700;
+}
+
+.sand-game-overlay-text {
+  margin: 0;
+  font-size: clamp(1.05rem, 2.5vw, 1.25rem);
+  font-weight: 600;
+}
+
+.sand-game-overlay-hint {
+  margin: 0;
+  font-size: 0.95rem;
+  opacity: 0.8;
+}
+
+@media (max-width: 768px) {
+  .sand-game-container {
+    padding: clamp(var(--space-sm), 4vw, var(--space-lg));
+  }
+
+  .sand-game-hud {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .sand-game-scoreboard {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/ui/src/pages/SandBlocks.jsx
+++ b/ui/src/pages/SandBlocks.jsx
@@ -1,0 +1,357 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import BackButton from '../components/BackButton.jsx';
+import './SandBlocks.css';
+
+const CELL_SIZE = 6;
+const GRID_WIDTH = 120;
+const GRID_HEIGHT = 80;
+const CANVAS_WIDTH = GRID_WIDTH * CELL_SIZE;
+const CANVAS_HEIGHT = GRID_HEIGHT * CELL_SIZE;
+const STORAGE_KEY = 'sandBlocksHighScore';
+
+const createEmptyGrid = () =>
+  Array.from({ length: GRID_HEIGHT }, () => Array(GRID_WIDTH).fill(0));
+
+export default function SandBlocks() {
+  const canvasRef = useRef(null);
+  const animationFrameRef = useRef(null);
+  const gridRef = useRef(createEmptyGrid());
+  const startTimeRef = useRef(null);
+  const isDrawingRef = useRef({ active: false, erase: false });
+  const isRunningRef = useRef(false);
+
+  const [elapsedTime, setElapsedTime] = useState(0);
+  const [isRunning, setIsRunning] = useState(false);
+  const [grainCount, setGrainCount] = useState(0);
+  const [highScore, setHighScore] = useState(() => {
+    if (typeof window === 'undefined') {
+      return 0;
+    }
+
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      const parsed = Number.parseFloat(stored);
+      return Number.isFinite(parsed) ? parsed : 0;
+    } catch {
+      return 0;
+    }
+  });
+
+  const drawGrid = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return;
+    }
+
+    const ctx = canvas.getContext('2d');
+    ctx.fillStyle = '#0f172a';
+    ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+
+    ctx.fillStyle = '#fbbf24';
+    const grid = gridRef.current;
+    for (let y = 0; y < GRID_HEIGHT; y += 1) {
+      for (let x = 0; x < GRID_WIDTH; x += 1) {
+        if (grid[y][x] !== 1) {
+          continue;
+        }
+
+        ctx.fillRect(
+          x * CELL_SIZE,
+          y * CELL_SIZE,
+          CELL_SIZE,
+          CELL_SIZE
+        );
+      }
+    }
+  }, []);
+
+  const countGrains = useCallback(() => {
+    const grid = gridRef.current;
+    let count = 0;
+    for (let y = 0; y < GRID_HEIGHT; y += 1) {
+      for (let x = 0; x < GRID_WIDTH; x += 1) {
+        if (grid[y][x] === 1) {
+          count += 1;
+        }
+      }
+    }
+    setGrainCount(count);
+  }, []);
+
+  const stepSimulation = useCallback(() => {
+    const currentGrid = gridRef.current;
+    const nextGrid = currentGrid.map((row) => row.slice());
+    let moved = false;
+
+    for (let y = GRID_HEIGHT - 2; y >= 0; y -= 1) {
+      for (let x = 0; x < GRID_WIDTH; x += 1) {
+        if (currentGrid[y][x] !== 1) {
+          continue;
+        }
+
+        const belowY = y + 1;
+        if (currentGrid[belowY][x] === 0) {
+          nextGrid[belowY][x] = 1;
+          nextGrid[y][x] = 0;
+          moved = true;
+          continue;
+        }
+
+        const candidates = [];
+        if (x > 0 && currentGrid[belowY][x - 1] === 0) {
+          candidates.push(x - 1);
+        }
+        if (x < GRID_WIDTH - 1 && currentGrid[belowY][x + 1] === 0) {
+          candidates.push(x + 1);
+        }
+
+        if (candidates.length === 0) {
+          continue;
+        }
+
+        const choice = candidates[Math.floor(Math.random() * candidates.length)];
+        nextGrid[belowY][choice] = 1;
+        nextGrid[y][x] = 0;
+        moved = true;
+      }
+    }
+
+    if (moved) {
+      gridRef.current = nextGrid;
+    }
+
+    return moved;
+  }, []);
+
+  const updateAnimation = useCallback(
+    (timestamp) => {
+      if (!isRunningRef.current) {
+        return;
+      }
+
+      if (!startTimeRef.current) {
+        startTimeRef.current = timestamp;
+      }
+
+      const hasMoved = stepSimulation();
+      drawGrid();
+
+      if (grainCount > 0 && startTimeRef.current) {
+        const elapsedSeconds = (timestamp - startTimeRef.current) / 1000;
+        setElapsedTime(elapsedSeconds);
+        setHighScore((prev) =>
+          elapsedSeconds > prev ? Number(elapsedSeconds.toFixed(2)) : prev
+        );
+      } else if (grainCount === 0) {
+        startTimeRef.current = timestamp;
+        setElapsedTime(0);
+      }
+
+      if (!hasMoved && grainCount === 0) {
+        startTimeRef.current = timestamp;
+      }
+
+      animationFrameRef.current = window.requestAnimationFrame(updateAnimation);
+    },
+    [drawGrid, grainCount, stepSimulation]
+  );
+
+  useEffect(() => {
+    isRunningRef.current = isRunning;
+  }, [isRunning]);
+
+  useEffect(() => {
+    if (!isRunning) {
+      if (animationFrameRef.current) {
+        window.cancelAnimationFrame(animationFrameRef.current);
+      }
+      return undefined;
+    }
+
+    animationFrameRef.current = window.requestAnimationFrame(updateAnimation);
+    return () => {
+      if (animationFrameRef.current) {
+        window.cancelAnimationFrame(animationFrameRef.current);
+      }
+    };
+  }, [isRunning, updateAnimation]);
+
+  useEffect(() => {
+    drawGrid();
+  }, [drawGrid]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      window.localStorage.setItem(STORAGE_KEY, String(highScore));
+    } catch {
+      // Ignore persistence failures.
+    }
+  }, [highScore]);
+
+  const resetBoard = useCallback(() => {
+    gridRef.current = createEmptyGrid();
+    drawGrid();
+    countGrains();
+    startTimeRef.current = null;
+    setElapsedTime(0);
+  }, [countGrains, drawGrid]);
+
+  const handleStart = useCallback(() => {
+    startTimeRef.current = null;
+    setIsRunning(true);
+  }, []);
+
+  const handlePause = useCallback(() => {
+    setIsRunning(false);
+  }, []);
+
+  const handleReset = useCallback(() => {
+    setIsRunning(false);
+    resetBoard();
+  }, [resetBoard]);
+
+  const applyAtPosition = useCallback((clientX, clientY, erase = false) => {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return;
+    }
+
+    const rect = canvas.getBoundingClientRect();
+    const scaleX = canvas.width / rect.width;
+    const scaleY = canvas.height / rect.height;
+    const x = Math.floor(((clientX - rect.left) * scaleX) / CELL_SIZE);
+    const y = Math.floor(((clientY - rect.top) * scaleY) / CELL_SIZE);
+
+    if (x < 0 || y < 0 || x >= GRID_WIDTH || y >= GRID_HEIGHT) {
+      return;
+    }
+
+    const grid = gridRef.current;
+    const current = grid[y][x];
+    if (!erase && current === 1) {
+      return;
+    }
+    if (erase && current === 0) {
+      return;
+    }
+
+    grid[y][x] = erase ? 0 : 1;
+    drawGrid();
+    countGrains();
+  }, [countGrains, drawGrid]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return undefined;
+    }
+
+    const handlePointerDown = (event) => {
+      const erase = event.button === 2 || event.ctrlKey;
+      isDrawingRef.current = { active: true, erase };
+      applyAtPosition(event.clientX, event.clientY, erase);
+    };
+
+    const handlePointerMove = (event) => {
+      if (!isDrawingRef.current.active) {
+        return;
+      }
+      applyAtPosition(event.clientX, event.clientY, isDrawingRef.current.erase);
+    };
+
+    const handlePointerUp = () => {
+      isDrawingRef.current = { active: false, erase: false };
+    };
+
+    const preventContextMenu = (event) => {
+      event.preventDefault();
+    };
+
+    canvas.addEventListener('mousedown', handlePointerDown);
+    window.addEventListener('mousemove', handlePointerMove);
+    window.addEventListener('mouseup', handlePointerUp);
+    canvas.addEventListener('contextmenu', preventContextMenu);
+
+    return () => {
+      canvas.removeEventListener('mousedown', handlePointerDown);
+      window.removeEventListener('mousemove', handlePointerMove);
+      window.removeEventListener('mouseup', handlePointerUp);
+      canvas.removeEventListener('contextmenu', preventContextMenu);
+    };
+  }, [applyAtPosition]);
+
+  useEffect(() => {
+    if (grainCount > 0 || !isRunning) {
+      return;
+    }
+    setIsRunning(false);
+  }, [grainCount, isRunning]);
+
+  return (
+    <div className="sand-page">
+      <BackButton />
+      <div className="sand-game-container">
+        <header className="sand-game-header">
+          <h1>Sand Blocks</h1>
+          <p className="sand-game-subtitle">
+            Click or drag to drop sand. Right click or hold Ctrl while drawing to
+            erase.
+          </p>
+        </header>
+
+        <div className="sand-game-hud">
+          <div className="sand-game-scoreboard">
+            <span>Elapsed: {elapsedTime.toFixed(2)}s</span>
+            <span>High Score: {highScore.toFixed(2)}s</span>
+            <span>Grains: {grainCount}</span>
+            <span>Status: {isRunning ? 'Running' : 'Paused'}</span>
+          </div>
+          <div className="sand-game-controls">
+            <button type="button" onClick={handleStart} className="sand-button">
+              Start
+            </button>
+            <button type="button" onClick={handlePause} className="sand-button">
+              Pause
+            </button>
+            <button type="button" onClick={handleReset} className="sand-button">
+              Reset
+            </button>
+          </div>
+        </div>
+
+        <div className="sand-game-board">
+          <canvas
+            ref={canvasRef}
+            className="sand-game-canvas"
+            width={CANVAS_WIDTH}
+            height={CANVAS_HEIGHT}
+          />
+          {!isRunning && (
+            <div className="sand-game-overlay">
+              <div className="sand-game-overlay-content">
+                <h2 className="sand-game-overlay-title">Sand Blocks</h2>
+                <p className="sand-game-overlay-text">
+                  Drop sand with left click to start the simulation.
+                </p>
+                <button
+                  type="button"
+                  className="sand-button"
+                  onClick={handleStart}
+                >
+                  Start Simulation
+                </button>
+                <p className="sand-game-overlay-hint">
+                  Right click or hold Ctrl to erase grains.
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a Sand Blocks game page with a falling-sand cellular automaton and persisted high score
- style the new canvas and HUD to match the existing game layouts
- register the Sand Blocks route and dashboard card so it is accessible from the games hub

## Testing
- npm run dev -- --host 0.0.0.0 --port 5226


------
https://chatgpt.com/codex/tasks/task_e_68dace8cafec8325a08112369fbb99ab