### PR TITLE
Add shared primary button component for generation flows

### DIFF
--- a/ui/src/components/PrimaryButton.css
+++ b/ui/src/components/PrimaryButton.css
@@ -1,0 +1,54 @@
+.primary-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-xs);
+  padding: calc(var(--space-sm) * 0.9) calc(var(--space-md) * 1.1);
+  font-family: var(--font);
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1.2;
+  color: var(--text);
+  background: var(--button-bg);
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease,
+    transform 0.2s ease, opacity 0.2s ease;
+  text-decoration: none;
+}
+
+.primary-button:hover:not(:disabled),
+.primary-button:focus-visible:not(:disabled) {
+  background: var(--button-hover-bg);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.18);
+  transform: translateY(-1px);
+}
+
+.primary-button:focus-visible {
+  outline-offset: 4px;
+}
+
+.primary-button:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+.primary-button__spinner {
+  width: 1em;
+  height: 1em;
+}
+
+.primary-button[data-loading="true"] {
+  cursor: progress;
+}
+
+.primary-button[data-loading="true"] .primary-button__label {
+  pointer-events: none;
+}
+
+.primary-button.is-loading {
+  pointer-events: none;
+}

--- a/ui/src/components/PrimaryButton.jsx
+++ b/ui/src/components/PrimaryButton.jsx
@@ -1,0 +1,40 @@
+import PropTypes from "prop-types";
+import "./PrimaryButton.css";
+
+export default function PrimaryButton({
+  children,
+  className = "",
+  loading = false,
+  loadingText,
+  disabled = false,
+  ...props
+}) {
+  const isDisabled = disabled || loading;
+  const classes = ["primary-button", loading ? "is-loading" : "", className]
+    .filter(Boolean)
+    .join(" ");
+  const content = loading && loadingText ? loadingText : children;
+
+  return (
+    <button
+      {...props}
+      className={classes}
+      disabled={isDisabled}
+      aria-busy={loading ? "true" : undefined}
+      data-loading={loading ? "true" : undefined}
+    >
+      {loading && (
+        <span className="spinner primary-button__spinner" aria-hidden="true" />
+      )}
+      <span className="primary-button__label">{content}</span>
+    </button>
+  );
+}
+
+PrimaryButton.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+  loading: PropTypes.bool,
+  loadingText: PropTypes.node,
+  disabled: PropTypes.bool,
+};

--- a/ui/src/pages/Dnd.css
+++ b/ui/src/pages/Dnd.css
@@ -1689,29 +1689,6 @@
   justify-content: flex-end;
 }
 
-.dnd-sheet-submit button {
-  padding: 0.75rem 1.75rem;
-  font-size: 1rem;
-  border-radius: 14px;
-  border: none;
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.65), rgba(14, 116, 144, 0.75));
-  color: #fff;
-  font-weight: 600;
-  cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.dnd-sheet-submit button:disabled {
-  opacity: 0.6;
-  cursor: progress;
-}
-
-.dnd-sheet-submit button:not(:disabled):hover,
-.dnd-sheet-submit button:not(:disabled):focus {
-  transform: translateY(-1px);
-  box-shadow: 0 12px 30px rgba(59, 130, 246, 0.25);
-}
-
 .dnd-sheet-section textarea,
 .dnd-sheet-section input,
 .dnd-sheet-section select {

--- a/ui/src/pages/DndDmPlayerAuto.jsx
+++ b/ui/src/pages/DndDmPlayerAuto.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 import BackButton from '../components/BackButton.jsx';
+import PrimaryButton from '../components/PrimaryButton.jsx';
 import { createPlayer } from '../api/players';
 import { createEmptyPlayerSheet, serializeCharacterSheet } from '../lib/playerSheet.js';
 import './Dnd.css';
@@ -96,9 +97,9 @@ export default function DndDmPlayerAuto() {
             <input type="number" min={1} max={20} value={level} onChange={(e) => setLevel(e.target.value)} />
           </label>
           <div style={{ display: 'flex', gap: '0.5rem' }}>
-            <button type="submit" disabled={creating}>
-              {creating ? (<><span className="spinner" aria-label="loading" /> Creating…</>) : 'Create with Blossom'}
-            </button>
+            <PrimaryButton type="submit" loading={creating} loadingText="Generating…">
+              Generate Character
+            </PrimaryButton>
           </div>
         </form>
       </section>

--- a/ui/src/pages/DndDmPlayerCreate.jsx
+++ b/ui/src/pages/DndDmPlayerCreate.jsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import BackButton from '../components/BackButton.jsx';
 import CharacterSheetSection from '../components/CharacterSheetSection.jsx';
 import AbilityScoreInputs from '../components/AbilityScoreInputs.jsx';
+import PrimaryButton from '../components/PrimaryButton.jsx';
 import { createPlayer } from '../api/players';
 import { serializeCharacterSheet, buildDerivedStats, createEmptyPlayerSheet, playerSheetReducer } from '../lib/playerSheet.js';
 import './Dnd.css';
@@ -321,9 +322,9 @@ export default function DndDmPlayerCreate() {
               <button type="button" onClick={next}>Next</button>
             )}
             {step === 3 && (
-              <button type="button" onClick={finish} disabled={saving}>
-                {saving ? 'Creating…' : 'Create Character'}
-              </button>
+              <PrimaryButton type="button" onClick={finish} loading={saving} loadingText="Generating…">
+                Generate Character
+              </PrimaryButton>
             )}
           </div>
         </div>

--- a/ui/src/pages/MusicGen.jsx
+++ b/ui/src/pages/MusicGen.jsx
@@ -6,6 +6,7 @@ import { open } from "@tauri-apps/plugin-dialog";
 import { Store } from "@tauri-apps/plugin-store";
 import BackButton from "../components/BackButton.jsx";
 import JobQueuePanel from "../components/JobQueuePanel.jsx";
+import PrimaryButton from "../components/PrimaryButton.jsx";
 import { useJobQueue } from "../lib/useJobQueue.js";
 import { useSharedState, DEFAULT_MUSICGEN_FORM } from "../lib/sharedState.jsx";
 
@@ -1049,9 +1050,8 @@ export default function MusicGen() {
           <div className="mb-md">
             <div style={{ marginBottom: "0.25rem" }}>Melody Reference</div>
             <div style={{ display: "flex", gap: "0.5rem", alignItems: "center", flexWrap: "wrap" }}>
-              <button
+              <PrimaryButton
                 type="button"
-                className="p-sm"
                 onClick={async () => {
                   try {
                     const res = await open({
@@ -1084,10 +1084,9 @@ export default function MusicGen() {
                     setFormError("Failed to open the file picker. Please try again.");
                   }
                 }}
-                style={{ background: "var(--button-bg)", color: "var(--text)" }}
               >
                 {melodyPath ? "Change Clip" : "Choose Clip"}
-              </button>
+              </PrimaryButton>
               {melodyPath ? (
                 <span style={{ fontSize: "0.9rem", wordBreak: "break-all" }}>
                   {melodyFileName}
@@ -1096,17 +1095,15 @@ export default function MusicGen() {
                 <span style={{ fontSize: "0.9rem", opacity: 0.7 }}>No clip selected</span>
               )}
               {melodyPath && (
-                <button
+                <PrimaryButton
                   type="button"
-                  className="p-sm"
                   onClick={() => {
                     setMelodyPath("");
                     setFormError("Select a melody clip before generating with the melody model.");
                   }}
-                  style={{ background: "var(--button-bg)", color: "var(--text)" }}
                 >
                   Clear
-                </button>
+                </PrimaryButton>
               )}
             </div>
             <div style={{ marginTop: "0.25rem", fontSize: "0.85rem", opacity: 0.7 }}>
@@ -1157,9 +1154,8 @@ export default function MusicGen() {
               placeholder="Default (App Data directory)"
               style={{ flex: 1 }}
             />
-            <button
+            <PrimaryButton
               type="button"
-              className="p-sm"
               onClick={async () => {
                 try {
                   setOutputDirError("");
@@ -1186,22 +1182,19 @@ export default function MusicGen() {
                   setOutputDirError("Failed to open the folder picker. Please try again.");
                 }
               }}
-              style={{ background: "var(--button-bg)", color: "var(--text)" }}
             >
               Browse…
-            </button>
+            </PrimaryButton>
             {outputDir && (
-              <button
+              <PrimaryButton
                 type="button"
-                className="p-sm"
                 onClick={() => {
                   outputDirDirtyRef.current = true;
                   setOutputDir("");
                 }}
-                style={{ background: "var(--button-bg)", color: "var(--text)" }}
               >
                 Use Default
-              </button>
+              </PrimaryButton>
             )}
           </div>
           {outputDirError && (
@@ -1238,16 +1231,15 @@ export default function MusicGen() {
             Use FP16 on GPU (lower VRAM)
           </label>
         </div>
-        <button
+        <PrimaryButton
           type="submit"
-          disabled={
-            generating || (modelName === "melody" && !melodyPath)
-          }
-          className="mt-md p-sm"
-          style={{ background: "var(--button-bg)", color: "var(--text)" }}
+          className="mt-md"
+          disabled={modelName === "melody" && !melodyPath}
+          loading={generating}
+          loadingText="Generating…"
         >
           Generate
-        </button>
+        </PrimaryButton>
         <div id="progress-placeholder" className="mt-md mb-md" style={{ display: "grid", gap: "0.5rem" }}>
           {generating ? (
             <div style={{ display: "grid", gap: "0.5rem" }}>
@@ -1273,14 +1265,9 @@ export default function MusicGen() {
                 <div style={{ color: "var(--accent)", fontSize: "0.9rem" }}>{fallbackMsg}</div>
               )}
               <div>
-                <button
-                  type="button"
-                  className="p-sm"
-                  onClick={cancelJob}
-                  style={{ background: "var(--button-bg)", color: "var(--text)" }}
-                >
+                <PrimaryButton type="button" onClick={cancelJob}>
                   Cancel Job
-                </button>
+                </PrimaryButton>
               </div>
             </div>
           ) : (
@@ -1301,9 +1288,8 @@ export default function MusicGen() {
         </div>
       </form>
       <div className="mt-sm" style={{ background: "var(--card-bg)", padding: "var(--space-sm)" }}>
-        <button
+        <PrimaryButton
           type="button"
-          className="p-sm"
           onClick={async () => {
             try {
               const info = await invoke("musicgen_env");
@@ -1313,10 +1299,9 @@ export default function MusicGen() {
               setEnvInfo({ error: String(e) });
             }
           }}
-          style={{ background: "var(--button-bg)", color: "var(--text)" }}
         >
           Check Environment
-        </button>
+        </PrimaryButton>
         {envInfo && (
           <div className="mt-sm" style={{ fontSize: "0.9rem", opacity: 0.9 }}>
             <div>Device: {envInfo.device?.toUpperCase?.() || ""}</div>
@@ -1345,14 +1330,9 @@ export default function MusicGen() {
             <div key={idx} style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
               <audio src={a.url} controls />
               <span style={{ fontSize: "0.9rem" }}>{a.name || `Track ${idx + 1}`}</span>
-              <button
-                type="button"
-                className="p-sm"
-                onClick={() => download(a, idx)}
-                style={{ background: "var(--button-bg)", color: "var(--text)" }}
-              >
+              <PrimaryButton type="button" onClick={() => download(a, idx)}>
                 Download
-              </button>
+              </PrimaryButton>
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- add a reusable PrimaryButton component with theme-aware styling and loading support
- update MusicGen and Dungeon Master character flows to consume the shared primary button and consistent CTA copy
- remove the gradient-based button override in the D&D styles to avoid conflicts with the shared component

## Testing
- npm --prefix ui run build *(fails: Syntax error "\x0A" in ui/src/pages/DndDmQuestGenerator.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68dc19dfe05083259d74d9b1d98597ca