### PR TITLE
Add day planner modal with persistent calendar events

### DIFF
--- a/ui/src/pages/Calendar.css
+++ b/ui/src/pages/Calendar.css
@@ -3,14 +3,13 @@
   max-width: 1200px;
   margin: 0 auto var(--space-xl);
   padding: 0 var(--space-xl) var(--space-xl);
-  display: grid;
-  grid-template-columns: minmax(0, 2.25fr) minmax(0, 1fr);
+  display: flex;
+  flex-direction: column;
   gap: var(--space-xl);
   box-sizing: border-box;
 }
 
-.calendar-main,
-.calendar-sidebar {
+.calendar-main {
   background: var(--card-bg);
   border-radius: 18px;
   box-shadow: var(--card-shadow);
@@ -100,6 +99,18 @@
   background: var(--button-hover-bg);
   transform: translateY(-1px);
   box-shadow: var(--card-shadow);
+}
+
+.calendar-action-button--primary {
+  background: var(--accent);
+  color: #ffffff;
+  box-shadow: 0 14px 32px rgba(0, 0, 0, 0.38);
+}
+
+.calendar-action-button--primary:hover,
+.calendar-action-button--primary:focus-visible {
+  background: color-mix(in srgb, var(--accent), #ffffff 18%);
+  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.45);
 }
 
 .calendar-week-start {
@@ -228,6 +239,39 @@
   color: #ffffff;
 }
 
+.calendar-cell-event-chips {
+  margin-top: auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.calendar-cell-event-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.18rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #ffffff;
+  background: color-mix(
+    in srgb,
+    var(--event-chip-color, var(--accent)),
+    rgba(0, 0, 0, 0.2) 20%
+  );
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  white-space: nowrap;
+}
+
+.calendar-cell-event-chip--count {
+  background: color-mix(in srgb, var(--card-hover-bg), var(--accent) 40%);
+  color: var(--text);
+  box-shadow: none;
+}
+
 .calendar-sidebar-title {
   font-size: 1.2rem;
   font-weight: 700;
@@ -268,13 +312,257 @@
   color: color-mix(in srgb, var(--text), transparent 35%);
 }
 
-@media (max-width: 1100px) {
-  .calendar-page {
-    grid-template-columns: 1fr;
-  }
+.calendar-day-view-overlay {
+  position: fixed;
+  inset: 0;
+  background: color-mix(in srgb, rgba(12, 14, 24, 0.85), transparent 12%);
+  backdrop-filter: blur(16px) saturate(120%);
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  padding: var(--space-xl);
+  box-sizing: border-box;
+  z-index: 1000;
+}
 
-  .calendar-main,
-  .calendar-sidebar {
+.calendar-day-view {
+  width: min(460px, 100%);
+  max-height: calc(100vh - 2 * var(--space-xl));
+  background: var(--card-bg);
+  border-radius: 20px;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  outline: none;
+}
+
+.calendar-day-view-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-md);
+  padding: var(--space-lg);
+  border-bottom: 1px solid color-mix(in srgb, var(--card-hover-bg), var(--text) 12%);
+}
+
+.calendar-day-view-header-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.calendar-day-view-subtitle {
+  margin: 0;
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.calendar-day-view-meta {
+  margin: 0;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: color-mix(in srgb, var(--text), transparent 40%);
+}
+
+.calendar-day-view-close {
+  border: none;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in srgb, var(--card-hover-bg), transparent 20%);
+  color: var(--text);
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.calendar-day-view-close:hover,
+.calendar-day-view-close:focus-visible {
+  background: color-mix(in srgb, var(--accent), transparent 65%);
+  color: var(--accent);
+  transform: translateY(-2px);
+  box-shadow: var(--card-shadow);
+}
+
+.calendar-day-view-body {
+  padding: var(--space-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+  overflow-y: auto;
+}
+
+.calendar-day-view-section-title {
+  margin: 0 0 0.3rem;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: color-mix(in srgb, var(--text), transparent 45%);
+}
+
+.calendar-day-view-summary {
+  margin: 0 0 var(--space-md);
+  font-weight: 600;
+  color: color-mix(in srgb, var(--text), transparent 30%);
+}
+
+.calendar-day-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+  border: 1px solid color-mix(in srgb, var(--card-hover-bg), var(--text) 12%);
+  border-radius: 16px;
+  padding: var(--space-md);
+  background: color-mix(in srgb, var(--card-bg), transparent 4%);
+  max-height: 340px;
+  overflow-y: auto;
+}
+
+.calendar-day-hour {
+  display: grid;
+  grid-template-columns: 70px 1fr;
+  gap: var(--space-sm);
+  align-items: flex-start;
+  padding: 0.4rem 0.5rem;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--card-bg), transparent 6%);
+}
+
+.calendar-day-hour-label {
+  font-weight: 700;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: color-mix(in srgb, var(--text), transparent 40%);
+}
+
+.calendar-day-hour-events {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.calendar-day-hour-empty {
+  font-size: 0.75rem;
+  color: color-mix(in srgb, var(--text), transparent 60%);
+}
+
+.calendar-event-chip {
+  background: color-mix(
+    in srgb,
+    var(--event-chip-color, var(--accent)),
+    var(--card-bg) 55%
+  );
+  border-left: 4px solid var(--event-chip-color, var(--accent));
+  border-radius: 14px;
+  padding: 0.65rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  box-shadow: 0 12px 22px rgba(0, 0, 0, 0.25);
+}
+
+.calendar-event-chip-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-sm);
+}
+
+.calendar-event-chip-title {
+  font-weight: 700;
+}
+
+.calendar-event-chip-time {
+  font-size: 0.75rem;
+  color: color-mix(in srgb, var(--text), transparent 40%);
+}
+
+.calendar-event-chip-category {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: color-mix(in srgb, var(--text), transparent 35%);
+}
+
+
+.calendar-day-view-schedule,
+.calendar-day-view-form-section {
+  display: flex;
+  flex-direction: column;
+}
+
+.calendar-day-view-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.calendar-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-md);
+}
+
+.calendar-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.calendar-form-label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: color-mix(in srgb, var(--text), transparent 45%);
+}
+
+.calendar-input {
+  border-radius: 12px;
+  border: 1px solid color-mix(in srgb, var(--card-hover-bg), var(--text) 18%);
+  background: color-mix(in srgb, var(--card-bg), transparent 10%);
+  color: var(--text);
+  font-weight: 600;
+  padding: 0.55rem 0.75rem;
+  font-size: 1rem;
+}
+
+.calendar-input:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent), transparent 55%);
+  outline-offset: 2px;
+}
+
+.calendar-form-error {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: color-mix(in srgb, #ff6b6b, var(--text) 20%);
+}
+
+.calendar-form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 1100px) {
+  .calendar-main {
     padding: var(--space-md);
   }
 
@@ -305,6 +593,44 @@
   .calendar-action-button,
   .calendar-cell {
     transition: none;
+  }
+}
+
+@media (max-width: 900px) {
+  .calendar-day-view-overlay {
+    justify-content: center;
+    padding: var(--space-lg);
+  }
+
+  .calendar-day-view {
+    width: min(520px, 100%);
+    max-height: calc(100vh - 2 * var(--space-lg));
+  }
+}
+
+@media (max-width: 720px) {
+  .calendar-form-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 600px) {
+  .calendar-day-view-overlay {
+    padding: 0;
+  }
+
+  .calendar-day-view {
+    width: 100%;
+    max-height: 100vh;
+    border-radius: 0;
+  }
+
+  .calendar-day-view-body {
+    padding: var(--space-md);
+  }
+
+  .calendar-day-view-header {
+    padding: var(--space-md);
   }
 }
 

--- a/ui/src/pages/Calendar.jsx
+++ b/ui/src/pages/Calendar.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useCallback } from 'react';
+import { useMemo, useState, useCallback, useEffect, useReducer, useRef } from 'react';
 import BackButton from '../components/BackButton.jsx';
 import Icon from '../components/Icon.jsx';
 import './Calendar.css';
@@ -9,6 +9,168 @@ const WEEK_START_OPTIONS = [
 ];
 
 const MS_IN_DAY = 24 * 60 * 60 * 1000;
+const LOCAL_STORAGE_KEY = 'calendar.events';
+
+const EVENT_CATEGORIES = [
+  {
+    id: 'work',
+    label: 'Work',
+    accent: '#7c8bff',
+    defaultTitle: 'Work session',
+  },
+  {
+    id: 'social',
+    label: 'Social',
+    accent: '#f472b6',
+    defaultTitle: 'Social plan',
+  },
+  {
+    id: 'task',
+    label: 'Task',
+    accent: '#34d399',
+    defaultTitle: 'Task reminder',
+  },
+  {
+    id: 'custom',
+    label: 'Custom',
+    accent: '#f59e0b',
+    defaultTitle: '',
+  },
+];
+
+function sanitizeStoredEvents(raw) {
+  if (!raw || typeof raw !== 'object') {
+    return {};
+  }
+
+  return Object.entries(raw).reduce((acc, [dateKey, events]) => {
+    if (!Array.isArray(events)) {
+      return acc;
+    }
+
+    const sanitized = events
+      .map((event) => {
+        if (!event) return null;
+        const startMinutes = Number(event.startMinutes ?? parseTimeToMinutes(event.startTime));
+        const endMinutes = Number(event.endMinutes ?? parseTimeToMinutes(event.endTime));
+        if (Number.isNaN(startMinutes) || Number.isNaN(endMinutes)) {
+          return null;
+        }
+        return {
+          id: event.id ?? `${dateKey}-${startMinutes}-${endMinutes}`,
+          title: event.title ?? 'Untitled event',
+          category: EVENT_CATEGORIES.some((cat) => cat.id === event.category)
+            ? event.category
+            : 'custom',
+          startTime: event.startTime ?? minutesToTimeString(startMinutes),
+          endTime: event.endTime ?? minutesToTimeString(endMinutes),
+          startMinutes,
+          endMinutes,
+        };
+      })
+      .filter(Boolean)
+      .sort((a, b) => a.startMinutes - b.startMinutes);
+
+    if (sanitized.length > 0) {
+      acc[dateKey] = sanitized;
+    }
+    return acc;
+  }, {});
+}
+
+function loadStoredEvents() {
+  if (typeof window === 'undefined') {
+    return {};
+  }
+  try {
+    const stored = window.localStorage.getItem(LOCAL_STORAGE_KEY);
+    if (!stored) {
+      return {};
+    }
+    const parsed = JSON.parse(stored);
+    return sanitizeStoredEvents(parsed);
+  } catch (error) {
+    console.warn('Failed to load stored calendar events', error);
+    return {};
+  }
+}
+
+function calendarEventsReducer(state, action) {
+  switch (action.type) {
+    case 'add': {
+      const { dateKey, event } = action.payload;
+      const existing = state[dateKey] ?? [];
+      const nextEvents = [...existing, event].sort((a, b) => a.startMinutes - b.startMinutes);
+      return { ...state, [dateKey]: nextEvents };
+    }
+    case 'set': {
+      return sanitizeStoredEvents(action.payload ?? {});
+    }
+    default:
+      return state;
+  }
+}
+
+function parseTimeToMinutes(value) {
+  if (typeof value !== 'string') return Number.NaN;
+  const [hours, minutes] = value.split(':').map((part) => Number.parseInt(part, 10));
+  if (Number.isNaN(hours) || Number.isNaN(minutes)) return Number.NaN;
+  return hours * 60 + minutes;
+}
+
+function minutesToTimeString(minutes) {
+  const hrs = Math.floor(minutes / 60)
+    .toString()
+    .padStart(2, '0');
+  const mins = Math.floor(minutes % 60)
+    .toString()
+    .padStart(2, '0');
+  return `${hrs}:${mins}`;
+}
+
+function validateTimeRange(startValue, endValue) {
+  const startMinutes = parseTimeToMinutes(startValue);
+  const endMinutes = parseTimeToMinutes(endValue);
+  if (Number.isNaN(startMinutes) || Number.isNaN(endMinutes)) {
+    return { isValid: false, message: 'Please provide valid start and end times.' };
+  }
+  if (startMinutes >= endMinutes) {
+    return {
+      isValid: false,
+      message: 'The start time must be earlier than the end time.',
+    };
+  }
+  return { isValid: true, startMinutes, endMinutes };
+}
+
+function hasTimeCollision(events, startMinutes, endMinutes) {
+  return events.some((event) => {
+    const startsBeforeEnd = event.startMinutes < endMinutes;
+    const endsAfterStart = event.endMinutes > startMinutes;
+    return startsBeforeEnd && endsAfterStart;
+  });
+}
+
+function generateHourLabels() {
+  return Array.from({ length: 24 }, (_, hour) => {
+    const label = `${hour.toString().padStart(2, '0')}:00`;
+    return { hour, label };
+  });
+}
+
+function formatMinutesRange(startMinutes, endMinutes) {
+  return `${minutesToTimeString(startMinutes)} – ${minutesToTimeString(endMinutes)}`;
+}
+
+function createDefaultFormState(category = 'work') {
+  const meta = EVENT_CATEGORIES.find((item) => item.id === category);
+  return {
+    category,
+    title: meta?.defaultTitle ?? '',
+    startTime: '09:00',
+    endTime: '10:00',
+  };
+}
 
 function startOfDay(date) {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate());
@@ -60,23 +222,40 @@ function getStartOfWeek(date, weekStart) {
   return result;
 }
 
-function getDayOfYear(date) {
-  const start = new Date(date.getFullYear(), 0, 0);
-  const diff = startOfDay(date) - start;
-  return Math.floor(diff / MS_IN_DAY);
-}
-
-function isLeapYear(year) {
-  if (year % 4 !== 0) return false;
-  if (year % 100 !== 0) return true;
-  return year % 400 === 0;
-}
-
 export default function Calendar() {
   const today = useMemo(() => startOfDay(new Date()), []);
   const [visibleMonth, setVisibleMonth] = useState(() => startOfMonth(today));
   const [selectedDate, setSelectedDate] = useState(() => today);
   const [weekStart, setWeekStart] = useState(WEEK_START_OPTIONS[0].value);
+  const [eventsByDate, dispatchEvents] = useReducer(
+    calendarEventsReducer,
+    {},
+    loadStoredEvents
+  );
+  const [isDayViewOpen, setDayViewOpen] = useState(false);
+  const [formState, setFormState] = useState(() => createDefaultFormState());
+  const [formError, setFormError] = useState('');
+  const dayViewRef = useRef(null);
+
+  const categoryMap = useMemo(
+    () =>
+      EVENT_CATEGORIES.reduce((acc, category) => {
+        acc[category.id] = category;
+        return acc;
+      }, {}),
+    []
+  );
+  const hourSlots = useMemo(() => generateHourLabels(), []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(eventsByDate));
+  }, [eventsByDate]);
+
+  const handleCloseDayView = useCallback(() => {
+    setDayViewOpen(false);
+    setFormError('');
+  }, []);
 
   const weeks = useMemo(
     () => buildCalendarWeeks(visibleMonth, weekStart),
@@ -167,21 +346,6 @@ export default function Calendar() {
     return diff > 0 ? `${abs} ${unit} from now` : `${abs} ${unit} ago`;
   }, [selectedDate, today]);
 
-  const dayOfYear = useMemo(
-    () => (selectedDate ? getDayOfYear(selectedDate) : null),
-    [selectedDate]
-  );
-  const totalDaysInYear = useMemo(() => {
-    if (!selectedDate) return null;
-    return isLeapYear(selectedDate.getFullYear()) ? 366 : 365;
-  }, [selectedDate]);
-  const quarter = useMemo(
-    () =>
-      selectedDate != null
-        ? Math.floor(selectedDate.getMonth() / 3) + 1
-        : null,
-    [selectedDate]
-  );
   const isoValue = useMemo(() => {
     if (!selectedDate) return '—';
     const year = selectedDate.getFullYear();
@@ -189,6 +353,84 @@ export default function Calendar() {
     const day = String(selectedDate.getDate()).padStart(2, '0');
     return `${year}-${month}-${day}`;
   }, [selectedDate]);
+
+  const selectedDateKey = useMemo(
+    () => (selectedDate ? formatDateKey(selectedDate) : null),
+    [selectedDate]
+  );
+  const dayEvents = selectedDateKey ? eventsByDate[selectedDateKey] ?? [] : [];
+
+  const handleOverlayClick = useCallback(
+    (event) => {
+      if (event.target === event.currentTarget) {
+        handleCloseDayView();
+      }
+    },
+    [handleCloseDayView]
+  );
+
+  useEffect(() => {
+    if (!isDayViewOpen) {
+      return undefined;
+    }
+    const node = dayViewRef.current;
+    if (!node) {
+      return undefined;
+    }
+
+    const focusableSelector =
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+    const focusFirstElement = () => {
+      const focusable = node.querySelectorAll(focusableSelector);
+      if (focusable.length > 0) {
+        focusable[0].focus();
+      } else {
+        node.focus();
+      }
+    };
+
+    focusFirstElement();
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        handleCloseDayView();
+        return;
+      }
+
+      if (event.key !== 'Tab') {
+        return;
+      }
+
+      const focusable = Array.from(node.querySelectorAll(focusableSelector)).filter(
+        (el) => !el.hasAttribute('disabled') && el.getAttribute('tabindex') !== '-1'
+      );
+
+      if (focusable.length === 0) {
+        event.preventDefault();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+
+      if (event.shiftKey) {
+        if (active === first || !node.contains(active)) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else if (active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleCloseDayView, isDayViewOpen]);
 
   const handleMonthChange = useCallback(
     (direction) => {
@@ -218,8 +460,115 @@ export default function Calendar() {
         }
         return startOfMonth(normalized);
       });
+      setFormError('');
+      setDayViewOpen(true);
     },
     [setSelectedDate, setVisibleMonth]
+  );
+
+  const handleAddEventClick = useCallback(() => {
+    setFormError('');
+    if (selectedDate) {
+      setDayViewOpen(true);
+      return;
+    }
+    const normalizedToday = today;
+    setSelectedDate(normalizedToday);
+    setVisibleMonth(startOfMonth(normalizedToday));
+    setDayViewOpen(true);
+  }, [selectedDate, setSelectedDate, setVisibleMonth, today]);
+
+  const handleFormChange = useCallback(
+    (event) => {
+      const { name, value } = event.target;
+      setFormError('');
+      if (name === 'category') {
+        setFormState((prev) => {
+          const nextCategory = value;
+          const nextMeta = categoryMap[nextCategory];
+          const nextTitle =
+            nextCategory === 'custom'
+              ? prev.category === 'custom'
+                ? prev.title
+                : ''
+              : nextMeta?.defaultTitle ?? prev.title ?? '';
+          return {
+            ...prev,
+            category: nextCategory,
+            title: nextTitle,
+          };
+        });
+        return;
+      }
+      setFormState((prev) => ({ ...prev, [name]: value }));
+    },
+    [categoryMap]
+  );
+
+  const handleSubmitEvent = useCallback(
+    (event) => {
+      event.preventDefault();
+      if (!selectedDateKey) {
+        setFormError('Please pick a day from the calendar first.');
+        return;
+      }
+
+      const { category, title, startTime, endTime } = formState;
+      const trimmedTitle = title.trim();
+      const categoryMeta = categoryMap[category];
+      if (category === 'custom' && trimmedTitle.length === 0) {
+        setFormError('Please provide a title when using the custom category.');
+        return;
+      }
+
+      const { isValid, startMinutes, endMinutes, message } = validateTimeRange(
+        startTime,
+        endTime
+      );
+
+      if (!isValid) {
+        setFormError(message ?? 'Please provide a valid time range.');
+        return;
+      }
+
+      if (hasTimeCollision(dayEvents, startMinutes, endMinutes)) {
+        setFormError('This time overlaps with an existing event.');
+        return;
+      }
+
+      const resolvedTitle =
+        trimmedTitle.length > 0
+          ? trimmedTitle
+          : categoryMeta?.defaultTitle || 'Untitled event';
+
+      const normalizedStart = minutesToTimeString(startMinutes);
+      const normalizedEnd = minutesToTimeString(endMinutes);
+
+      const newEvent = {
+        id: `${selectedDateKey}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        title: resolvedTitle,
+        category,
+        startTime: normalizedStart,
+        endTime: normalizedEnd,
+        startMinutes,
+        endMinutes,
+      };
+
+      dispatchEvents({ type: 'add', payload: { dateKey: selectedDateKey, event: newEvent } });
+      setFormError('');
+      setFormState((prev) => {
+        const base = {
+          ...prev,
+          startTime: normalizedStart,
+          endTime: normalizedEnd,
+        };
+        if (category === 'custom') {
+          return { ...base, title: '' };
+        }
+        return { ...base, title: categoryMeta?.defaultTitle ?? base.title };
+      });
+    },
+    [categoryMap, dayEvents, dispatchEvents, formState, selectedDateKey]
   );
 
   const handleWeekStartChange = useCallback((event) => {
@@ -265,6 +614,13 @@ export default function Calendar() {
               >
                 Today
               </button>
+              <button
+                type="button"
+                className="calendar-action-button calendar-action-button--primary"
+                onClick={handleAddEventClick}
+              >
+                Add event
+              </button>
               <label className="calendar-week-start">
                 Week starts on
                 <select
@@ -302,6 +658,12 @@ export default function Calendar() {
               <div key={weekIndex} className="calendar-week" role="row">
                 {week.map((date) => {
                   const key = formatDateKey(date);
+                  const eventsForDay = eventsByDate[key] ?? [];
+                  const eventCount = eventsForDay.length;
+                  const eventCountLabel =
+                    eventCount > 0
+                      ? `, ${eventCount} ${eventCount === 1 ? 'event' : 'events'} scheduled`
+                      : '';
                   const inCurrentMonth =
                     date.getMonth() === visibleMonth.getMonth() &&
                     date.getFullYear() === visibleMonth.getFullYear();
@@ -320,7 +682,7 @@ export default function Calendar() {
 
                   const label = `${fullDateFormatter.format(
                     date
-                  )}${isToday ? ' (Today)' : ''}`;
+                  )}${isToday ? ' (Today)' : ''}${eventCountLabel}`;
 
                   return (
                     <button
@@ -335,6 +697,37 @@ export default function Calendar() {
                     >
                       <span className="calendar-cell-day">{date.getDate()}</span>
                       {isToday && <span className="calendar-cell-badge">Today</span>}
+                      {eventCount > 0 && (
+                        <div className="calendar-cell-event-chips" aria-hidden="true">
+                          {eventsForDay.slice(0, 3).map((eventItem) => {
+                            const meta = categoryMap[eventItem.category];
+                            const color = meta?.accent || '#9ca3af';
+                            return (
+                              <span
+                                key={eventItem.id}
+                                className="calendar-cell-event-chip"
+                                style={{ '--event-chip-color': color }}
+                                title={`${eventItem.title} • ${formatMinutesRange(
+                                  eventItem.startMinutes,
+                                  eventItem.endMinutes
+                                )}`}
+                              >
+                                {meta?.label ?? 'Custom'}
+                              </span>
+                            );
+                          })}
+                          {eventCount > 3 && (
+                            <span className="calendar-cell-event-chip calendar-cell-event-chip--count">
+                              +{eventCount - 3}
+                            </span>
+                          )}
+                        </div>
+                      )}
+                      <span className="visually-hidden">
+                        {eventCount > 0
+                          ? `${eventCount} ${eventCount === 1 ? 'event' : 'events'} scheduled`
+                          : 'No events scheduled'}
+                      </span>
                     </button>
                   );
                 })}
@@ -342,47 +735,185 @@ export default function Calendar() {
             ))}
           </div>
         </section>
-        <aside className="calendar-sidebar">
-          <h2 className="calendar-sidebar-title">Date details</h2>
-          {selectedDate ? (
-            <>
-              <p className="calendar-selected-label">{selectedLabel}</p>
-              <dl className="calendar-detail-list">
-                <div className="calendar-detail-item">
-                  <dt className="calendar-detail-term">Relative</dt>
-                  <dd className="calendar-detail-value">{relativeLabel}</dd>
-                </div>
-                <div className="calendar-detail-item">
-                  <dt className="calendar-detail-term">Week range</dt>
-                  <dd className="calendar-detail-value">{weekRangeLabel}</dd>
-                </div>
-                <div className="calendar-detail-item">
-                  <dt className="calendar-detail-term">Day of year</dt>
-                  <dd className="calendar-detail-value">
-                    {dayOfYear != null && totalDaysInYear != null
-                      ? `${dayOfYear} of ${totalDaysInYear}`
-                      : '—'}
-                  </dd>
-                </div>
-                <div className="calendar-detail-item">
-                  <dt className="calendar-detail-term">Quarter</dt>
-                  <dd className="calendar-detail-value">
-                    {quarter != null ? `Q${quarter}` : '—'}
-                  </dd>
-                </div>
-                <div className="calendar-detail-item">
-                  <dt className="calendar-detail-term">ISO date</dt>
-                  <dd className="calendar-detail-value">{isoValue}</dd>
-                </div>
-              </dl>
-            </>
-          ) : (
-            <p className="calendar-empty-state">
-              Select any day in the grid to see more information.
-            </p>
-          )}
-        </aside>
       </main>
+      {isDayViewOpen && (
+        <div
+          className="calendar-day-view-overlay"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="calendar-day-view-title"
+          onMouseDown={handleOverlayClick}
+        >
+          <div
+            className="calendar-day-view"
+            ref={dayViewRef}
+            tabIndex={-1}
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            <header className="calendar-day-view-header">
+              <div className="calendar-day-view-header-text">
+                <h2 id="calendar-day-view-title">Day planner</h2>
+                <p className="calendar-day-view-subtitle">
+                  {selectedDate ? selectedLabel : 'Pick a day to start planning.'}
+                </p>
+                {selectedDate && (
+                  <p className="calendar-day-view-meta" role="status">
+                    {relativeLabel} · {weekRangeLabel} · ISO {isoValue}
+                  </p>
+                )}
+              </div>
+              <button
+                type="button"
+                className="calendar-day-view-close"
+                onClick={handleCloseDayView}
+                aria-label="Close day planner"
+              >
+                <Icon name="X" size={20} />
+              </button>
+            </header>
+            <div className="calendar-day-view-body">
+              <section className="calendar-day-view-schedule" aria-label="Hourly schedule">
+                <h3 className="calendar-day-view-section-title">Schedule</h3>
+                <p className="calendar-day-view-summary">
+                  {dayEvents.length > 0
+                    ? `${dayEvents.length} ${
+                        dayEvents.length === 1 ? 'event' : 'events'
+                      } scheduled`
+                    : 'No events scheduled yet.'}
+                </p>
+                <div className="calendar-day-grid" role="list">
+                  {hourSlots.map(({ hour, label }) => {
+                    const eventsForHour = dayEvents.filter(
+                      (eventItem) => Math.floor(eventItem.startMinutes / 60) === hour
+                    );
+                    return (
+                      <div key={label} className="calendar-day-hour" role="listitem">
+                        <span className="calendar-day-hour-label">{label}</span>
+                        <div className="calendar-day-hour-events">
+                          {eventsForHour.length === 0 ? (
+                            <span className="calendar-day-hour-empty">—</span>
+                          ) : (
+                            eventsForHour.map((eventItem) => {
+                              const meta = categoryMap[eventItem.category];
+                              const chipColor = meta?.accent || '#9ca3af';
+                              return (
+                                <article
+                                  key={eventItem.id}
+                                  className="calendar-event-chip"
+                                  style={{ '--event-chip-color': chipColor }}
+                                >
+                                  <header className="calendar-event-chip-header">
+                                    <span className="calendar-event-chip-title">{eventItem.title}</span>
+                                    <span className="calendar-event-chip-time">
+                                      {formatMinutesRange(
+                                        eventItem.startMinutes,
+                                        eventItem.endMinutes
+                                      )}
+                                    </span>
+                                  </header>
+                                  <span className="calendar-event-chip-category">
+                                    {meta?.label ?? 'Custom'}
+                                  </span>
+                                </article>
+                              );
+                            })
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </section>
+              <section className="calendar-day-view-form-section" aria-label="Add new event">
+                <h3 className="calendar-day-view-section-title">Add event</h3>
+                <form className="calendar-day-view-form" onSubmit={handleSubmitEvent}>
+                  <div className="calendar-form-grid">
+                    <label className="calendar-form-field">
+                      <span className="calendar-form-label">Category</span>
+                      <select
+                        name="category"
+                        className="calendar-select"
+                        value={formState.category}
+                        onChange={handleFormChange}
+                      >
+                        {EVENT_CATEGORIES.map((category) => (
+                          <option key={category.id} value={category.id}>
+                            {category.label}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                    <label className="calendar-form-field">
+                      <span className="calendar-form-label">Title</span>
+                      <input
+                        type="text"
+                        name="title"
+                        className="calendar-input"
+                        value={formState.title}
+                        onChange={handleFormChange}
+                        placeholder={
+                          formState.category === 'custom'
+                            ? 'Describe your event'
+                            : categoryMap[formState.category]?.defaultTitle || 'Event title'
+                        }
+                        required={formState.category === 'custom'}
+                        aria-describedby={formError ? 'calendar-form-error' : undefined}
+                        aria-invalid={formError ? true : undefined}
+                      />
+                    </label>
+                    <label className="calendar-form-field">
+                      <span className="calendar-form-label">Starts</span>
+                      <input
+                        type="time"
+                        name="startTime"
+                        className="calendar-input"
+                        value={formState.startTime}
+                        onChange={handleFormChange}
+                        step="300"
+                        aria-describedby={formError ? 'calendar-form-error' : undefined}
+                        aria-invalid={formError ? true : undefined}
+                      />
+                    </label>
+                    <label className="calendar-form-field">
+                      <span className="calendar-form-label">Ends</span>
+                      <input
+                        type="time"
+                        name="endTime"
+                        className="calendar-input"
+                        value={formState.endTime}
+                        onChange={handleFormChange}
+                        step="300"
+                        aria-describedby={formError ? 'calendar-form-error' : undefined}
+                        aria-invalid={formError ? true : undefined}
+                      />
+                    </label>
+                  </div>
+                  {formError && (
+                    <p className="calendar-form-error" role="alert" id="calendar-form-error">
+                      {formError}
+                    </p>
+                  )}
+                  <div className="calendar-form-actions">
+                    <button type="submit" className="calendar-action-button calendar-action-button--primary">
+                      Save event
+                    </button>
+                    <button
+                      type="button"
+                      className="calendar-action-button"
+                      onClick={() => {
+                        setFormError('');
+                        setFormState(createDefaultFormState(formState.category));
+                      }}
+                    >
+                      Reset
+                    </button>
+                  </div>
+                </form>
+              </section>
+            </div>
+          </div>
+        </div>
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- add a localStorage-backed reducer and time helpers to manage calendar events with collision checks
- surface day-level planning via a drawer modal that shows hourly schedules, existing events, and an add-event form
- refresh calendar styling with event badges, overlay layout, accessible controls, and primary action button treatments

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68db6ff3a0dc8325a7484aaf24451552