### PR TITLE
Increase SandBlocks tile size and update scaling

### DIFF
--- a/ui/src/pages/SandBlocks.css
+++ b/ui/src/pages/SandBlocks.css
@@ -181,9 +181,9 @@
 
 .sand-preview-grid {
   display: grid;
-  grid-template-columns: repeat(4, clamp(18px, 4vw, 28px));
-  grid-auto-rows: clamp(18px, 4vw, 28px);
-  gap: 4px;
+  grid-template-columns: repeat(4, clamp(28px, 4vw, 40px));
+  grid-auto-rows: clamp(28px, 4vw, 40px);
+  gap: 6px;
   padding: 0.75rem;
   border-radius: var(--space-sm);
   background: rgba(255, 255, 255, 0.04);
@@ -252,7 +252,7 @@
 }
 
 .sand-game-canvas {
-  width: min(100%, 720px);
+  width: auto;
   height: auto;
   border: 2px solid var(--accent);
   border-radius: var(--space-sm);
@@ -320,7 +320,7 @@
   }
 
   .sand-preview-grid {
-    grid-template-columns: repeat(4, clamp(16px, 8vw, 24px));
-    grid-auto-rows: clamp(16px, 8vw, 24px);
+    grid-template-columns: repeat(4, clamp(24px, 8vw, 32px));
+    grid-auto-rows: clamp(24px, 8vw, 32px);
   }
 }

--- a/ui/src/pages/SandBlocks.jsx
+++ b/ui/src/pages/SandBlocks.jsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import BackButton from '../components/BackButton.jsx';
 import './SandBlocks.css';
 
-const CELL_SIZE = 6;
+const CELL_SIZE = 16;
 const GRID_WIDTH = 120;
 const GRID_HEIGHT = 80;
 const CANVAS_WIDTH = GRID_WIDTH * CELL_SIZE;


### PR DESCRIPTION
## Summary
- raise the Sand Blocks canvas cell size to 16 to expand the playfield resolution
- remove the canvas width cap so the larger grid renders at its native size
- enlarge the preview grid cells to keep the HUD visuals aligned with the new tiles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db6e052cd0832597d5a24a21cc3f0c