### PR TITLE
Fix redundant closing div in DnD NPC page

### DIFF
--- a/ui/src/pages/DndDmNpcs.jsx
+++ b/ui/src/pages/DndDmNpcs.jsx
@@ -674,7 +674,6 @@ const establishmentOptions = useMemo(() => {
         {usingPath && <span className="muted">Folder: {usingPath}</span>}
         {error && <span className="error">{error}</span>}
       </div>
-      </div>
 
       <section className="pantheon-grid">
         {visibleItems.map((item) => (


### PR DESCRIPTION
## Summary
- remove the redundant closing div after the pantheon controls so the main wrapper remains intact

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dafb06f0d083259cce6ca08516bcbe