### PR TITLE
Clarify CPU vs GPU dependency stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,19 @@ Blossom is a toolkit for algorithmic arrangement, MusicGen-powered synthesis, an
    ```bash
    python -m venv .venv              # py -3.10 -m venv .venv on Windows
    source .venv/bin/activate         # .\.venv\Scripts\activate on Windows
+   # CPU / default stack
    pip install -r requirements.txt
    ```
+
+   * **CPU-only workflows** (MusicGen, Piper, desktop shell) only need `requirements.txt`.
+   * **NVIDIA GPU Riffusion workflows** require the pinned CUDA 12.4 wheels:
+
+     ```bash
+     pip install --extra-index-url https://download.pytorch.org/whl/cu124 \
+       -r requirements-riffusion.txt
+     ```
+
+     Install this after the base requirements so the pinned Torch/Diffusers stack overlays cleanly.
 
    Optional helpers:
 

--- a/requirements-riffusion.txt
+++ b/requirements-riffusion.txt
@@ -1,3 +1,6 @@
+#! Install after the base requirements.txt to add the CUDA-enabled Riffusion stack.
+#! Use pip --extra-index-url https://download.pytorch.org/whl/cu124 when installing.
+
 diffusers==0.31.0
 # Core stack pinned to avoid drift
 torch==2.6.0+cu124

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,15 +33,5 @@ transformers>=4.45
 accelerate>=0.33
 safetensors>=0.4.2
 
-# --- Riffusion stack (pinned) ---
-# Pinned versions used by the Riffusion feature to avoid drift.
-# These do not alter existing workflows but ensure stable builds for Riffusion.
-diffusers==0.31.0
-torch==2.6.0+cu124
-transformers==4.56.1
-accelerate==1.10.1
-pillow==11.3.0
-librosa==0.11.0
-soundfile==0.13.1
-numpy==2.2.6
-scipy==1.15.3
+# --- Optional GPU / Riffusion stack ---
+# CUDA builds for the Riffusion feature are pinned in requirements-riffusion.txt.


### PR DESCRIPTION
## Summary
- keep the default requirements focused on the CPU-friendly stack and reference the optional GPU pins
- document how to install the CUDA/Riffusion requirements and the needed extra index URL
- add guidance to the Riffusion requirements file about applying the pinned stack after the base install

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69166fd129b88325a59fb1368ec50854)