### PR TITLE
Fix mel codec orientation for stitched tiles

### DIFF
--- a/blossom/audio/riffusion/cli_riffusion.py
+++ b/blossom/audio/riffusion/cli_riffusion.py
@@ -183,10 +183,15 @@ def main() -> int:
         try:
             hifi, vsetup, deno = hub_load_hifigan(device="cuda")
             from .mel_codec import image_to_mel
-            mel_power512 = image_to_mel(stitched, target_shape=(cfg_mel.n_mels, stitched.width))
+            mel_power512 = image_to_mel(
+                stitched, target_shape=(cfg_mel.n_mels, stitched.width)
+            )
             assert (
                 mel_power512.shape[0] == cfg_mel.n_mels
             ), f"Hub HiFi-GAN expected {cfg_mel.n_mels} mel bins, got {mel_power512.shape}"
+            assert (
+                mel_power512.shape[1] == stitched.width
+            ), f"Hub HiFi-GAN expected time {stitched.width}, got {mel_power512.shape}"
             emit("vocoder: synthesizing audio (hub)")
             v0 = time.time()
             audio = hub_mel_to_audio(mel_power512, vsetup, hifi, denoiser=deno if args.hub_denoise > 0 else None, device="cuda")
@@ -207,10 +212,15 @@ def main() -> int:
             mel_power512 = mel512_power = None
             # Convert image->mel power (512) using our codec, then to 80-log-mel
             from .mel_codec import image_to_mel
-            mel_power512 = image_to_mel(stitched, target_shape=(cfg_mel.n_mels, stitched.width))
+            mel_power512 = image_to_mel(
+                stitched, target_shape=(cfg_mel.n_mels, stitched.width)
+            )
             assert (
                 mel_power512.shape[0] == cfg_mel.n_mels
             ), f"Local HiFi-GAN expected {cfg_mel.n_mels} mel bins, got {mel_power512.shape}"
+            assert (
+                mel_power512.shape[1] == stitched.width
+            ), f"Local HiFi-GAN expected time {stitched.width}, got {mel_power512.shape}"
             mel80_log = mel512_power_to_mel80_log(
                 mel_power512,
                 sr=cfg_mel.sample_rate,

--- a/blossom/audio/riffusion/cli_soundscape.py
+++ b/blossom/audio/riffusion/cli_soundscape.py
@@ -162,10 +162,15 @@ def main() -> int:
                 hifi, vsetup, deno = hub_load_hifigan(device="cuda")
                 from .mel_codec import image_to_mel
                 stitched = stitch_tiles_horizontally(tiles, overlap_px=overlap_px)
-                mel_power512 = image_to_mel(stitched, target_shape=(mel.n_mels, stitched.width))
+                mel_power512 = image_to_mel(
+                    stitched, target_shape=(mel.n_mels, stitched.width)
+                )
                 assert (
                     mel_power512.shape[0] == mel.n_mels
                 ), f"Hub HiFi-GAN expected {mel.n_mels} mel bins, got {mel_power512.shape}"
+                assert (
+                    mel_power512.shape[1] == stitched.width
+                ), f"Hub HiFi-GAN expected time {stitched.width}, got {mel_power512.shape}"
                 audio = hub_mel_to_audio(mel_power512, vsetup, hifi, denoiser=deno if args.hub_denoise > 0 else None, device="cuda")
                 emit("vocoder_used: hifigan")
             except Exception as e:
@@ -181,10 +186,15 @@ def main() -> int:
                 emit("vocoder: preparing 80-mel features")
                 from .mel_codec import image_to_mel
                 stitched = stitch_tiles_horizontally(tiles, overlap_px=overlap_px)
-                mel_power512 = image_to_mel(stitched, target_shape=(mel.n_mels, stitched.width))
+                mel_power512 = image_to_mel(
+                    stitched, target_shape=(mel.n_mels, stitched.width)
+                )
                 assert (
                     mel_power512.shape[0] == mel.n_mels
                 ), f"Local HiFi-GAN expected {mel.n_mels} mel bins, got {mel_power512.shape}"
+                assert (
+                    mel_power512.shape[1] == stitched.width
+                ), f"Local HiFi-GAN expected time {stitched.width}, got {mel_power512.shape}"
                 mel80_log = mel512_power_to_mel80_log(
                     mel_power512,
                     sr=mel.sample_rate,

--- a/blossom/audio/riffusion/mel_codec.py
+++ b/blossom/audio/riffusion/mel_codec.py
@@ -62,7 +62,14 @@ def image_to_mel(img: Image.Image, target_shape: Tuple[int, int] = (512, 512)) -
         raise ValueError("image_to_mel expects a 2D grayscale image")
 
     expected_mels = int(target_shape[0]) if target_shape else arr.shape[0]
-    if arr.shape[0] == expected_mels:
+    expected_time = int(target_shape[1]) if target_shape else arr.shape[1]
+
+    if arr.shape[0] == expected_mels and arr.shape[1] == expected_time:
+        mel_axes = arr
+    elif arr.shape[1] == expected_mels and arr.shape[0] == expected_time:
+        mel_axes = np.transpose(arr, (1, 0))
+    elif arr.shape[0] == expected_mels:
+        # Allow time dimension to differ when callers intentionally overspecify.
         mel_axes = arr
     elif arr.shape[1] == expected_mels:
         mel_axes = np.transpose(arr, (1, 0))

--- a/blossom/audio/riffusion/stitcher.py
+++ b/blossom/audio/riffusion/stitcher.py
@@ -69,9 +69,9 @@ def tiles_to_audio(
     """
     stitched = stitch_tiles_horizontally(tiles, overlap_px=overlap_px)
     mel_power = image_to_mel(stitched, target_shape=(cfg.n_mels, stitched.width))
-    if mel_power.shape[0] != cfg.n_mels:
+    if mel_power.shape[0] != cfg.n_mels or mel_power.shape[1] != stitched.width:
         raise ValueError(
-            f"Expected stitched mel to have {cfg.n_mels} bins; got {mel_power.shape}"
+            f"Expected stitched mel to have shape ({cfg.n_mels}, {stitched.width}); got {mel_power.shape}"
         )
     if (vocoder_name or '').lower() == 'hifigan':
         try:


### PR DESCRIPTION
## Summary
- ensure `image_to_mel` preserves the expected mel/time orientation for stitched spectrogram tiles
- add explicit shape assertions before HiFi-GAN inference to surface orientation regressions early
- tighten the stitched mel validation used by the Griffin-Lim fallback path

## Testing
- python -m blossom.audio.riffusion.cli_riffusion --duration 12 --outfile demo.wav *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68de8d1b91d8832581b01bfedb2a8d75