### PR TITLE
Add selectable queue preview to Sand Blocks

### DIFF
--- a/ui/src/pages/SandBlocks.css
+++ b/ui/src/pages/SandBlocks.css
@@ -128,6 +128,57 @@
   opacity: 0.8;
 }
 
+.sand-preview-queue {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: var(--space-sm);
+}
+
+.sand-preview-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: center;
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: var(--space-sm);
+  background: rgba(15, 23, 42, 0.55);
+  color: inherit;
+  cursor: pointer;
+  text-align: center;
+  transition: transform 0.15s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.sand-preview-card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(96, 165, 250, 0.5);
+  box-shadow: 0 10px 18px rgba(15, 23, 42, 0.35);
+}
+
+.sand-preview-card.selected {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.45);
+}
+
+.sand-preview-card:focus {
+  outline: none;
+  border-color: rgba(96, 165, 250, 0.75);
+  box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.45);
+}
+
+.sand-preview-order {
+  position: absolute;
+  top: 0.45rem;
+  left: 0.6rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  opacity: 0.7;
+}
+
 .sand-preview-grid {
   display: grid;
   grid-template-columns: repeat(4, clamp(18px, 4vw, 28px));
@@ -156,6 +207,13 @@
   font-weight: 600;
   letter-spacing: 0.04em;
   text-align: center;
+}
+
+.sand-preview-helper {
+  font-size: 0.8rem;
+  opacity: 0.7;
+  text-align: center;
+  max-width: 16rem;
 }
 
 .sand-game-controls {


### PR DESCRIPTION
## Summary
- expand Sand Blocks upcoming piece state into a three-shape queue that can be selected
- consume the selected queued shape when spawning and replenish the queue
- redesign the HUD preview to display queued cards with updated styling and instructions

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68db6c5c73f08325a9ff0474a1fe2858