### PR TITLE
Add exit code and module entry point to cli_riffusion

### DIFF
--- a/blossom/audio/riffusion/cli_riffusion.py
+++ b/blossom/audio/riffusion/cli_riffusion.py
@@ -247,3 +247,9 @@ def main() -> int:
         emit("audio_warn: empty/invalid audio after inversion; generating silence")
         est_len = int(max(1, round((total_tiles * seconds_per_tile) * out_sr)))
         audio = np.zeros(est_len, dtype=np.float32)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- ensure `cli_riffusion.main` returns an integer exit code for callers
- add a `__main__` guard so `python -m blossom.audio.riffusion.cli_riffusion` executes `main()`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddfd54094c8325a6b525bfae588ac7