### PR TITLE
Simplify Discord settings guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,9 @@ systems.
 Blossom stores sensitive keys (like ElevenLabs and Discord) in a Tauri Store file named `secrets.json` under your app data directory. You don’t need to commit this file.
 
 Quick start:
-- Use the UI (AI Voice Labs) to paste your ElevenLabs key. It will be saved to `secrets.json` automatically.
+- Visit **Settings → Discord** in the desktop app for a walkthrough on supplying your Discord bot token via
+  `secrets.json` or the `DISCORD_TOKEN` environment variable.
+- Use the AI Voice Labs screen to paste your ElevenLabs key. It will be saved to `secrets.json` automatically.
 - Or create a `secrets.json` file manually in the app’s data directory with this shape:
 
 ```

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -1,19 +1,30 @@
 # Discord Configuration
 
-Set the bot token in the ``DISCORD_TOKEN`` environment variable before
-starting ``discord_bot.py`` or persist it to ``config/discord_token.txt`` using
-``config.discord_token.set_token``. When the environment variable is not set
-the bot falls back to the stored token.
+Set the bot token before launching ``discord_bot.py``. Blossom first checks the
+``DISCORD_TOKEN`` environment variable and then looks for a ``secrets.json``
+file (the desktop app’s **Settings → Discord** page mirrors these steps).
 
 ```bash
 export DISCORD_TOKEN="your_bot_token"
 python discord_bot.py
 ```
 
-```python
-from config.discord_token import set_token
-set_token("your_bot_token")
+Alternatively, create ``secrets.json`` in the project root or in the app data
+directory (``%APPDATA%/com.blossom.musicgen`` on Windows,
+``~/Library/Application Support/com.blossom.musicgen`` on macOS, or
+``~/.local/share/com.blossom.musicgen`` on Linux):
+
+```json
+{
+  "discord": {
+    "botToken": "your_bot_token",
+    "guildId": "optional guild id"
+  }
+}
 ```
+
+If you prefer a text file, ``config.discord_token.set_token`` will write the
+token to ``config/discord_token.txt``, which is also checked at runtime.
 
 The Discord bot reads command permission rules from `config/discord.yaml` on startup.
 Each top-level key in the file is the name of a slash command (use the full

--- a/ui/src/pages/DndDiscord.jsx
+++ b/ui/src/pages/DndDiscord.jsx
@@ -879,7 +879,9 @@ export default function DndDiscord() {
             <div>
               <h2 id="discord-bot-controls-heading">Discord Bot</h2>
               <p className="muted" style={{ marginTop: '0.25rem' }}>
-                Token from <code>secrets.json</code> or selected in <code>Settings → Discord</code>. Commands: <code>/ping</code>, <code>/join</code>, <code>/leave</code>, <code>/say</code>.
+                Token from <code>secrets.json</code> (see <code>Settings → Discord</code> for setup instructions) or the{' '}
+                <code>DISCORD_TOKEN</code> environment variable. Commands: <code>/ping</code>, <code>/join</code>,
+                <code>/leave</code>, <code>/say</code>.
               </p>
             </div>
             <div className="button-row" style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>

--- a/ui/src/pages/SettingsHome.jsx
+++ b/ui/src/pages/SettingsHome.jsx
@@ -5,7 +5,7 @@ import './Settings.css';
 
 const sections = [
   { to: '/settings/users', icon: 'User', title: 'Users', description: 'Switch or manage users.' },
-  { to: '/settings/discord', icon: 'MessageSquare', title: 'Discord', description: 'Manage bot tokens and guilds.' },
+  { to: '/settings/discord', icon: 'MessageSquare', title: 'Discord', description: 'Instructions for configuring your bot token.' },
   { to: '/settings/appearance', icon: 'Palette', title: 'Appearance', description: 'Theme, accent color, and font size.' },
   { to: '/settings/models', icon: 'HardDrive', title: 'Models & Voices', description: 'Manage Whisper, LLM, and Piper voices.' },
   { to: '/settings/advanced', icon: 'Settings', title: 'Advanced Settings', description: 'Diagnostics and activity logs.' },


### PR DESCRIPTION
## Summary
- replace the Discord settings tables with a concise token setup guide and token-source detector
- refresh the settings home card, README, and Discord docs to reference the streamlined workflow
- update the Discord DnD screen copy to point at the new setup instructions and environment variable

## Testing
- npm --prefix ui run build

------
https://chatgpt.com/codex/tasks/task_e_68e5806119a483259ac458617f29e6b3