### PR TITLE
Improve Sound Lab layout responsiveness

### DIFF
--- a/ui/src/pages/MusicGen.css
+++ b/ui/src/pages/MusicGen.css
@@ -9,3 +9,48 @@
     padding: 0 var(--space-sm);
   }
 }
+
+.output-folder-row,
+.hardware-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  align-items: center;
+}
+
+.output-folder-row input[type="text"] {
+  flex: 1 1 18rem;
+  min-width: 0;
+}
+
+.output-folder-row button {
+  flex: 0 0 auto;
+}
+
+.hardware-options {
+  gap: var(--space-md);
+}
+
+.hardware-options .hardware-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+@media (max-width: 900px) {
+  .output-folder-row,
+  .hardware-options {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .output-folder-row input[type="text"],
+  .output-folder-row button,
+  .hardware-options .hardware-toggle {
+    width: 100%;
+  }
+
+  .hardware-options .hardware-toggle {
+    justify-content: flex-start;
+  }
+}

--- a/ui/src/pages/MusicGen.jsx
+++ b/ui/src/pages/MusicGen.jsx
@@ -1143,7 +1143,7 @@ export default function MusicGen() {
         </label>
         <div className="mb-md">
           <div style={{ marginBottom: "0.25rem" }}>Output Folder</div>
-          <div style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
+          <div className="output-folder-row">
             <input
               type="text"
               value={outputDir}
@@ -1154,7 +1154,6 @@ export default function MusicGen() {
               }}
               className="p-sm"
               placeholder="Default (App Data directory)"
-              style={{ flex: 1 }}
             />
             <PrimaryButton
               type="button"
@@ -1213,8 +1212,8 @@ export default function MusicGen() {
           />
           Force CPU
         </label>
-        <div className="mb-md" style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
-          <label style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+        <div className="mb-md hardware-options">
+          <label className="hardware-toggle">
             <input
               type="checkbox"
               checked={forceGpu}
@@ -1223,7 +1222,7 @@ export default function MusicGen() {
             />
             Force GPU
           </label>
-          <label style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+          <label className="hardware-toggle">
             <input
               type="checkbox"
               checked={useFp16}


### PR DESCRIPTION
## Summary
- replace inline flex layouts for the output folder and hardware option rows with semantic class names
- add responsive Sound Lab styles that wrap controls and stack them below 900px

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dc25a19c5c8325962287547b24470d