### PR TITLE
Add route transition fade animation

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -8,6 +8,26 @@ body {
   min-height: 100vh;
 }
 
+.route-fade {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  width: 100%;
+  animation: route-fade-in 180ms ease-out;
+}
+
+@keyframes route-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 header {
   text-align: center;
   padding: var(--space-xl) var(--space-md) 0;

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -1,4 +1,4 @@
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, useLocation } from 'react-router-dom';
 import AppLayout from './components/AppLayout.jsx';
 import Dashboard from './pages/Dashboard.jsx';
 import Dnd from './pages/Dnd.jsx';
@@ -181,6 +181,7 @@ function UserSelectorOverlay({ onClose }) {
 export default function App() {
   const [needsUser, setNeedsUser] = useState(false);
   const greetedRef = useRef(false);
+  const location = useLocation();
   useEffect(() => {
     (async () => {
       try {
@@ -261,93 +262,95 @@ export default function App() {
       {needsUser && (
         <UserSelectorOverlay onClose={() => setNeedsUser(false)} />
       )}
-      <Routes>
-        <Route element={<AppLayout />}>
-          <Route path="/" element={<Dashboard />} />
-          <Route path="/musicgen" element={<SoundLab />}>
-            <Route path="musicgen" element={<MusicGen />} />
-            <Route path="algorithmic" element={<AlgorithmicGenerator />} />
+      <div className="route-fade" key={location.pathname}>
+        <Routes location={location} key={location.pathname}>
+          <Route element={<AppLayout />}>
+            <Route path="/" element={<Dashboard />} />
+            <Route path="/musicgen" element={<SoundLab />}>
+              <Route path="musicgen" element={<MusicGen />} />
+              <Route path="algorithmic" element={<AlgorithmicGenerator />} />
+            </Route>
+            <Route path="/dnd" element={<Dnd />} />
+            <Route path="/dnd/inbox" element={<DndInbox />} />
+            <Route path="/dnd/world" element={<DndWorld />} />
+            <Route path="/dnd/world/bank" element={<DndWorldBank />} />
+            <Route path="/dnd/world/bank/economy" element={<DndWorldBankEconomy />} />
+            <Route path="/dnd/world/bank/transactions" element={<DndWorldBankTransactions />} />
+            <Route path="/dnd/world/pantheon" element={<DndWorldPantheon />} />
+            <Route path="/dnd/world/regions" element={<DndWorldRegions />} />
+            <Route path="/dnd/world/factions" element={<DndWorldFactions />} />
+            <Route path="/dnd/world/calendar" element={<DndWorldCalendar />} />
+            <Route path="/dnd/lore/secrets" element={<DndLoreSecrets />} />
+            <Route path="/dnd/lore/journal" element={<DndLoreJournal />} />
+            <Route path="/dnd/lore/stories" element={<DndLoreStories />} />
+            <Route path="/dnd/lore/notes" element={<DndLoreNotes />} />
+            <Route path="/dnd/lore/relations" element={<DndLorePlayerRelations />} />
+            <Route path="/dnd/lore/spellbook" element={<DndLoreSpellBook />} />
+            <Route path="/dnd/lore/races" element={<DndLoreRaces />} />
+            <Route path="/dnd/lore/classes" element={<DndLoreClasses />} />
+            <Route path="/dnd/lore/rules" element={<DndLoreRules />} />
+            <Route path="/dnd/lore/background-rules" element={<DndLoreBackgroundRules />} />
+            <Route path="/dnd/tasks" element={<DndTasks />} />
+            <Route path="/dnd/dungeon-master" element={<DndDungeonMaster />} />
+            <Route path="/dnd/dungeon-master/events" element={<DndDmEvents />} />
+            <Route path="/dnd/dungeon-master/monsters" element={<DndDmMonsters />} />
+            <Route path="/dnd/dungeon-master/npcs" element={<DndDmNpcs />} />
+            <Route path="/dnd/dungeon-master/players" element={<DndDmPlayersHome />} />
+            <Route path="/dnd/dungeon-master/players/sheet" element={<DndDmPlayers />} />
+            <Route path="/dnd/dungeon-master/players/new" element={<DndDmPlayerCreate />} />
+            <Route path="/dnd/dungeon-master/players/auto" element={<DndDmPlayerAuto />} />
+            <Route path="/dnd/dungeon-master/quests" element={<DndDmQuests />} />
+            <Route path="/dnd/dungeon-master/quests/faction" element={<DndDmQuestsFaction />} />
+            <Route path="/dnd/dungeon-master/quests/main" element={<DndDmQuestsMain />} />
+            <Route path="/dnd/dungeon-master/quests/personal" element={<DndDmQuestsPersonal />} />
+            <Route path="/dnd/dungeon-master/quests/side" element={<DndDmQuestsSide />} />
+            <Route
+              path="/dnd/dungeon-master/quests/generator"
+              element={<DndDmQuestGenerator />}
+            />
+            <Route path="/dnd/dungeon-master/establishments" element={<DndDmEstablishments />} />
+            <Route path="/dnd/dungeon-master/tag-manager" element={<DndDmTagManager />} />
+            <Route path="/dnd/dungeon-master/world-inventory" element={<DndDmWorldInventory />} />
+            <Route path="/dnd/assets" element={<DndAssets />} />
+            <Route path="/dnd/lore" element={<DndLore />} />
+            <Route path="/dnd/piper" element={<DndVoiceLabs />} />
+            <Route path="/dnd/piper/piper" element={<DndPiperOnly />} />
+            <Route path="/dnd/piper/eleven" element={<DndElevenLabs />} />
+            <Route path="/tools/voices" element={<DndVoiceLabs />} />
+            <Route path="/tools/voices/piper" element={<DndPiperOnly />} />
+            <Route path="/tools/voices/eleven" element={<DndElevenLabs />} />
+            <Route path="/tools/voices/manage" element={<ManageVoices />} />
+            <Route path="/dnd/discord" element={<DndDiscord />} />
+            <Route path="/dnd/chat" element={<DndChat />} />
+            <Route path="/settings" element={<Settings />} />
+            <Route path="/settings/users" element={<SettingsUsers />} />
+            <Route path="/settings/vault" element={<SettingsVault />} />
+            <Route path="/settings/discord" element={<SettingsDiscord />} />
+            <Route path="/settings/appearance" element={<SettingsAppearance />} />
+            <Route path="/settings/models" element={<SettingsModels />} />
+            <Route path="/settings/devices" element={<SettingsDevices />} />
+            <Route path="/settings/hotwords" element={<SettingsHotwords />} />
+            <Route path="/settings/backup" element={<SettingsBackup />} />
+            <Route path="/settings/advanced" element={<SettingsAdvanced />} />
+            <Route path="/profiles" element={<Profiles />} />
+            <Route path="/train" element={<Train />} />
+            <Route path="/tools" element={<Tools />} />
+            <Route path="/tools/whisper" element={<WhisperOutput />} />
+            <Route path="/calendar" element={<Calendar />} />
+            <Route path="/chat" element={<GeneralChat />} />
+            <Route path="/queue" element={<Queue />} />
+            <Route path="/fusion" element={<Fusion />} />
+            <Route path="/loopmaker" element={<LoopMaker />} />
+            <Route path="/beatmaker" element={<BeatMaker />} />
+            <Route path="/album" element={<AlbumMaker />} />
+            <Route path="/games" element={<Games />} />
+            <Route path="/games/rain-blocks" element={<RainBlocks />} />
+            <Route path="/games/sand-blocks" element={<SandBlocks />} />
+            <Route path="/games/brick-breaker" element={<BrickBreaker />} />
+            <Route path="/games/snake" element={<Snake />} />
           </Route>
-          <Route path="/dnd" element={<Dnd />} />
-          <Route path="/dnd/inbox" element={<DndInbox />} />
-          <Route path="/dnd/world" element={<DndWorld />} />
-          <Route path="/dnd/world/bank" element={<DndWorldBank />} />
-          <Route path="/dnd/world/bank/economy" element={<DndWorldBankEconomy />} />
-          <Route path="/dnd/world/bank/transactions" element={<DndWorldBankTransactions />} />
-          <Route path="/dnd/world/pantheon" element={<DndWorldPantheon />} />
-          <Route path="/dnd/world/regions" element={<DndWorldRegions />} />
-          <Route path="/dnd/world/factions" element={<DndWorldFactions />} />
-          <Route path="/dnd/world/calendar" element={<DndWorldCalendar />} />
-          <Route path="/dnd/lore/secrets" element={<DndLoreSecrets />} />
-          <Route path="/dnd/lore/journal" element={<DndLoreJournal />} />
-          <Route path="/dnd/lore/stories" element={<DndLoreStories />} />
-          <Route path="/dnd/lore/notes" element={<DndLoreNotes />} />
-          <Route path="/dnd/lore/relations" element={<DndLorePlayerRelations />} />
-          <Route path="/dnd/lore/spellbook" element={<DndLoreSpellBook />} />
-          <Route path="/dnd/lore/races" element={<DndLoreRaces />} />
-          <Route path="/dnd/lore/classes" element={<DndLoreClasses />} />
-          <Route path="/dnd/lore/rules" element={<DndLoreRules />} />
-          <Route path="/dnd/lore/background-rules" element={<DndLoreBackgroundRules />} />
-          <Route path="/dnd/tasks" element={<DndTasks />} />
-          <Route path="/dnd/dungeon-master" element={<DndDungeonMaster />} />
-          <Route path="/dnd/dungeon-master/events" element={<DndDmEvents />} />
-          <Route path="/dnd/dungeon-master/monsters" element={<DndDmMonsters />} />
-          <Route path="/dnd/dungeon-master/npcs" element={<DndDmNpcs />} />
-          <Route path="/dnd/dungeon-master/players" element={<DndDmPlayersHome />} />
-          <Route path="/dnd/dungeon-master/players/sheet" element={<DndDmPlayers />} />
-          <Route path="/dnd/dungeon-master/players/new" element={<DndDmPlayerCreate />} />
-          <Route path="/dnd/dungeon-master/players/auto" element={<DndDmPlayerAuto />} />
-          <Route path="/dnd/dungeon-master/quests" element={<DndDmQuests />} />
-          <Route path="/dnd/dungeon-master/quests/faction" element={<DndDmQuestsFaction />} />
-          <Route path="/dnd/dungeon-master/quests/main" element={<DndDmQuestsMain />} />
-          <Route path="/dnd/dungeon-master/quests/personal" element={<DndDmQuestsPersonal />} />
-          <Route path="/dnd/dungeon-master/quests/side" element={<DndDmQuestsSide />} />
-          <Route
-            path="/dnd/dungeon-master/quests/generator"
-            element={<DndDmQuestGenerator />}
-          />
-          <Route path="/dnd/dungeon-master/establishments" element={<DndDmEstablishments />} />
-          <Route path="/dnd/dungeon-master/tag-manager" element={<DndDmTagManager />} />
-          <Route path="/dnd/dungeon-master/world-inventory" element={<DndDmWorldInventory />} />
-          <Route path="/dnd/assets" element={<DndAssets />} />
-          <Route path="/dnd/lore" element={<DndLore />} />
-          <Route path="/dnd/piper" element={<DndVoiceLabs />} />
-          <Route path="/dnd/piper/piper" element={<DndPiperOnly />} />
-          <Route path="/dnd/piper/eleven" element={<DndElevenLabs />} />
-          <Route path="/tools/voices" element={<DndVoiceLabs />} />
-          <Route path="/tools/voices/piper" element={<DndPiperOnly />} />
-          <Route path="/tools/voices/eleven" element={<DndElevenLabs />} />
-          <Route path="/tools/voices/manage" element={<ManageVoices />} />
-          <Route path="/dnd/discord" element={<DndDiscord />} />
-          <Route path="/dnd/chat" element={<DndChat />} />
-          <Route path="/settings" element={<Settings />} />
-          <Route path="/settings/users" element={<SettingsUsers />} />
-          <Route path="/settings/vault" element={<SettingsVault />} />
-          <Route path="/settings/discord" element={<SettingsDiscord />} />
-          <Route path="/settings/appearance" element={<SettingsAppearance />} />
-          <Route path="/settings/models" element={<SettingsModels />} />
-          <Route path="/settings/devices" element={<SettingsDevices />} />
-          <Route path="/settings/hotwords" element={<SettingsHotwords />} />
-          <Route path="/settings/backup" element={<SettingsBackup />} />
-          <Route path="/settings/advanced" element={<SettingsAdvanced />} />
-          <Route path="/profiles" element={<Profiles />} />
-          <Route path="/train" element={<Train />} />
-          <Route path="/tools" element={<Tools />} />
-          <Route path="/tools/whisper" element={<WhisperOutput />} />
-          <Route path="/calendar" element={<Calendar />} />
-          <Route path="/chat" element={<GeneralChat />} />
-          <Route path="/queue" element={<Queue />} />
-          <Route path="/fusion" element={<Fusion />} />
-          <Route path="/loopmaker" element={<LoopMaker />} />
-          <Route path="/beatmaker" element={<BeatMaker />} />
-          <Route path="/album" element={<AlbumMaker />} />
-          <Route path="/games" element={<Games />} />
-          <Route path="/games/rain-blocks" element={<RainBlocks />} />
-          <Route path="/games/sand-blocks" element={<SandBlocks />} />
-          <Route path="/games/brick-breaker" element={<BrickBreaker />} />
-          <Route path="/games/snake" element={<Snake />} />
-        </Route>
-      </Routes>
+        </Routes>
+      </div>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- wrap the router in a keyed container that uses the current location to trigger transitions
- add a route-fade animation so primary pages fade in on navigation

## Testing
- not run (UI changes without automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68dc1d2fe4308325846a74a5467b9c29