### PR TITLE
Adjust fileSrc fallback handling

### DIFF
--- a/ui/src/lib/paths.js
+++ b/ui/src/lib/paths.js
@@ -4,7 +4,7 @@ export function fileSrc(path) {
   if (!path || typeof path !== 'string') return '';
   try {
     const url = convertFileSrc(path);
-    if (typeof url === 'string' && url.startsWith('asset://')) return url;
+    if (typeof url === 'string' && url) return url;
     // Fallback: build asset URL manually (Windows-safe)
     const norm = path.replaceAll('\\', '/');
     return 'asset://localhost/' + encodeURI(norm);


### PR DESCRIPTION
## Summary
- ensure `fileSrc` returns the `convertFileSrc` result whenever it yields a non-empty string
- keep the existing asset URL fallback for environments without `convertFileSrc`

## Testing
- npm --prefix ui run build
- npm run tauri build *(fails: missing system dependency `glib-2.0` in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ddfd644a648325b5d84d2ef5696595