### PR TITLE
Surface calendar entry on dashboard wheel

### DIFF
--- a/ui/src/pages/Dashboard.jsx
+++ b/ui/src/pages/Dashboard.jsx
@@ -22,6 +22,7 @@ export default function Dashboard() {
   }, []);
   const items = [
     { to: '/musicgen', icon: 'Music', title: 'Sound Lab' },
+    { to: '/calendar', icon: 'CalendarDays', title: 'Calendar' },
     { to: '/dnd', icon: 'Dice5', title: 'Dungeons & Dragons' },
     { to: '/games', icon: 'Gamepad2', title: 'Games' },
     { to: '/tools', icon: 'Wrench', title: 'Tools' },

--- a/ui/src/pages/Tools.jsx
+++ b/ui/src/pages/Tools.jsx
@@ -31,9 +31,6 @@ export default function Tools() {
         <Card to="/album" icon="Disc3" title="Album Maker">
           Cover + Tracklist Generator
         </Card>
-        <Card to="/calendar" icon="CalendarDays" title="Calendar">
-          Visual Schedule Planner
-        </Card>
         <Card to="/train" icon="Sliders" title="Train Model">
           Custom Model Trainer
         </Card>


### PR DESCRIPTION
## Summary
- add the calendar option to the dashboard feature wheel for quick access
- remove the duplicate calendar card from the tools grid

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db6df92fec8325947340239984ed01