### PR TITLE
Add quest generator card to DM quests page

### DIFF
--- a/ui/src/pages/DndDmQuests.jsx
+++ b/ui/src/pages/DndDmQuests.jsx
@@ -7,6 +7,12 @@ const sections = [
   { to: '/dnd/dungeon-master/quests/main', icon: 'Swords', title: 'Main Quests', description: 'Primary storyline and key beats.' },
   { to: '/dnd/dungeon-master/quests/personal', icon: 'UserRound', title: 'Personal Quests', description: 'Character-driven goals and threads.' },
   { to: '/dnd/dungeon-master/quests/side', icon: 'ScrollText', title: 'Side Quests', description: 'Optional tasks and diversions.' },
+  {
+    to: '/dnd/dungeon-master/quests/generator',
+    icon: 'Sparkles',
+    title: 'Quest Generator',
+    description: 'AI-assisted synopsis creation for fresh adventures.',
+  },
 ];
 
 export default function DndDmQuests() {


### PR DESCRIPTION
## Summary
- add a quest generator entry to the dungeon master quests dashboard
- describe the AI-assisted synopsis feature for the new card

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc12b58b4c832597d7eda586f3eae0