### PR TITLE
Add tetromino sand bridging mechanic to Sand Blocks

### DIFF
--- a/ui/src/pages/SandBlocks.css
+++ b/ui/src/pages/SandBlocks.css
@@ -40,30 +40,121 @@
 }
 
 .sand-game-hud {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
   gap: var(--space-md);
   align-items: stretch;
 }
 
 .sand-game-scoreboard {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: var(--space-xs);
-  padding: var(--space-sm);
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: var(--space-sm);
+  padding: var(--space-md);
   border-radius: var(--space-sm);
-  background: rgba(15, 23, 42, 0.85);
+  background: rgba(15, 23, 42, 0.9);
   color: var(--text);
-  font-weight: 600;
-  letter-spacing: 0.02em;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.15);
 }
 
-.sand-game-scoreboard span {
-  display: block;
-  padding: var(--space-xs);
-  border-radius: var(--space-xs);
+.sand-score-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-sm);
+  border-radius: var(--space-sm);
   background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 0 4px 12px rgba(15, 23, 42, 0.45);
+}
+
+.sand-score-label {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+
+.sand-score-value {
+  font-size: clamp(1.4rem, 2.8vw, 1.8rem);
+  font-weight: 700;
+}
+
+.sand-score-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  background: rgba(148, 163, 184, 0.22);
+  color: rgba(226, 232, 240, 0.95);
+}
+
+.sand-score-badge.running {
+  background: rgba(34, 197, 94, 0.25);
+  color: #4ade80;
+}
+
+.sand-score-badge.paused {
+  background: rgba(251, 191, 36, 0.25);
+  color: #facc15;
+}
+
+.sand-score-badge.over {
+  background: rgba(248, 113, 113, 0.28);
+  color: #f87171;
+}
+
+.sand-game-preview {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-md);
+  border-radius: var(--space-sm);
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.95), rgba(30, 64, 175, 0.55));
+  color: var(--text);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.15);
+}
+
+.sand-preview-title {
+  font-size: 0.9rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  opacity: 0.8;
+}
+
+.sand-preview-grid {
+  display: grid;
+  grid-template-columns: repeat(4, clamp(18px, 4vw, 28px));
+  grid-auto-rows: clamp(18px, 4vw, 28px);
+  gap: 4px;
+  padding: 0.75rem;
+  border-radius: var(--space-sm);
+  background: rgba(255, 255, 255, 0.04);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.1);
+}
+
+.sand-preview-cell {
+  border-radius: 6px;
+  box-shadow: inset 0 2px 6px rgba(15, 23, 42, 0.45);
+  transition: transform 0.2s ease;
+}
+
+.sand-preview-cell.empty {
+  background: rgba(148, 163, 184, 0.16);
+  opacity: 0.35;
+  box-shadow: none;
+}
+
+.sand-preview-label {
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
   text-align: center;
 }
 
@@ -151,17 +242,27 @@
   opacity: 0.8;
 }
 
+@media (max-width: 1024px) {
+  .sand-game-hud {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
 @media (max-width: 768px) {
   .sand-game-container {
     padding: clamp(var(--space-sm), 4vw, var(--space-lg));
   }
 
-  .sand-game-hud {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
   .sand-game-scoreboard {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .sand-game-preview {
+    padding: var(--space-sm) var(--space-md);
+  }
+
+  .sand-preview-grid {
+    grid-template-columns: repeat(4, clamp(16px, 8vw, 24px));
+    grid-auto-rows: clamp(16px, 8vw, 24px);
   }
 }

--- a/ui/src/pages/SandBlocks.jsx
+++ b/ui/src/pages/SandBlocks.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import BackButton from '../components/BackButton.jsx';
 import './SandBlocks.css';
 
@@ -7,22 +7,119 @@ const GRID_WIDTH = 120;
 const GRID_HEIGHT = 80;
 const CANVAS_WIDTH = GRID_WIDTH * CELL_SIZE;
 const CANVAS_HEIGHT = GRID_HEIGHT * CELL_SIZE;
+const SPAWN_INTERVAL = 2000;
+const SPAWN_WARNING_ROW = 10;
+const WALL_INDICATOR_WIDTH = 4;
+const POINTS_PER_GRAIN = 10;
 const STORAGE_KEY = 'sandBlocksHighScore';
+
+const COLOR_PALETTE = [
+  { name: 'Sunburst', value: '#fbbf24' },
+  { name: 'Lagoon', value: '#38bdf8' },
+  { name: 'Rose Quartz', value: '#fb7185' },
+  { name: 'Verdant', value: '#34d399' },
+  { name: 'Amethyst', value: '#a78bfa' },
+  { name: 'Tangerine', value: '#fb923c' },
+];
+
+const BASE_SHAPES = [
+  {
+    name: 'Square',
+    cells: [
+      [0, 0],
+      [1, 0],
+      [0, 1],
+      [1, 1],
+    ],
+  },
+  {
+    name: 'Line',
+    cells: [
+      [0, 0],
+      [0, 1],
+      [0, 2],
+      [0, 3],
+    ],
+  },
+  {
+    name: 'Tee',
+    cells: [
+      [0, 0],
+      [1, 0],
+      [2, 0],
+      [1, 1],
+    ],
+  },
+  {
+    name: 'L-Shape',
+    cells: [
+      [0, 0],
+      [0, 1],
+      [0, 2],
+      [1, 2],
+    ],
+  },
+  {
+    name: 'J-Shape',
+    cells: [
+      [1, 0],
+      [1, 1],
+      [1, 2],
+      [0, 2],
+    ],
+  },
+  {
+    name: 'Zig',
+    cells: [
+      [0, 0],
+      [1, 0],
+      [1, 1],
+      [2, 1],
+    ],
+  },
+  {
+    name: 'Zag',
+    cells: [
+      [1, 0],
+      [2, 0],
+      [0, 1],
+      [1, 1],
+    ],
+  },
+];
+
+const SHAPES = BASE_SHAPES.map((shape) => {
+  const xs = shape.cells.map(([x]) => x);
+  const ys = shape.cells.map(([, y]) => y);
+  return {
+    ...shape,
+    width: Math.max(...xs) + 1,
+    height: Math.max(...ys) + 1,
+  };
+});
 
 const createEmptyGrid = () =>
   Array.from({ length: GRID_HEIGHT }, () => Array(GRID_WIDTH).fill(0));
+
+const randomShape = () => {
+  const template = SHAPES[Math.floor(Math.random() * SHAPES.length)];
+  const color = Math.floor(Math.random() * COLOR_PALETTE.length) + 1;
+  return { ...template, color };
+};
 
 export default function SandBlocks() {
   const canvasRef = useRef(null);
   const animationFrameRef = useRef(null);
   const gridRef = useRef(createEmptyGrid());
-  const startTimeRef = useRef(null);
-  const isDrawingRef = useRef({ active: false, erase: false });
   const isRunningRef = useRef(false);
+  const isGameOverRef = useRef(false);
+  const lastSpawnTimeRef = useRef(0);
 
-  const [elapsedTime, setElapsedTime] = useState(0);
   const [isRunning, setIsRunning] = useState(false);
+  const [isGameOver, setIsGameOver] = useState(false);
   const [grainCount, setGrainCount] = useState(0);
+  const [score, setScore] = useState(0);
+  const [bridgesCleared, setBridgesCleared] = useState(0);
   const [highScore, setHighScore] = useState(() => {
     if (typeof window === 'undefined') {
       return 0;
@@ -30,12 +127,26 @@ export default function SandBlocks() {
 
     try {
       const stored = window.localStorage.getItem(STORAGE_KEY);
-      const parsed = Number.parseFloat(stored);
+      const parsed = Number.parseInt(stored ?? '0', 10);
       return Number.isFinite(parsed) ? parsed : 0;
     } catch {
       return 0;
     }
   });
+  const [nextShape, setNextShape] = useState(() => randomShape());
+  const nextShapeRef = useRef(nextShape);
+
+  useEffect(() => {
+    nextShapeRef.current = nextShape;
+  }, [nextShape]);
+
+  useEffect(() => {
+    isRunningRef.current = isRunning;
+  }, [isRunning]);
+
+  useEffect(() => {
+    isGameOverRef.current = isGameOver;
+  }, [isGameOver]);
 
   const drawGrid = useCallback(() => {
     const canvas = canvasRef.current;
@@ -47,22 +158,46 @@ export default function SandBlocks() {
     ctx.fillStyle = '#0f172a';
     ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
 
-    ctx.fillStyle = '#fbbf24';
+    ctx.fillStyle = 'rgba(148, 163, 184, 0.08)';
+    ctx.fillRect(0, 0, WALL_INDICATOR_WIDTH * CELL_SIZE, CANVAS_HEIGHT);
+    ctx.fillRect(
+      CANVAS_WIDTH - WALL_INDICATOR_WIDTH * CELL_SIZE,
+      0,
+      WALL_INDICATOR_WIDTH * CELL_SIZE,
+      CANVAS_HEIGHT
+    );
+
     const grid = gridRef.current;
     for (let y = 0; y < GRID_HEIGHT; y += 1) {
       for (let x = 0; x < GRID_WIDTH; x += 1) {
-        if (grid[y][x] !== 1) {
+        const value = grid[y][x];
+        if (value === 0) {
           continue;
         }
 
-        ctx.fillRect(
-          x * CELL_SIZE,
-          y * CELL_SIZE,
-          CELL_SIZE,
-          CELL_SIZE
-        );
+        const paletteEntry = COLOR_PALETTE[value - 1] ?? COLOR_PALETTE[0];
+        const cellX = x * CELL_SIZE;
+        const cellY = y * CELL_SIZE;
+
+        ctx.fillStyle = paletteEntry.value;
+        ctx.fillRect(cellX, cellY, CELL_SIZE, CELL_SIZE);
+
+        ctx.fillStyle = 'rgba(255, 255, 255, 0.08)';
+        ctx.fillRect(cellX, cellY, CELL_SIZE, CELL_SIZE / 2);
+        ctx.fillStyle = 'rgba(15, 23, 42, 0.18)';
+        ctx.fillRect(cellX, cellY + CELL_SIZE / 2, CELL_SIZE, CELL_SIZE / 2);
       }
     }
+
+    const warningY = SPAWN_WARNING_ROW * CELL_SIZE + CELL_SIZE / 2;
+    ctx.strokeStyle = 'rgba(248, 113, 113, 0.6)';
+    ctx.lineWidth = 2;
+    ctx.setLineDash([CELL_SIZE * 2, CELL_SIZE]);
+    ctx.beginPath();
+    ctx.moveTo(0, warningY);
+    ctx.lineTo(CANVAS_WIDTH, warningY);
+    ctx.stroke();
+    ctx.setLineDash([]);
   }, []);
 
   const countGrains = useCallback(() => {
@@ -70,7 +205,7 @@ export default function SandBlocks() {
     let count = 0;
     for (let y = 0; y < GRID_HEIGHT; y += 1) {
       for (let x = 0; x < GRID_WIDTH; x += 1) {
-        if (grid[y][x] === 1) {
+        if (grid[y][x] !== 0) {
           count += 1;
         }
       }
@@ -85,13 +220,14 @@ export default function SandBlocks() {
 
     for (let y = GRID_HEIGHT - 2; y >= 0; y -= 1) {
       for (let x = 0; x < GRID_WIDTH; x += 1) {
-        if (currentGrid[y][x] !== 1) {
+        const cell = currentGrid[y][x];
+        if (cell === 0) {
           continue;
         }
 
         const belowY = y + 1;
         if (currentGrid[belowY][x] === 0) {
-          nextGrid[belowY][x] = 1;
+          nextGrid[belowY][x] = cell;
           nextGrid[y][x] = 0;
           moved = true;
           continue;
@@ -110,7 +246,7 @@ export default function SandBlocks() {
         }
 
         const choice = candidates[Math.floor(Math.random() * candidates.length)];
-        nextGrid[belowY][choice] = 1;
+        nextGrid[belowY][choice] = cell;
         nextGrid[y][x] = 0;
         moved = true;
       }
@@ -123,42 +259,156 @@ export default function SandBlocks() {
     return moved;
   }, []);
 
-  const updateAnimation = useCallback(
+  const clearBridges = useCallback(() => {
+    const grid = gridRef.current;
+    const visited = Array.from({ length: GRID_HEIGHT }, () =>
+      Array(GRID_WIDTH).fill(false)
+    );
+
+    let clearedCells = 0;
+    let componentsCleared = 0;
+
+    for (let y = 0; y < GRID_HEIGHT; y += 1) {
+      const color = grid[y][0];
+      if (color === 0 || visited[y][0]) {
+        continue;
+      }
+
+      const queue = [[0, y]];
+      const component = [];
+      let touchesRight = false;
+
+      while (queue.length > 0) {
+        const [cx, cy] = queue.shift();
+        if (
+          cx < 0 ||
+          cy < 0 ||
+          cx >= GRID_WIDTH ||
+          cy >= GRID_HEIGHT ||
+          visited[cy][cx]
+        ) {
+          continue;
+        }
+
+        if (grid[cy][cx] !== color) {
+          continue;
+        }
+
+        visited[cy][cx] = true;
+        component.push([cx, cy]);
+
+        if (cx === GRID_WIDTH - 1) {
+          touchesRight = true;
+        }
+
+        for (let nx = cx - 1; nx <= cx + 1; nx += 1) {
+          for (let ny = cy - 1; ny <= cy + 1; ny += 1) {
+            if (nx === cx && ny === cy) {
+              continue;
+            }
+            if (nx < 0 || ny < 0 || nx >= GRID_WIDTH || ny >= GRID_HEIGHT) {
+              continue;
+            }
+            if (!visited[ny][nx] && grid[ny][nx] === color) {
+              queue.push([nx, ny]);
+            }
+          }
+        }
+      }
+
+      if (touchesRight && component.length > 0) {
+        component.forEach(([cx, cy]) => {
+          grid[cy][cx] = 0;
+        });
+        clearedCells += component.length;
+        componentsCleared += 1;
+      }
+    }
+
+    if (clearedCells > 0) {
+      gridRef.current = grid;
+      setBridgesCleared((prev) => prev + componentsCleared);
+      setScore((prevScore) => {
+        const updatedScore = prevScore + clearedCells * POINTS_PER_GRAIN;
+        setHighScore((prevHigh) =>
+          updatedScore > prevHigh ? updatedScore : prevHigh
+        );
+        return updatedScore;
+      });
+      drawGrid();
+      countGrains();
+    }
+  }, [countGrains, drawGrid]);
+
+  const spawnShape = useCallback(
     (timestamp) => {
-      if (!isRunningRef.current) {
+      const shape = nextShapeRef.current;
+      if (!shape) {
         return;
       }
 
-      if (!startTimeRef.current) {
-        startTimeRef.current = timestamp;
+      const spawnX = Math.floor((GRID_WIDTH - shape.width) / 2);
+      const placements = shape.cells.map(([dx, dy]) => ({
+        x: spawnX + dx,
+        y: dy,
+      }));
+
+      const grid = gridRef.current;
+      const blocked = placements.some(
+        ({ x, y }) => x < 0 || x >= GRID_WIDTH || y < 0 || y >= GRID_HEIGHT || grid[y][x] !== 0
+      );
+
+      if (blocked) {
+        setIsGameOver(true);
+        setIsRunning(false);
+        return;
       }
 
-      const hasMoved = stepSimulation();
+      placements.forEach(({ x, y }) => {
+        grid[y][x] = shape.color;
+      });
+      gridRef.current = grid;
+      countGrains();
       drawGrid();
 
-      if (grainCount > 0 && startTimeRef.current) {
-        const elapsedSeconds = (timestamp - startTimeRef.current) / 1000;
-        setElapsedTime(elapsedSeconds);
-        setHighScore((prev) =>
-          elapsedSeconds > prev ? Number(elapsedSeconds.toFixed(2)) : prev
-        );
-      } else if (grainCount === 0) {
-        startTimeRef.current = timestamp;
-        setElapsedTime(0);
+      const upcoming = randomShape();
+      nextShapeRef.current = upcoming;
+      setNextShape(upcoming);
+      lastSpawnTimeRef.current = timestamp;
+    },
+    [countGrains, drawGrid]
+  );
+
+  const maybeSpawnShape = useCallback(
+    (timestamp) => {
+      if (!isRunningRef.current || isGameOverRef.current) {
+        return;
       }
 
-      if (!hasMoved && grainCount === 0) {
-        startTimeRef.current = timestamp;
+      if (timestamp - lastSpawnTimeRef.current < SPAWN_INTERVAL) {
+        return;
       }
+
+      spawnShape(timestamp);
+    },
+    [spawnShape]
+  );
+
+  const updateAnimation = useCallback(
+    (timestamp) => {
+      if (!isRunningRef.current || isGameOverRef.current) {
+        return;
+      }
+
+      stepSimulation();
+      clearBridges();
+      maybeSpawnShape(timestamp);
+      drawGrid();
 
       animationFrameRef.current = window.requestAnimationFrame(updateAnimation);
     },
-    [drawGrid, grainCount, stepSimulation]
+    [clearBridges, drawGrid, maybeSpawnShape, stepSimulation]
   );
-
-  useEffect(() => {
-    isRunningRef.current = isRunning;
-  }, [isRunning]);
 
   useEffect(() => {
     if (!isRunning) {
@@ -196,14 +446,15 @@ export default function SandBlocks() {
     gridRef.current = createEmptyGrid();
     drawGrid();
     countGrains();
-    startTimeRef.current = null;
-    setElapsedTime(0);
+    lastSpawnTimeRef.current = 0;
   }, [countGrains, drawGrid]);
 
   const handleStart = useCallback(() => {
-    startTimeRef.current = null;
+    if (isGameOver) {
+      return;
+    }
     setIsRunning(true);
-  }, []);
+  }, [isGameOver]);
 
   const handlePause = useCallback(() => {
     setIsRunning(false);
@@ -211,85 +462,53 @@ export default function SandBlocks() {
 
   const handleReset = useCallback(() => {
     setIsRunning(false);
+    setIsGameOver(false);
     resetBoard();
+    setScore(0);
+    setBridgesCleared(0);
+    const upcoming = randomShape();
+    nextShapeRef.current = upcoming;
+    setNextShape(upcoming);
   }, [resetBoard]);
 
-  const applyAtPosition = useCallback((clientX, clientY, erase = false) => {
-    const canvas = canvasRef.current;
-    if (!canvas) {
-      return;
+  const handlePlayAgain = useCallback(() => {
+    handleReset();
+    setIsRunning(true);
+  }, [handleReset]);
+
+  const previewMatrix = useMemo(() => {
+    const matrix = Array.from({ length: 4 }, () => Array(4).fill(0));
+    if (!nextShape) {
+      return matrix;
     }
 
-    const rect = canvas.getBoundingClientRect();
-    const scaleX = canvas.width / rect.width;
-    const scaleY = canvas.height / rect.height;
-    const x = Math.floor(((clientX - rect.left) * scaleX) / CELL_SIZE);
-    const y = Math.floor(((clientY - rect.top) * scaleY) / CELL_SIZE);
+    const offsetX = Math.floor((4 - nextShape.width) / 2);
+    const offsetY = Math.floor((4 - nextShape.height) / 2);
 
-    if (x < 0 || y < 0 || x >= GRID_WIDTH || y >= GRID_HEIGHT) {
-      return;
-    }
-
-    const grid = gridRef.current;
-    const current = grid[y][x];
-    if (!erase && current === 1) {
-      return;
-    }
-    if (erase && current === 0) {
-      return;
-    }
-
-    grid[y][x] = erase ? 0 : 1;
-    drawGrid();
-    countGrains();
-  }, [countGrains, drawGrid]);
-
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) {
-      return undefined;
-    }
-
-    const handlePointerDown = (event) => {
-      const erase = event.button === 2 || event.ctrlKey;
-      isDrawingRef.current = { active: true, erase };
-      applyAtPosition(event.clientX, event.clientY, erase);
-    };
-
-    const handlePointerMove = (event) => {
-      if (!isDrawingRef.current.active) {
-        return;
+    nextShape.cells.forEach(([dx, dy]) => {
+      const px = dx + offsetX;
+      const py = dy + offsetY;
+      if (px >= 0 && px < 4 && py >= 0 && py < 4) {
+        matrix[py][px] = nextShape.color;
       }
-      applyAtPosition(event.clientX, event.clientY, isDrawingRef.current.erase);
-    };
+    });
 
-    const handlePointerUp = () => {
-      isDrawingRef.current = { active: false, erase: false };
-    };
+    return matrix;
+  }, [nextShape]);
 
-    const preventContextMenu = (event) => {
-      event.preventDefault();
-    };
+  const statusLabel = isGameOver
+    ? 'Game Over'
+    : isRunning
+    ? 'Running'
+    : 'Paused';
 
-    canvas.addEventListener('mousedown', handlePointerDown);
-    window.addEventListener('mousemove', handlePointerMove);
-    window.addEventListener('mouseup', handlePointerUp);
-    canvas.addEventListener('contextmenu', preventContextMenu);
+  const statusBadgeClass = isGameOver
+    ? 'sand-score-badge over'
+    : isRunning
+    ? 'sand-score-badge running'
+    : 'sand-score-badge paused';
 
-    return () => {
-      canvas.removeEventListener('mousedown', handlePointerDown);
-      window.removeEventListener('mousemove', handlePointerMove);
-      window.removeEventListener('mouseup', handlePointerUp);
-      canvas.removeEventListener('contextmenu', preventContextMenu);
-    };
-  }, [applyAtPosition]);
-
-  useEffect(() => {
-    if (grainCount > 0 || !isRunning) {
-      return;
-    }
-    setIsRunning(false);
-  }, [grainCount, isRunning]);
+  const nextColor = COLOR_PALETTE[nextShape?.color - 1];
 
   return (
     <div className="sand-page">
@@ -298,29 +517,72 @@ export default function SandBlocks() {
         <header className="sand-game-header">
           <h1>Sand Blocks</h1>
           <p className="sand-game-subtitle">
-            Click or drag to drop sand. Right click or hold Ctrl while drawing to
-            erase.
+            Guide falling blocky sand shapes and forge bridges of matching colors
+            from the left wall to the right wall to clear them and score points.
           </p>
         </header>
 
         <div className="sand-game-hud">
           <div className="sand-game-scoreboard">
-            <span>Elapsed: {elapsedTime.toFixed(2)}s</span>
-            <span>High Score: {highScore.toFixed(2)}s</span>
-            <span>Grains: {grainCount}</span>
-            <span>Status: {isRunning ? 'Running' : 'Paused'}</span>
+            <div className="sand-score-card">
+              <span className="sand-score-label">Score</span>
+              <span className="sand-score-value">{score.toLocaleString()}</span>
+            </div>
+            <div className="sand-score-card">
+              <span className="sand-score-label">High Score</span>
+              <span className="sand-score-value">
+                {highScore.toLocaleString()}
+              </span>
+            </div>
+            <div className="sand-score-card">
+              <span className="sand-score-label">Bridges Cleared</span>
+              <span className="sand-score-value">
+                {bridgesCleared.toLocaleString()}
+              </span>
+            </div>
+            <div className="sand-score-card">
+              <span className="sand-score-label">Grains</span>
+              <span className="sand-score-value">{grainCount.toLocaleString()}</span>
+            </div>
+            <div className="sand-score-card">
+              <span className="sand-score-label">Status</span>
+              <span className={statusBadgeClass}>{statusLabel}</span>
+            </div>
           </div>
-          <div className="sand-game-controls">
-            <button type="button" onClick={handleStart} className="sand-button">
-              Start
-            </button>
-            <button type="button" onClick={handlePause} className="sand-button">
-              Pause
-            </button>
-            <button type="button" onClick={handleReset} className="sand-button">
-              Reset
-            </button>
+
+          <div className="sand-game-preview">
+            <span className="sand-preview-title">Next</span>
+            <div className="sand-preview-grid">
+              {previewMatrix.map((row, rowIndex) =>
+                row.map((value, columnIndex) => {
+                  const key = `${rowIndex}-${columnIndex}`;
+                  const paletteEntry = COLOR_PALETTE[value - 1];
+                  const style = value
+                    ? { backgroundColor: paletteEntry?.value }
+                    : undefined;
+                  const cellClass = value
+                    ? 'sand-preview-cell'
+                    : 'sand-preview-cell empty';
+                  return <div key={key} className={cellClass} style={style} />;
+                })
+              )}
+            </div>
+            <span className="sand-preview-label">
+              {nextColor ? `${nextColor.name} ${nextShape.name}` : nextShape.name}
+            </span>
           </div>
+        </div>
+
+        <div className="sand-game-controls">
+          <button type="button" onClick={handleStart} className="sand-button">
+            Start
+          </button>
+          <button type="button" onClick={handlePause} className="sand-button">
+            Pause
+          </button>
+          <button type="button" onClick={handleReset} className="sand-button">
+            Reset
+          </button>
         </div>
 
         <div className="sand-game-board">
@@ -330,22 +592,35 @@ export default function SandBlocks() {
             width={CANVAS_WIDTH}
             height={CANVAS_HEIGHT}
           />
-          {!isRunning && (
+          {(!isRunning || isGameOver) && (
             <div className="sand-game-overlay">
               <div className="sand-game-overlay-content">
                 <h2 className="sand-game-overlay-title">Sand Blocks</h2>
                 <p className="sand-game-overlay-text">
-                  Drop sand with left click to start the simulation.
+                  Connect a single color from one wall to the other using the
+                  falling tetromino-style sand pieces. Clearing bridges keeps the
+                  board from overflowing and earns huge points.
                 </p>
-                <button
-                  type="button"
-                  className="sand-button"
-                  onClick={handleStart}
-                >
-                  Start Simulation
-                </button>
+                {isGameOver ? (
+                  <button
+                    type="button"
+                    className="sand-button"
+                    onClick={handlePlayAgain}
+                  >
+                    Play Again
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    className="sand-button"
+                    onClick={handleStart}
+                  >
+                    Start Simulation
+                  </button>
+                )}
                 <p className="sand-game-overlay-hint">
-                  Right click or hold Ctrl to erase grains.
+                  Tip: Watch the edges—only bridges that touch both walls will
+                  collapse into points.
                 </p>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- spawn color-coded tetromino sand shapes and simulate their granular fall
- track bridge clears that connect matching colors from wall to wall and score them with persistence
- refresh the Sand Blocks UI with a next-piece preview, updated scoreboard, and overlay messaging

## Testing
- Not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68db451d44f88325bc056a479ba5c5d1