### PR TITLE
Remove vault selection command and hardcode default DreadHaven root

### DIFF
--- a/ui/src/api/config.js
+++ b/ui/src/api/config.js
@@ -4,4 +4,5 @@ export const getConfig = (key) => invoke("get_config", { key });
 export const setConfig = (key, value) => invoke("set_config", { key, value });
 export const exportSettings = (path) => invoke("export_settings", { path });
 export const importSettings = (path) => invoke("import_settings", { path });
+export const getDreadhavenRoot = () => invoke("get_dreadhaven_root");
 

--- a/ui/src/api/establishments.js
+++ b/ui/src/api/establishments.js
@@ -1,4 +1,4 @@
-import { getConfig } from './config';
+import { getDreadhavenRoot } from './config';
 import { listDir } from './dir';
 
 const DEFAULT_REGIONS = 'D:\\Documents\\DreadHaven\\10_World\\Regions';
@@ -122,12 +122,12 @@ function sortItems(items) {
 export async function loadEstablishments() {
   const candidates = [];
   try {
-    const vault = await getConfig('vaultPath');
+    const vault = await getDreadhavenRoot();
     if (typeof vault === 'string' && vault.trim()) {
-      candidates.push(joinSegments(vault, '10_World', 'Regions'));
+      candidates.push(joinSegments(vault.trim(), '10_World', 'Regions'));
     }
   } catch (err) {
-    console.warn('Failed to read vault path for establishments', err);
+    console.warn('Failed to resolve DreadHaven root for establishments', err);
   }
   if (!candidates.includes(DEFAULT_REGIONS)) {
     candidates.push(DEFAULT_REGIONS);

--- a/ui/src/api/races.js
+++ b/ui/src/api/races.js
@@ -1,4 +1,4 @@
-import { getConfig } from './config';
+import { getDreadhavenRoot } from './config';
 import { listDir } from './dir';
 import { invoke } from '@tauri-apps/api/core';
 
@@ -18,11 +18,13 @@ function joinSegments(base, ...segments) {
   return result;
 }
 
+const DEFAULT_ROOT = 'D:\\Documents\\DreadHaven';
+
 export async function loadRaces() {
-  let base = 'D:\\Documents\\DreadHaven';
+  let base = DEFAULT_ROOT;
   try {
-    const vault = await getConfig('vaultPath');
-    if (typeof vault === 'string' && vault.trim()) base = vault;
+    const vault = await getDreadhavenRoot();
+    if (typeof vault === 'string' && vault.trim()) base = vault.trim();
   } catch {}
   const folder = joinSegments(base, '10_World', 'Races');
   const results = [];

--- a/ui/src/lib/vaultAttachments.js
+++ b/ui/src/lib/vaultAttachments.js
@@ -1,4 +1,4 @@
-import { getConfig } from '../api/config.js';
+import { getDreadhavenRoot } from '../api/config.js';
 import { readFileBytes } from '../api/files.js';
 
 const attachmentUrlCache = new Map();
@@ -126,8 +126,8 @@ function bytesToUrl(bytes, mime) {
 function getVaultPath() {
   if (!vaultPathPromise) {
     try {
-      const promise = Promise.resolve(getConfig('vaultPath'))
-        .then((value) => (typeof value === 'string' ? value : ''))
+      const promise = Promise.resolve(getDreadhavenRoot())
+        .then((value) => (typeof value === 'string' ? value.trim() : ''))
         .catch(() => '');
       vaultPathPromise = promise;
     } catch (err) {

--- a/ui/src/pages/DndAssets.jsx
+++ b/ui/src/pages/DndAssets.jsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import BackButton from '../components/BackButton.jsx';
 import Icon from '../components/Icon.jsx';
-import { getConfig } from '../api/config';
+import { getDreadhavenRoot } from '../api/config';
 import { listDir } from '../api/dir';
 import { readFileBytes, openPath } from '../api/files';
 import './Dnd.css';
@@ -37,9 +37,9 @@ export default function DndAssets() {
     setLoading(true);
     setError('');
     try {
-      const vault = await getConfig('vaultPath');
-      const base = (typeof vault === 'string' && vault)
-        ? `${vault}\\\\30_Assets`.replace(/\\\\/g, '\\\\')
+      const vault = await getDreadhavenRoot();
+      const base = (typeof vault === 'string' && vault.trim())
+        ? `${vault.trim()}\\\\30_Assets`.replace(/\\\\/g, '\\\\')
         : DEFAULT_ASSETS;
       setBasePath(base);
       setCurrentPath(base);

--- a/ui/src/pages/DndDiscord.jsx
+++ b/ui/src/pages/DndDiscord.jsx
@@ -9,7 +9,7 @@ import { listNpcs, saveNpc } from '../api/npcs.js';
 import { listPiperVoices } from '../lib/piperVoices';
 import { listDir } from '../api/dir';
 import { readFileBytes } from '../api/files';
-import { getConfig } from '../api/config';
+import { getDreadhavenRoot } from '../api/config';
 import './Dnd.css';
 
 const PROVIDERS = [
@@ -748,8 +748,8 @@ export default function DndDiscord() {
 
         let base = '';
         try {
-          const v = await getConfig('vaultPath');
-          const vStr = typeof v === 'string' ? v : '';
+          const v = await getDreadhavenRoot();
+          const vStr = typeof v === 'string' ? v.trim() : '';
           if (vStr) {
             base = joinPortraitPath(vStr, '30_Assets', 'Images', 'NPC_Portraits');
           }

--- a/ui/src/pages/DndDmEvents.jsx
+++ b/ui/src/pages/DndDmEvents.jsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import BackButton from '../components/BackButton.jsx';
-import { getConfig } from '../api/config';
+import { getDreadhavenRoot } from '../api/config';
 import { listInbox, readInbox } from '../api/inbox';
 import { renderMarkdown } from '../lib/markdown.jsx';
 import './Dnd.css';
@@ -42,8 +42,8 @@ export default function DndDmEvents() {
     setLoading(true);
     setError('');
     try {
-      const vault = await getConfig('vaultPath');
-      const base = (typeof vault === 'string' && vault) ? `${vault}\\20_DM\\Events` : '';
+      const vault = await getDreadhavenRoot();
+      const base = (typeof vault === 'string' && vault.trim()) ? `${vault.trim()}\\20_DM\\Events` : '';
       if (base) {
         const list = await listInbox(base);
         setUsingPath(base);

--- a/ui/src/pages/DndDmMonsters.jsx
+++ b/ui/src/pages/DndDmMonsters.jsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import BackButton from '../components/BackButton.jsx';
-import { getConfig } from '../api/config';
+import { getDreadhavenRoot } from '../api/config';
 import { listInbox, readInbox } from '../api/inbox';
 import { listDir } from '../api/dir';
 import { readFileBytes } from '../api/files';
@@ -55,8 +55,9 @@ export default function DndDmMonsters() {
   const [createError, setCreateError] = useState('');
 
   const refreshVaultPath = useCallback(async () => {
+    const fallback = 'D:\\Documents\\DreadHaven';
     try {
-      const vault = await getConfig('vaultPath');
+      const vault = await getDreadhavenRoot();
       const normalized = typeof vault === 'string' ? vault.trim() : '';
       if (normalized) {
         setVaultPath(normalized);
@@ -65,8 +66,8 @@ export default function DndDmMonsters() {
     } catch (e) {
       // ignore
     }
-    setVaultPath('');
-    return '';
+    setVaultPath(fallback);
+    return fallback;
   }, []);
 
   const fetchItems = useCallback(async () => {
@@ -133,7 +134,7 @@ export default function DndDmMonsters() {
     } catch (e) {
       const msg = e?.message || String(e);
       const hint = /Failed to read template/i.test(msg)
-        ? '\nHint: Place the monster template under \\_Templates\\ or set your Vault path in Settings.'
+        ? '\nHint: Place the monster template under \\_Templates\\.'
         : '';
       setCreateError(`${msg}${hint}`);
     } finally {
@@ -147,9 +148,9 @@ export default function DndDmMonsters() {
   useEffect(() => {
     (async () => {
       try {
-        const vault = await getConfig('vaultPath');
-        const base = (typeof vault === 'string' && vault)
-          ? `${vault}\\\\30_Assets\\\\Images\\\\Monster_Portraits`.replace(/\\\\/g, '\\\\')
+        const vault = await getDreadhavenRoot();
+        const base = (typeof vault === 'string' && vault.trim())
+          ? `${vault.trim()}\\\\30_Assets\\\\Images\\\\Monster_Portraits`.replace(/\\\\/g, '\\\\')
           : DEFAULT_PORTRAITS;
         const entries = await listDir(base);
         const idx = {};

--- a/ui/src/pages/DndDmNpcs.jsx
+++ b/ui/src/pages/DndDmNpcs.jsx
@@ -1,7 +1,7 @@
 import { listPiperVoices } from '../lib/piperVoices';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import BackButton from '../components/BackButton.jsx';
-import { getConfig } from '../api/config';
+import { getDreadhavenRoot } from '../api/config';
 import { listDir } from '../api/dir';
 import { readInbox, deleteInbox } from '../api/inbox';
 import { readFileBytes } from '../api/files';
@@ -186,9 +186,9 @@ const establishmentOptions = useMemo(() => {
     setLoading(true);
     setError('');
     try {
-      const vault = await getConfig('vaultPath');
-      const base = (typeof vault === 'string' && vault)
-        ? `${vault}\\\\20_DM\\\\NPC`.replace(/\\\\/g, '\\\\')
+      const vault = await getDreadhavenRoot();
+      const base = (typeof vault === 'string' && vault.trim())
+        ? `${vault.trim()}\\\\20_DM\\\\NPC`.replace(/\\\\/g, '\\\\')
         : '';
       if (base) {
         const list = await crawl(base);
@@ -219,9 +219,9 @@ const establishmentOptions = useMemo(() => {
   useEffect(() => {
     (async () => {
       try {
-        const vault = await getConfig('vaultPath');
-        const base = (typeof vault === 'string' && vault)
-          ? `${vault}\\\\10_World\\\\Regions`.replace(/\\\\/g, '\\\\')
+        const vault = await getDreadhavenRoot();
+        const base = (typeof vault === 'string' && vault.trim())
+          ? `${vault.trim()}\\\\10_World\\\\Regions`.replace(/\\\\/g, '\\\\')
           : 'D:\\Documents\\DreadHaven\\10_World\\Regions';
         const stack = [base];
         const seen = new Set();
@@ -260,9 +260,9 @@ const establishmentOptions = useMemo(() => {
     (async () => {
       try {
         // Determine Regions root
-        const vault = await getConfig('vaultPath');
-        const regionsRoot = (typeof vault === 'string' && vault)
-          ? `${vault}\\10_World\\Regions`
+        const vault = await getDreadhavenRoot();
+        const regionsRoot = (typeof vault === 'string' && vault.trim())
+          ? `${vault.trim()}\\10_World\\Regions`
           : 'D:\\Documents\\DreadHaven\\10_World\\Regions';
         // Resolve region path
         const regionPath = selRegion
@@ -330,9 +330,9 @@ const establishmentOptions = useMemo(() => {
   useEffect(() => {
     (async () => {
       try {
-        const vault = await getConfig('vaultPath');
-        const base = (typeof vault === 'string' && vault)
-          ? `${vault}\\\\30_Assets\\\\Images\\\\NPC_Portraits`.replace(/\\\\/g, '\\\\')
+        const vault = await getDreadhavenRoot();
+        const base = (typeof vault === 'string' && vault.trim())
+          ? `${vault.trim()}\\\\30_Assets\\\\Images\\\\NPC_Portraits`.replace(/\\\\/g, '\\\\')
           : DEFAULT_PORTRAITS;
 
         // Recursively crawl portrait folders (images may be nested)

--- a/ui/src/pages/DndLoreRaces.jsx
+++ b/ui/src/pages/DndLoreRaces.jsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { fileSrc } from '../lib/paths.js';
-import { getConfig } from '../api/config';
+import { getDreadhavenRoot } from '../api/config';
 import BackButton from '../components/BackButton.jsx';
 import Card from '../components/Card.jsx';
 import { loadRaces, createRace, saveRacePortrait } from '../api/races';
@@ -50,8 +50,8 @@ export default function DndLoreRaces() {
   const resolvePortrait = useCallback(async (raceName) => {
     let base = 'D:\\Documents\\DreadHaven';
     try {
-      const vault = await getConfig('vaultPath');
-      if (typeof vault === 'string' && vault.trim()) base = vault;
+      const vault = await getDreadhavenRoot();
+      if (typeof vault === 'string' && vault.trim()) base = vault.trim();
     } catch {}
     const dir = `${base}\\\\30_Assets\\\\Images\\\\Race_Portraits`;
     const clean = (s) => String(s || '').trim().replace(/\s+/g, '_');

--- a/ui/src/pages/DndLoreSpellBook.jsx
+++ b/ui/src/pages/DndLoreSpellBook.jsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import BackButton from '../components/BackButton.jsx';
-import { getConfig } from '../api/config';
+import { getDreadhavenRoot } from '../api/config';
 import { listInbox, readInbox } from '../api/inbox';
 import { createSpell } from '../api/spells';
 import { renderMarkdown } from '../lib/markdown.jsx';
@@ -57,9 +57,9 @@ export default function DndLoreSpellBook() {
     setLoading(true);
     setError('');
     try {
-      const vault = await getConfig('vaultPath');
-      const base = (typeof vault === 'string' && vault)
-        ? `${vault}\\10_World\\SpellBook`
+      const vault = await getDreadhavenRoot();
+      const base = (typeof vault === 'string' && vault.trim())
+        ? `${vault.trim()}\\10_World\\SpellBook`
         : '';
       if (base) {
         const list = await listInbox(base);

--- a/ui/src/pages/DndTasks.jsx
+++ b/ui/src/pages/DndTasks.jsx
@@ -4,7 +4,7 @@ import Card from '../components/Card.jsx';
 import { listenToTagUpdates, updateSectionTags } from '../api/tags.js';
 import { TAG_SECTIONS } from '../lib/dndTags.js';
 import './Dnd.css';
-import { getConfig } from '../api/config';
+import { getDreadhavenRoot } from '../api/config';
 import { listDir } from '../api/dir';
 import { listInbox, readInbox } from '../api/inbox';
 import { listNpcs } from '../api/npcs';
@@ -225,13 +225,12 @@ export default function DndTasks() {
           setImageLoading(true);
           setImageLogs([]);
           try {
-            const vault = await getConfig('vaultPath');
-            const npcPortraitBase = (typeof vault === 'string' && vault)
-              ? `${vault}\\30_Assets\\Images\\NPC_Portraits`.replace(/\\/g, '\\\\')
-              : 'D\\\\Documents\\\\DreadHaven\\\\30_Assets\\\\Images\\\\NPC_Portraits'.replace(/\\/g, '\\\\');
-            const godPortraitBase = (typeof vault === 'string' && vault)
-              ? `${vault}\\30_Assets\\Images\\God_Portraits`.replace(/\\/g, '\\\\')
-              : 'D\\\\Documents\\\\DreadHaven\\\\30_Assets\\\\Images\\\\God_Portraits'.replace(/\\/g, '\\\\');
+            const vault = await getDreadhavenRoot();
+            const baseRoot = (typeof vault === 'string' && vault.trim())
+              ? vault.trim()
+              : 'D\\\\Documents\\\\DreadHaven';
+            const npcPortraitBase = `${baseRoot}\\30_Assets\\Images\\NPC_Portraits`.replace(/\\/g, '\\\\');
+            const godPortraitBase = `${baseRoot}\\30_Assets\\Images\\God_Portraits`.replace(/\\/g, '\\\\');
             pushImageLog('started', `Indexing portraits (NPC: ${npcPortraitBase}, God: ${godPortraitBase})`);
             const buildIndex = async (base) => {
               const idx = {};

--- a/ui/src/pages/DndWorldFactions.jsx
+++ b/ui/src/pages/DndWorldFactions.jsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import BackButton from '../components/BackButton.jsx';
 import Icon from '../components/Icon.jsx';
-import { getConfig } from '../api/config';
+import { getDreadhavenRoot } from '../api/config';
 import { listDir } from '../api/dir';
 import { readInbox } from '../api/inbox';
 import { renderMarkdown } from '../lib/markdown.jsx';
@@ -32,9 +32,9 @@ export default function DndWorldFactions() {
     setLoading(true);
     setError('');
     try {
-      const vault = await getConfig('vaultPath');
-      const base = (typeof vault === 'string' && vault)
-        ? `${vault}\\\\10_World\\\\Factions`.replace(/\\\\/g, '\\\\')
+      const vault = await getDreadhavenRoot();
+      const base = (typeof vault === 'string' && vault.trim())
+        ? `${vault.trim()}\\\\10_World\\\\Factions`.replace(/\\\\/g, '\\\\')
         : DEFAULT_FACTIONS;
       setBasePath(base);
       setCurrentPath(base);

--- a/ui/src/pages/DndWorldPantheon.jsx
+++ b/ui/src/pages/DndWorldPantheon.jsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import BackButton from '../components/BackButton.jsx';
-import { getConfig } from '../api/config';
+import { getDreadhavenRoot } from '../api/config';
 import { listInbox, readInbox, deleteInbox } from '../api/inbox';
 import { listDir } from '../api/dir';
 import { readFileBytes } from '../api/files';
@@ -60,8 +60,8 @@ export default function DndWorldPantheon() {
     setLoading(true);
     setError('');
     try {
-      const vault = await getConfig('vaultPath');
-      const base = (typeof vault === 'string' && vault) ? `${vault}\\10_World\\Gods of the Realm` : '';
+      const vault = await getDreadhavenRoot();
+      const base = (typeof vault === 'string' && vault.trim()) ? `${vault.trim()}\\10_World\\Gods of the Realm` : '';
       if (base) {
         const list = await listInbox(base);
         setUsingPath(base);
@@ -110,9 +110,9 @@ export default function DndWorldPantheon() {
   useEffect(() => {
     (async () => {
       try {
-        const vault = await getConfig('vaultPath');
-        const base = (typeof vault === 'string' && vault)
-          ? `${vault}\\\\30_Assets\\\\Images\\\\God_Portraits`.replace(/\\\\/g, '\\\\')
+        const vault = await getDreadhavenRoot();
+        const base = (typeof vault === 'string' && vault.trim())
+          ? `${vault.trim()}\\\\30_Assets\\\\Images\\\\God_Portraits`.replace(/\\\\/g, '\\\\')
           : DEFAULT_GOD_PORTRAITS;
         // Recursively crawl portrait folders
         const stack = [base];

--- a/ui/src/pages/DndWorldRegions.jsx
+++ b/ui/src/pages/DndWorldRegions.jsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import BackButton from '../components/BackButton.jsx';
 import Icon from '../components/Icon.jsx';
-import { getConfig } from '../api/config';
+import { getDreadhavenRoot } from '../api/config';
 import { listDir } from '../api/dir';
 import { readInbox } from '../api/inbox';
 import { renderMarkdown } from '../lib/markdown.jsx';
@@ -32,9 +32,9 @@ export default function DndWorldRegions() {
     setLoading(true);
     setError('');
     try {
-      const vault = await getConfig('vaultPath');
-      const base = (typeof vault === 'string' && vault)
-        ? `${vault}\\10_World\\Regions`
+      const vault = await getDreadhavenRoot();
+      const base = (typeof vault === 'string' && vault.trim())
+        ? `${vault.trim()}\\10_World\\Regions`
         : DEFAULT_REGIONS;
       setBasePath(base);
       setCurrentPath(base);


### PR DESCRIPTION
## Summary
- drop the unused `select_vault` Tauri command and expose a helper that returns the default DreadHaven root
- replace backend `vaultPath` lookups with the shared default helper and provide a UI API wrapper for the new command
- update D&D pages and attachment utilities to rely on the default root while removing references to selecting a vault

## Testing
- cargo fmt --manifest-path src-tauri/Cargo.toml
- npm --prefix ui run build

------
https://chatgpt.com/codex/tasks/task_e_68e5733230088325bc3dd380c4931875