### PR TITLE
Resolve Piper voice resources before synth

### DIFF
--- a/ui/src/lib/piperVoices.ts
+++ b/ui/src/lib/piperVoices.ts
@@ -99,3 +99,22 @@ export async function listPiperVoices(): Promise<PiperVoice[]> {
 
   return voices;
 }
+
+export async function resolveVoiceResources(
+  voice?: Pick<PiperVoice, "modelPath" | "configPath">
+): Promise<{ modelPath: string; configPath: string }> {
+  const resolvePath = async (path?: string) => {
+    if (!path) return "";
+    try {
+      const resolved = await invoke("resolve_resource", { path });
+      return typeof resolved === "string" && resolved ? resolved : path;
+    } catch {
+      return path ?? "";
+    }
+  };
+
+  const modelPath = await resolvePath(voice?.modelPath);
+  const configPath = await resolvePath(voice?.configPath);
+
+  return { modelPath, configPath };
+}


### PR DESCRIPTION
## Summary
- keep full Piper voice metadata in SettingsUsers and resolve the on-disk paths before running the voice preview
- add a shared helper for resolving Piper model/config files via Tauri
- resolve voice resources for the welcome greeting so the selected user voice plays reliably

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e570624ca88325b5518d1408fa7984