### PR TITLE
Add reusable navigation layout for UI routes

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -76,3 +76,146 @@ header {
   cursor: pointer;
 }
 
+
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.skip-link:focus {
+  left: var(--space-md);
+  top: var(--space-md);
+  width: auto;
+  height: auto;
+  padding: var(--space-sm) var(--space-md);
+  background: var(--card-bg);
+  color: var(--text);
+  border-radius: 999px;
+  box-shadow: var(--card-shadow);
+  z-index: 10000;
+}
+
+.app-layout {
+  display: flex;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.main-nav {
+  position: sticky;
+  top: 0;
+  align-self: flex-start;
+  min-width: 220px;
+  max-width: 260px;
+  width: 20vw;
+  padding: var(--space-lg) var(--space-md);
+  box-sizing: border-box;
+  background: var(--card-bg);
+  box-shadow: var(--topbar-shadow);
+  border-right: 1px solid color-mix(in srgb, var(--text) 20%, transparent);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.main-nav__brand {
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  opacity: 0.7;
+}
+
+.main-nav__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.main-nav__link {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: 0.65rem 0.85rem;
+  border-radius: 0.75rem;
+  text-decoration: none;
+  color: inherit;
+  font-weight: 600;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.main-nav__link:is(:hover, :focus-visible) {
+  background: var(--card-hover-bg);
+}
+
+.main-nav__link.is-active {
+  background: color-mix(in srgb, var(--accent) 20%, transparent);
+  color: var(--accent);
+}
+
+.main-nav__text {
+  line-height: 1.2;
+}
+
+.app-layout__content {
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  box-sizing: border-box;
+  padding: var(--space-lg);
+  overflow-y: auto;
+}
+
+@media (max-width: 960px) {
+  .app-layout {
+    flex-direction: column;
+  }
+
+  .main-nav {
+    position: sticky;
+    width: 100%;
+    max-width: 100%;
+    min-width: auto;
+    top: 0;
+    z-index: 10;
+    border-right: none;
+    border-bottom: 1px solid color-mix(in srgb, var(--text) 20%, transparent);
+    padding: var(--space-md);
+  }
+
+  .main-nav__list {
+    flex-direction: row;
+    align-items: center;
+    gap: 0.5rem;
+    overflow-x: auto;
+    padding-bottom: 0.25rem;
+  }
+
+  .main-nav__item {
+    flex: 0 0 auto;
+  }
+
+  .main-nav__link {
+    border-radius: 999px;
+    white-space: nowrap;
+    padding: 0.5rem 0.9rem;
+  }
+
+  .app-layout__content {
+    padding: var(--space-md);
+  }
+}
+
+@media (max-width: 600px) {
+  .main-nav__brand {
+    display: none;
+  }
+}

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -1,4 +1,5 @@
 import { Routes, Route } from 'react-router-dom';
+import AppLayout from './components/AppLayout.jsx';
 import Dashboard from './pages/Dashboard.jsx';
 import Dnd from './pages/Dnd.jsx';
 import DndChat from './pages/DndChat.jsx';
@@ -261,89 +262,91 @@ export default function App() {
         <UserSelectorOverlay onClose={() => setNeedsUser(false)} />
       )}
       <Routes>
-        <Route path="/" element={<Dashboard />} />
-        <Route path="/musicgen" element={<SoundLab />}>
-          <Route path="musicgen" element={<MusicGen />} />
-          <Route path="algorithmic" element={<AlgorithmicGenerator />} />
+        <Route element={<AppLayout />}>
+          <Route path="/" element={<Dashboard />} />
+          <Route path="/musicgen" element={<SoundLab />}>
+            <Route path="musicgen" element={<MusicGen />} />
+            <Route path="algorithmic" element={<AlgorithmicGenerator />} />
+          </Route>
+          <Route path="/dnd" element={<Dnd />} />
+          <Route path="/dnd/inbox" element={<DndInbox />} />
+          <Route path="/dnd/world" element={<DndWorld />} />
+          <Route path="/dnd/world/bank" element={<DndWorldBank />} />
+          <Route path="/dnd/world/bank/economy" element={<DndWorldBankEconomy />} />
+          <Route path="/dnd/world/bank/transactions" element={<DndWorldBankTransactions />} />
+          <Route path="/dnd/world/pantheon" element={<DndWorldPantheon />} />
+          <Route path="/dnd/world/regions" element={<DndWorldRegions />} />
+          <Route path="/dnd/world/factions" element={<DndWorldFactions />} />
+          <Route path="/dnd/world/calendar" element={<DndWorldCalendar />} />
+          <Route path="/dnd/lore/secrets" element={<DndLoreSecrets />} />
+          <Route path="/dnd/lore/journal" element={<DndLoreJournal />} />
+          <Route path="/dnd/lore/stories" element={<DndLoreStories />} />
+          <Route path="/dnd/lore/notes" element={<DndLoreNotes />} />
+          <Route path="/dnd/lore/relations" element={<DndLorePlayerRelations />} />
+          <Route path="/dnd/lore/spellbook" element={<DndLoreSpellBook />} />
+          <Route path="/dnd/lore/races" element={<DndLoreRaces />} />
+          <Route path="/dnd/lore/classes" element={<DndLoreClasses />} />
+          <Route path="/dnd/lore/rules" element={<DndLoreRules />} />
+          <Route path="/dnd/lore/background-rules" element={<DndLoreBackgroundRules />} />
+          <Route path="/dnd/tasks" element={<DndTasks />} />
+          <Route path="/dnd/dungeon-master" element={<DndDungeonMaster />} />
+          <Route path="/dnd/dungeon-master/events" element={<DndDmEvents />} />
+          <Route path="/dnd/dungeon-master/monsters" element={<DndDmMonsters />} />
+          <Route path="/dnd/dungeon-master/npcs" element={<DndDmNpcs />} />
+          <Route path="/dnd/dungeon-master/players" element={<DndDmPlayersHome />} />
+          <Route path="/dnd/dungeon-master/players/sheet" element={<DndDmPlayers />} />
+          <Route path="/dnd/dungeon-master/players/new" element={<DndDmPlayerCreate />} />
+          <Route path="/dnd/dungeon-master/players/auto" element={<DndDmPlayerAuto />} />
+          <Route path="/dnd/dungeon-master/quests" element={<DndDmQuests />} />
+          <Route path="/dnd/dungeon-master/quests/faction" element={<DndDmQuestsFaction />} />
+          <Route path="/dnd/dungeon-master/quests/main" element={<DndDmQuestsMain />} />
+          <Route path="/dnd/dungeon-master/quests/personal" element={<DndDmQuestsPersonal />} />
+          <Route path="/dnd/dungeon-master/quests/side" element={<DndDmQuestsSide />} />
+          <Route
+            path="/dnd/dungeon-master/quests/generator"
+            element={<DndDmQuestGenerator />}
+          />
+          <Route path="/dnd/dungeon-master/establishments" element={<DndDmEstablishments />} />
+          <Route path="/dnd/dungeon-master/tag-manager" element={<DndDmTagManager />} />
+          <Route path="/dnd/dungeon-master/world-inventory" element={<DndDmWorldInventory />} />
+          <Route path="/dnd/assets" element={<DndAssets />} />
+          <Route path="/dnd/lore" element={<DndLore />} />
+          <Route path="/dnd/piper" element={<DndVoiceLabs />} />
+          <Route path="/dnd/piper/piper" element={<DndPiperOnly />} />
+          <Route path="/dnd/piper/eleven" element={<DndElevenLabs />} />
+          <Route path="/tools/voices" element={<DndVoiceLabs />} />
+          <Route path="/tools/voices/piper" element={<DndPiperOnly />} />
+          <Route path="/tools/voices/eleven" element={<DndElevenLabs />} />
+          <Route path="/tools/voices/manage" element={<ManageVoices />} />
+          <Route path="/dnd/discord" element={<DndDiscord />} />
+          <Route path="/dnd/chat" element={<DndChat />} />
+          <Route path="/settings" element={<Settings />} />
+          <Route path="/settings/users" element={<SettingsUsers />} />
+          <Route path="/settings/vault" element={<SettingsVault />} />
+          <Route path="/settings/discord" element={<SettingsDiscord />} />
+          <Route path="/settings/appearance" element={<SettingsAppearance />} />
+          <Route path="/settings/models" element={<SettingsModels />} />
+          <Route path="/settings/devices" element={<SettingsDevices />} />
+          <Route path="/settings/hotwords" element={<SettingsHotwords />} />
+          <Route path="/settings/backup" element={<SettingsBackup />} />
+          <Route path="/settings/advanced" element={<SettingsAdvanced />} />
+          <Route path="/profiles" element={<Profiles />} />
+          <Route path="/train" element={<Train />} />
+          <Route path="/tools" element={<Tools />} />
+          <Route path="/tools/whisper" element={<WhisperOutput />} />
+          <Route path="/calendar" element={<Calendar />} />
+          <Route path="/chat" element={<GeneralChat />} />
+          <Route path="/queue" element={<Queue />} />
+          <Route path="/fusion" element={<Fusion />} />
+          <Route path="/loopmaker" element={<LoopMaker />} />
+          <Route path="/beatmaker" element={<BeatMaker />} />
+          <Route path="/album" element={<AlbumMaker />} />
+          <Route path="/games" element={<Games />} />
+          <Route path="/games/rain-blocks" element={<RainBlocks />} />
+          <Route path="/games/sand-blocks" element={<SandBlocks />} />
+          <Route path="/games/brick-breaker" element={<BrickBreaker />} />
+          <Route path="/games/snake" element={<Snake />} />
         </Route>
-        <Route path="/dnd" element={<Dnd />} />
-        <Route path="/dnd/inbox" element={<DndInbox />} />
-        <Route path="/dnd/world" element={<DndWorld />} />
-        <Route path="/dnd/world/bank" element={<DndWorldBank />} />
-        <Route path="/dnd/world/bank/economy" element={<DndWorldBankEconomy />} />
-        <Route path="/dnd/world/bank/transactions" element={<DndWorldBankTransactions />} />
-        <Route path="/dnd/world/pantheon" element={<DndWorldPantheon />} />
-        <Route path="/dnd/world/regions" element={<DndWorldRegions />} />
-        <Route path="/dnd/world/factions" element={<DndWorldFactions />} />
-        <Route path="/dnd/world/calendar" element={<DndWorldCalendar />} />
-        <Route path="/dnd/lore/secrets" element={<DndLoreSecrets />} />
-        <Route path="/dnd/lore/journal" element={<DndLoreJournal />} />
-        <Route path="/dnd/lore/stories" element={<DndLoreStories />} />
-        <Route path="/dnd/lore/notes" element={<DndLoreNotes />} />
-        <Route path="/dnd/lore/relations" element={<DndLorePlayerRelations />} />
-        <Route path="/dnd/lore/spellbook" element={<DndLoreSpellBook />} />
-        <Route path="/dnd/lore/races" element={<DndLoreRaces />} />
-        <Route path="/dnd/lore/classes" element={<DndLoreClasses />} />
-        <Route path="/dnd/lore/rules" element={<DndLoreRules />} />
-        <Route path="/dnd/lore/background-rules" element={<DndLoreBackgroundRules />} />
-        <Route path="/dnd/tasks" element={<DndTasks />} />
-        <Route path="/dnd/dungeon-master" element={<DndDungeonMaster />} />
-        <Route path="/dnd/dungeon-master/events" element={<DndDmEvents />} />
-        <Route path="/dnd/dungeon-master/monsters" element={<DndDmMonsters />} />
-        <Route path="/dnd/dungeon-master/npcs" element={<DndDmNpcs />} />
-        <Route path="/dnd/dungeon-master/players" element={<DndDmPlayersHome />} />
-        <Route path="/dnd/dungeon-master/players/sheet" element={<DndDmPlayers />} />
-        <Route path="/dnd/dungeon-master/players/new" element={<DndDmPlayerCreate />} />
-        <Route path="/dnd/dungeon-master/players/auto" element={<DndDmPlayerAuto />} />
-        <Route path="/dnd/dungeon-master/quests" element={<DndDmQuests />} />
-        <Route path="/dnd/dungeon-master/quests/faction" element={<DndDmQuestsFaction />} />
-        <Route path="/dnd/dungeon-master/quests/main" element={<DndDmQuestsMain />} />
-        <Route path="/dnd/dungeon-master/quests/personal" element={<DndDmQuestsPersonal />} />
-        <Route path="/dnd/dungeon-master/quests/side" element={<DndDmQuestsSide />} />
-        <Route
-          path="/dnd/dungeon-master/quests/generator"
-          element={<DndDmQuestGenerator />}
-        />
-        <Route path="/dnd/dungeon-master/establishments" element={<DndDmEstablishments />} />
-        <Route path="/dnd/dungeon-master/tag-manager" element={<DndDmTagManager />} />
-        <Route path="/dnd/dungeon-master/world-inventory" element={<DndDmWorldInventory />} />
-        <Route path="/dnd/assets" element={<DndAssets />} />
-        <Route path="/dnd/lore" element={<DndLore />} />
-        <Route path="/dnd/piper" element={<DndVoiceLabs />} />
-        <Route path="/dnd/piper/piper" element={<DndPiperOnly />} />
-        <Route path="/dnd/piper/eleven" element={<DndElevenLabs />} />
-        <Route path="/tools/voices" element={<DndVoiceLabs />} />
-        <Route path="/tools/voices/piper" element={<DndPiperOnly />} />
-        <Route path="/tools/voices/eleven" element={<DndElevenLabs />} />
-        <Route path="/tools/voices/manage" element={<ManageVoices />} />
-        <Route path="/dnd/discord" element={<DndDiscord />} />
-        <Route path="/dnd/chat" element={<DndChat />} />
-        <Route path="/settings" element={<Settings />} />
-        <Route path="/settings/users" element={<SettingsUsers />} />
-        <Route path="/settings/vault" element={<SettingsVault />} />
-        <Route path="/settings/discord" element={<SettingsDiscord />} />
-        <Route path="/settings/appearance" element={<SettingsAppearance />} />
-        <Route path="/settings/models" element={<SettingsModels />} />
-        <Route path="/settings/devices" element={<SettingsDevices />} />
-        <Route path="/settings/hotwords" element={<SettingsHotwords />} />
-        <Route path="/settings/backup" element={<SettingsBackup />} />
-        <Route path="/settings/advanced" element={<SettingsAdvanced />} />
-        <Route path="/profiles" element={<Profiles />} />
-        <Route path="/train" element={<Train />} />
-        <Route path="/tools" element={<Tools />} />
-        <Route path="/tools/whisper" element={<WhisperOutput />} />
-        <Route path="/calendar" element={<Calendar />} />
-        <Route path="/chat" element={<GeneralChat />} />
-        <Route path="/queue" element={<Queue />} />
-        <Route path="/fusion" element={<Fusion />} />
-        <Route path="/loopmaker" element={<LoopMaker />} />
-        <Route path="/beatmaker" element={<BeatMaker />} />
-        <Route path="/album" element={<AlbumMaker />} />
-        <Route path="/games" element={<Games />} />
-        <Route path="/games/rain-blocks" element={<RainBlocks />} />
-        <Route path="/games/sand-blocks" element={<SandBlocks />} />
-        <Route path="/games/brick-breaker" element={<BrickBreaker />} />
-        <Route path="/games/snake" element={<Snake />} />
       </Routes>
     </>
   );

--- a/ui/src/components/AppLayout.jsx
+++ b/ui/src/components/AppLayout.jsx
@@ -1,0 +1,16 @@
+import { Outlet } from 'react-router-dom';
+import MainNav from './MainNav.jsx';
+
+export default function AppLayout() {
+  return (
+    <div className="app-layout">
+      <a className="skip-link" href="#main-content">
+        Skip to content
+      </a>
+      <MainNav />
+      <main id="main-content" className="app-layout__content" tabIndex={-1}>
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/ui/src/components/MainNav.jsx
+++ b/ui/src/components/MainNav.jsx
@@ -1,0 +1,42 @@
+import { NavLink } from 'react-router-dom';
+
+const links = [
+  { to: '/', label: 'Dashboard', end: true },
+  { to: '/musicgen', label: 'Sound Lab' },
+  { to: '/dnd', label: 'D&D' },
+  { to: '/games', label: 'Games' },
+  { to: '/tools', label: 'Tools' },
+  { to: '/queue', label: 'Queue' },
+  { to: '/profiles', label: 'Profiles' },
+  { to: '/train', label: 'Training' },
+  { to: '/settings', label: 'Settings' },
+];
+
+function classNames(...values) {
+  return values.filter(Boolean).join(' ');
+}
+
+export default function MainNav() {
+  return (
+    <nav className="main-nav" aria-label="Primary">
+      <div className="main-nav__brand" aria-hidden="true">
+        Blossom
+      </div>
+      <ul className="main-nav__list">
+        {links.map(({ to, label, end }) => (
+          <li key={to} className="main-nav__item">
+            <NavLink
+              to={to}
+              end={end}
+              className={({ isActive }) =>
+                classNames('main-nav__link', isActive && 'is-active')
+              }
+            >
+              <span className="main-nav__text">{label}</span>
+            </NavLink>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable MainNav component for primary navigation links
- introduce an AppLayout wrapper and apply it across the main routes
- style the layout so the navigation is accessible and responsive

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc16d6fe408325ad5da53783130735