### PR TITLE
Fix invalid waveform icons in tools pages

### DIFF
--- a/ui/src/pages/SoundLab.jsx
+++ b/ui/src/pages/SoundLab.jsx
@@ -16,7 +16,7 @@ export default function SoundLab() {
       <main className="dashboard">
         <Card
           to="/musicgen/musicgen"
-          icon="Waveform"
+          icon="AudioWaveform"
           title="MusicGen"
         >
           Launch the classic prompt-to-music workflow.

--- a/ui/src/pages/Tools.jsx
+++ b/ui/src/pages/Tools.jsx
@@ -22,7 +22,7 @@ export default function Tools() {
         <Card to="/loopmaker" icon="Repeat" title="Loop Maker">
           Video Loop Creator
         </Card>
-        <Card to="/beatmaker" icon="Waveform" title="Beat Maker">
+        <Card to="/beatmaker" icon="AudioWaveform" title="Beat Maker">
           Audio Loop Builder
         </Card>
         <Card to="/album" icon="Disc3" title="Album Maker">


### PR DESCRIPTION
## Summary
- replace the Beat Maker card icon with the valid `AudioWaveform` Lucide icon
- update the Sound Lab MusicGen card to use the same valid `AudioWaveform` icon to avoid future failures

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5688a1d148325aeecb499e71edc85