### PR TITLE
Update D&D Discord system prompt templates

### DIFF
--- a/ui/src/pages/DndDiscord.jsx
+++ b/ui/src/pages/DndDiscord.jsx
@@ -388,8 +388,8 @@ export default function DndDiscord() {
               try {
                 const npc = npcs.find((n) => n.name === actNpc);
                 const sys = [
-                  npc?.name ? You are , a D&D NPC. : 'You are a D&D NPC.',
-                  npc?.description ? Description:  : '',
+                  npc?.name ? `You are ${npc.name}, a D&D NPC.` : 'You are a D&D NPC.',
+                  npc?.description ? `Description: ${npc.description}` : '',
                   npc?.prompt || '',
                   'Respond in character, concise but vivid.',
                 ].filter(Boolean).join('\n');


### PR DESCRIPTION
## Summary
- update DndDiscord system prompt entries to use template literals for NPC name and description
- keep filtering and newline joining of system messages intact

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68db452115708325b214dde56f0e9e1d