### PR TITLE
feat: add responsive navigation drawer controls

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -121,17 +121,46 @@ header {
 
 .app-layout {
   display: flex;
+  flex-direction: column;
   min-height: 100vh;
   background: var(--bg);
   color: var(--text);
 }
 
+.app-layout__nav-toggle {
+  position: fixed;
+  top: var(--space-md);
+  left: var(--space-md);
+  z-index: 140;
+  padding: 0.5rem 1rem;
+  border: 1px solid color-mix(in srgb, var(--text) 15%, transparent);
+  border-radius: 999px;
+  background: var(--card-bg);
+  color: inherit;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: var(--topbar-shadow);
+}
+
+.app-layout__scrim {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(10, 10, 20, 0.55);
+  z-index: 120;
+}
+
+.app-layout[data-nav-open='true'] .app-layout__scrim {
+  display: block;
+}
+
 .main-nav {
-  position: sticky;
+  position: fixed;
   top: 0;
-  align-self: stretch;
-  flex: 0 0 clamp(220px, 20vw, 260px);
-  min-height: 100vh;
+  left: 0;
+  width: clamp(240px, 80vw, 300px);
+  height: 100vh;
   padding: var(--space-lg) var(--space-md);
   box-sizing: border-box;
   background: var(--card-bg);
@@ -141,6 +170,30 @@ header {
   flex-direction: column;
   gap: var(--space-md);
   overflow-y: auto;
+  transform: translateX(-100%);
+  transition: transform 0.3s ease;
+  z-index: 130;
+}
+
+.main-nav.is-open,
+.app-layout[data-nav-open='true'] .main-nav {
+  transform: translateX(0);
+}
+
+.main-nav__close {
+  align-self: flex-end;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: none;
+  border: 1px solid transparent;
+  color: inherit;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.main-nav__close:is(:hover, :focus-visible) {
+  background: var(--card-hover-bg);
 }
 
 .main-nav__brand {
@@ -194,48 +247,37 @@ header {
   overflow-y: auto;
 }
 
-@media (max-width: 960px) {
+@media (max-width: 959.98px) {
+  .app-layout__content {
+    padding: var(--space-md);
+  }
+}
+
+@media (min-width: 960px) {
   .app-layout {
-    flex-direction: column;
+    flex-direction: row;
+  }
+
+  .app-layout__nav-toggle {
+    display: none;
+  }
+
+  .app-layout__scrim {
+    display: none !important;
   }
 
   .main-nav {
     position: sticky;
-    flex: none;
-    width: 100%;
-    max-width: 100%;
-    min-width: auto;
     top: 0;
-    z-index: 10;
-    align-self: auto;
-    min-height: auto;
-    max-height: none;
-    border-right: none;
-    border-bottom: 1px solid color-mix(in srgb, var(--text) 20%, transparent);
-    padding: var(--space-md);
-    overflow-y: visible;
+    align-self: stretch;
+    flex: 0 0 clamp(220px, 20vw, 260px);
+    min-height: 100vh;
+    transform: none;
+    transition: none;
   }
 
-  .main-nav__list {
-    flex-direction: row;
-    align-items: center;
-    gap: 0.5rem;
-    overflow-x: auto;
-    padding-bottom: 0.25rem;
-  }
-
-  .main-nav__item {
-    flex: 0 0 auto;
-  }
-
-  .main-nav__link {
-    border-radius: 999px;
-    white-space: nowrap;
-    padding: 0.5rem 0.9rem;
-  }
-
-  .app-layout__content {
-    padding: var(--space-md);
+  .main-nav__close {
+    display: none;
   }
 }
 

--- a/ui/src/components/AppLayout.jsx
+++ b/ui/src/components/AppLayout.jsx
@@ -1,17 +1,91 @@
+import { useEffect, useState } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 import MainNav from './MainNav.jsx';
+
+const DESKTOP_QUERY = '(min-width: 960px)';
+
+function getIsDesktop() {
+  return typeof window !== 'undefined'
+    ? window.matchMedia(DESKTOP_QUERY).matches
+    : false;
+}
 
 export default function AppLayout() {
   const location = useLocation();
   const normalizedPath = location.pathname.replace(/\/+$/, '') || '/';
   const showNav = normalizedPath !== '/';
+  const [isDesktop, setIsDesktop] = useState(getIsDesktop);
+  const [isNavOpen, setIsNavOpen] = useState(() => showNav && getIsDesktop());
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
+    const mediaQuery = window.matchMedia(DESKTOP_QUERY);
+
+    const handleChange = (event) => {
+      setIsDesktop(event.matches);
+      setIsNavOpen(event.matches);
+    };
+
+    handleChange(mediaQuery);
+    mediaQuery.addEventListener('change', handleChange);
+
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  useEffect(() => {
+    if (!showNav) {
+      setIsNavOpen(false);
+    } else if (isDesktop) {
+      setIsNavOpen(true);
+    }
+  }, [showNav, isDesktop]);
+
+  useEffect(() => {
+    if (!isDesktop) {
+      setIsNavOpen(false);
+    }
+  }, [location.pathname, isDesktop]);
+
+  const closeNav = () => {
+    if (!isDesktop) {
+      setIsNavOpen(false);
+    }
+  };
+  const toggleNav = () => {
+    if (isDesktop) {
+      return;
+    }
+    setIsNavOpen((prev) => !prev);
+  };
+
+  const navId = 'main-navigation';
+  const navOpenAttribute = showNav && isNavOpen ? 'true' : 'false';
 
   return (
-    <div className="app-layout">
+    <div className="app-layout" data-nav-open={navOpenAttribute}>
       <a className="skip-link" href="#main-content">
         Skip to content
       </a>
-      {showNav && <MainNav />}
+      {showNav && (
+        <button
+          type="button"
+          className="app-layout__nav-toggle"
+          aria-controls={navId}
+          aria-expanded={isNavOpen}
+          onClick={toggleNav}
+        >
+          Menu
+        </button>
+      )}
+      {showNav && (
+        <MainNav isOpen={isNavOpen} onNavigate={closeNav} navId={navId} />
+      )}
+      {showNav && (
+        <div className="app-layout__scrim" aria-hidden="true" onClick={closeNav} />
+      )}
       <main id="main-content" className="app-layout__content" tabIndex={-1}>
         <Outlet />
       </main>

--- a/ui/src/components/MainNav.jsx
+++ b/ui/src/components/MainNav.jsx
@@ -16,9 +16,27 @@ function classNames(...values) {
   return values.filter(Boolean).join(' ');
 }
 
-export default function MainNav() {
+export default function MainNav({ isOpen, onNavigate, navId = 'main-navigation' }) {
+  const handleNavigate = () => {
+    if (typeof onNavigate === 'function') {
+      onNavigate();
+    }
+  };
+
   return (
-    <nav className="main-nav" aria-label="Primary">
+    <nav
+      id={navId}
+      className={classNames('main-nav', isOpen && 'is-open')}
+      aria-label="Primary"
+    >
+      <button
+        type="button"
+        className="main-nav__close"
+        aria-label="Close navigation"
+        onClick={handleNavigate}
+      >
+        Close
+      </button>
       <div className="main-nav__brand" aria-hidden="true">
         Blossom
       </div>
@@ -31,6 +49,7 @@ export default function MainNav() {
               className={({ isActive }) =>
                 classNames('main-nav__link', isActive && 'is-active')
               }
+              onClick={handleNavigate}
             >
               <span className="main-nav__text">{label}</span>
             </NavLink>


### PR DESCRIPTION
## Summary
- add responsive navigation state management with toggle controls and scrim handling in the app layout
- update the main navigation to support drawer open state, close control, and auto-collapse on navigation
- extend global styles to provide off-canvas drawer behavior on small screens while keeping the desktop sidebar

## Testing
- npm install *(fails: 403 Forbidden fetching react-is)*

------
https://chatgpt.com/codex/tasks/task_e_68dc40c428d083258cf53c2ce7ca5575