### PR TITLE
Log HiFi-GAN usage in riffusion CLI

### DIFF
--- a/blossom/audio/riffusion/cli_riffusion.py
+++ b/blossom/audio/riffusion/cli_riffusion.py
@@ -214,6 +214,7 @@ def main() -> int:
                 device=hub_device,
             )
             emit(f"vocoder_time: {time.time() - v0:.3f}s")
+            emit("vocoder_used: hifigan")
         except Exception as e:
             emit(f"vocoder: hub failed ({e}); falling back")
             audio = None
@@ -251,6 +252,7 @@ def main() -> int:
             v0 = time.time()
             audio = hifigan_synthesize(gen, dev, mel80_log)
             emit(f"vocoder_time: {time.time() - v0:.3f}s")
+            emit("vocoder_used: hifigan-local")
         except Exception as e:
             emit(f"vocoder: failed ({e}); falling back to Griffin-Lim")
 

--- a/tests/test_riffusion_cli.py
+++ b/tests/test_riffusion_cli.py
@@ -314,6 +314,7 @@ def test_riffusion_cli_hub_hifigan_cpu(monkeypatch, tmp_path, use_tiles):
     assert log_path.exists()
     log_text = log_path.read_text(encoding="utf-8")
     assert "vocoder: synthesizing audio (hub, device=cpu)" in log_text
+    assert "vocoder_used: hifigan" in log_text
     assert "vocoder_used: griffinlim" not in log_text
 
     assert outfile.exists()


### PR DESCRIPTION
## Summary
- emit explicit vocoder_used lines after successful hub or local HiFi-GAN synthesis
- update riffusion CLI tests to assert the HiFi-GAN log entry

## Testing
- pytest tests/test_riffusion_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68de9eb46cb88325afbd5114dfce27c4