### PR TITLE
Handle torchaudio InverseMelScale max_iter compat

### DIFF
--- a/blossom/audio/riffusion/mel_codec.py
+++ b/blossom/audio/riffusion/mel_codec.py
@@ -144,14 +144,17 @@ def project_mel_power(
 
     n_stft = src.n_fft // 2 + 1
     mel_t = torch.from_numpy(mel_power.astype(np.float32))
-    inv_transform = torchaudio.transforms.InverseMelScale(
+    inverse_kwargs = dict(
         n_stft=n_stft,
         n_mels=src.n_mels,
         sample_rate=src.sample_rate,
         f_min=src.f_min,
         f_max=src.f_max,
-        max_iter=0,
     )
+    try:
+        inv_transform = torchaudio.transforms.InverseMelScale(max_iter=0, **inverse_kwargs)
+    except TypeError:
+        inv_transform = torchaudio.transforms.InverseMelScale(**inverse_kwargs)
     linear_power = inv_transform(mel_t)
 
     mel_transform = torchaudio.transforms.MelScale(

--- a/tests/test_riffusion_mel_codec.py
+++ b/tests/test_riffusion_mel_codec.py
@@ -1,0 +1,24 @@
+import pytest
+
+
+pytest.importorskip("numpy")
+pytest.importorskip("torch")
+pytest.importorskip("torchaudio")
+
+import numpy as np
+
+from blossom.audio.riffusion.vocoder_hifigan import mel512_power_to_mel80_log
+
+
+def test_mel512_power_to_mel80_log_runs_without_error():
+    mel_power = np.ones((512, 4), dtype=np.float32)
+    result = mel512_power_to_mel80_log(
+        mel_power,
+        sr=22050,
+        n_fft=1024,
+        hop=256,
+        fmin=30.0,
+        fmax=8000.0,
+    )
+
+    assert result.shape == (80, mel_power.shape[1])


### PR DESCRIPTION
## Summary
- guard torchaudio InverseMelScale usage so max_iter is passed only when supported in both riffusion mel projection paths
- add a regression test for mel512_power_to_mel80_log to ensure the conversion path stays callable

## Testing
- pytest tests/test_riffusion_mel_codec.py

------
https://chatgpt.com/codex/tasks/task_e_68dee2f8e33c83258a46a6f28be91a14