### PR TITLE
Fix job record tuple capture and whisper result handling

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2859,6 +2859,7 @@ impl JobRegistry {
             (
                 Option<String>,
                 Option<String>,
+                Option<String>,
                 Vec<String>,
                 DateTime<Utc>,
                 Option<DateTime<Utc>>,
@@ -3156,7 +3157,7 @@ fn settings_store(app: &AppHandle) -> Result<Arc<Store<tauri::Wry>>, String> {
 #[tauri::command]
 async fn update_section_tags(
     app: AppHandle,
-    registry: State<JobRegistry>,
+    registry: State<'_, JobRegistry>,
     section: String,
 ) -> Result<TagUpdateSummary, String> {
     let trimmed = section.trim();
@@ -5763,6 +5764,7 @@ print(json.dumps({{"text": result}}))
     })
     .await
     .map_err(|e| e.to_string())?;
+    let text = text?;
     Ok(text)
 }
 


### PR DESCRIPTION
## Summary
- fix the captured job metadata tuple so JobRecord construction uses the correct source/args order
- add the required lifetime when retrieving the job registry Rocket state
- propagate the Whisper transcription result out of the blocking task before returning

## Testing
- `cargo fmt`
- `cargo check` *(fails: missing system library glib-2.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e56bfe671c8325b6b16f3c63eb4d22