### PR TITLE
Track job sources in queue and D&D tag jobs

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -54,17 +54,35 @@ pub async fn riffusion_generate(
         "32".into(),
         "--sr".into(),
         "22050".into(),
-        "--hs_freq".into(), "5000".into(),
-        "--hs_gain".into(), "2.0".into(),
-        "--lowcut".into(), "35".into(),
-        "--wet".into(), "0.12".into(),
+        "--hs_freq".into(),
+        "5000".into(),
+        "--hs_gain".into(),
+        "2.0".into(),
+        "--lowcut".into(),
+        "35".into(),
+        "--wet".into(),
+        "0.12".into(),
     ];
-    if let Some(s) = steps { args.push("--steps".into()); args.push(s.to_string()); }
-    if let Some(g) = guidance { args.push("--guidance".into()); args.push(format!("{}", g)); }
-    if let Some(n) = negative.clone() { args.push("--negative".into()); args.push(n); }
-    if let Some(sd) = seed { args.push("--seed".into()); args.push(sd.to_string()); }
+    if let Some(s) = steps {
+        args.push("--steps".into());
+        args.push(s.to_string());
+    }
+    if let Some(g) = guidance {
+        args.push("--guidance".into());
+        args.push(format!("{}", g));
+    }
+    if let Some(n) = negative.clone() {
+        args.push("--negative".into());
+        args.push(n);
+    }
+    if let Some(sd) = seed {
+        args.push("--seed".into());
+        args.push(sd.to_string());
+    }
     // Prefer explicit prompt if provided; otherwise rely on preset default (piano)
-    if let Some(p) = prompt.clone() { args.push(p); }
+    if let Some(p) = prompt.clone() {
+        args.push(p);
+    }
 
     let output = async_runtime::spawn_blocking(move || {
         Command::new("python")
@@ -81,7 +99,9 @@ pub async fn riffusion_generate(
         return Err(String::from_utf8_lossy(&output.stderr).to_string());
     }
 
-    Ok(RiffusionResult { path: out_path.to_string_lossy().to_string() })
+    Ok(RiffusionResult {
+        path: out_path.to_string_lossy().to_string(),
+    })
 }
 
 #[tauri::command]

--- a/ui/src/components/JobQueuePanel.jsx
+++ b/ui/src/components/JobQueuePanel.jsx
@@ -36,6 +36,7 @@ export default function JobQueuePanel({ queue = [], onCancel, activeId } = {}) {
             <th>Status</th>
             <th>Position</th>
             <th>Label</th>
+            <th>Source</th>
             <th>ETA</th>
             <th>Queued</th>
             <th>Started</th>
@@ -57,6 +58,7 @@ export default function JobQueuePanel({ queue = [], onCancel, activeId } = {}) {
                 <td>{item.status}</td>
                 <td>{position}</td>
                 <td>{item.label || item.kind || item.id}</td>
+                <td>{item.source || "—"}</td>
                 <td>
                   {typeof item.eta_seconds === "number"
                     ? formatSeconds(item.eta_seconds)

--- a/ui/src/pages/BeatMaker.jsx
+++ b/ui/src/pages/BeatMaker.jsx
@@ -673,6 +673,7 @@ export default function BeatMaker() {
           const jobIdValue = await invoke('record_manual_job', {
             kind: 'beat-maker',
             label: downloadName,
+            source: 'Beat Maker',
             args: jobArgs,
             artifacts: [{ name: downloadName, path: savePath }],
             stdout: [`Saved to ${savePath}`],
@@ -766,6 +767,7 @@ export default function BeatMaker() {
       const jobIdValue = await invoke('record_manual_job', {
         kind: 'beat-maker',
         label: downloadName,
+        source: 'Beat Maker',
         args: jobArgs,
         stdout: ['Download started'],
       });

--- a/ui/src/pages/LoopMaker.jsx
+++ b/ui/src/pages/LoopMaker.jsx
@@ -1405,6 +1405,7 @@ export default function LoopMaker() {
           const jobIdValue = await invoke('record_manual_job', {
             kind: 'loop-maker',
             label: defaultFileName,
+            source: 'Loop Maker',
             args: jobArgs,
             artifacts: [{ name: defaultFileName, path: savePath }],
             stdout: [`Saved to ${savePath}`],
@@ -1511,6 +1512,7 @@ export default function LoopMaker() {
         const jobIdValue = await invoke('record_manual_job', {
           kind: 'loop-maker',
           label: defaultFileName,
+          source: 'Loop Maker',
           args: jobArgs,
           stdout: ['Download started'],
         });

--- a/ui/src/pages/Queue.jsx
+++ b/ui/src/pages/Queue.jsx
@@ -66,6 +66,7 @@ export default function Queue() {
                   <th>ID</th>
                   <th>Status</th>
                   <th>Label</th>
+                  <th>Source</th>
                   <th>Created</th>
                   <th>Finished</th>
                 </tr>
@@ -76,6 +77,7 @@ export default function Queue() {
                     <td>{job.id}</td>
                     <td>{job.status}</td>
                     <td>{job.label || job.args?.[0] || ''}</td>
+                    <td>{job.source || '—'}</td>
                     <td>{formatTimestamp(job.created_at || job.createdAt)}</td>
                     <td>{formatTimestamp(job.finished_at || job.finishedAt)}</td>
                   </tr>


### PR DESCRIPTION
## Summary
- add `source` metadata across job context, records, state and persistence so launchers can label their origin
- extend job registry with helpers for in-process work and run the D&D tag refresh flow as a queued job with progress logging
- populate source labels for MusicGen, Riffusion, render, loop export, and manual jobs and surface the source column in the queue UI

## Testing
- `cargo check` *(fails: missing system dependency glib-2.0)*
- `npm --prefix ui run lint` *(fails: project has no lint script)*
- `cargo fmt`


------
https://chatgpt.com/codex/tasks/task_e_68e55e3a157c8325b1d51f026b1eeef1